### PR TITLE
Fix typo in per-resource maintenance mode command

### DIFF
--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -2119,7 +2119,7 @@ Resource Group: dlm-clvm:1
        <command>meta</command> command. For example, to put the resource
        <literal>ipaddress</literal> into maintenance mode, enter:
       </para>
-<screen>&prompt.root;<command>crm</command> meta ipaddress set maintenance true</screen>
+<screen>&prompt.root;<command>crm</command> resource maintenance ipaddress true</screen>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
Technically, this would also work:

    crm resource meta ipaddress set maintenance true

But I thought using the maintenance command is a bit cleaner.
