### PR TITLE
some modifications for Quick Start

### DIFF
--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -99,13 +99,12 @@
   <sect1 xml:id="sec.ha.inst.quick.req">
    <title>System Requirements</title>
    <para>
-    This section informs you about the key system requirements for the usage
+    This section informs you about the key system requirements for the
     scenario described in <xref linkend="sec.ha.inst.quick.usage-scenario"/>.
     If you want to adjust the cluster for use in a production environment,
     read the full list of <citetitle>System Requirements and
     Recommendations</citetitle> in the <citetitle>&admin;</citetitle>
-    for &productnamereg;, available at 
-    <link
+    for &productnamereg;: <link
     xlink:href="https://www.suse.com/documentation/sle-ha-12/book_sleha/data/cha_ha_requirements.html"/>.
    </para>
   <itemizedlist xml:id="vl.ha.inst.quick.req.hw">
@@ -185,16 +184,14 @@
   <sect1 xml:id="sec.ha.inst.quick.installation">
     <title>Installing &sls; and &ha; Extension</title>
     <para>
-      The packages needed for configuring and managing a cluster with the
+      The packages for configuring and managing a cluster with the
       &hasi; are included in the <literal>&ha;</literal> installation
       pattern. This pattern is only available after &productname; has been
       installed as an extension to &slsreg;. For information on how to install
       extensions, see the <citetitle>&sle; &productnumber;
-        &deploy;</citetitle>, available at
-      <link xlink:href="http://www.suse.com/doc"/>. Refer to chapter
-      <citetitle>Installing Modules, Extensions, and Third Party Add-On Products</citetitle>.
-      <!--taroth: need to use hard-coded link here as the target is not included in the same set-->
-    </para>
+      &deploy;</citetitle>:
+     <link
+      xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/cha_add-ons.html"></link>.</para>
 
     <procedure xml:id="pro.ha.inst.quick.pattern">
       <title>Installing the &ha; Pattern</title>
@@ -204,10 +201,6 @@
           Start &yast; and select <menuchoice>
             <guimenu>Software</guimenu> <guimenu>Software Management</guimenu>
           </menuchoice>.
-        </para>
-        <para>
-          Alternatively, start the &yast; module as &rootuser; user on a command
-          line with <command>yast2&nbsp;sw_single</command>.
         </para>
       </step>
       <step>
@@ -300,7 +293,7 @@
    <para>
     If you have shared storage, for example, a SAN (Storage Area Network),
     you can use it to avoid split-brain scenarios by configuring SBD
-    (&stonith; Block Devices) as node fencing mechanism. SBD uses watchdog support
+    as node fencing mechanism. SBD uses watchdog support
     and the <literal>external/sbd</literal> &stonith; resource agent.
    </para>
 
@@ -333,7 +326,7 @@
 
   <para>
    For details how to set up shared storage, refer to the <citetitle>&storage;</citetitle>
-   for &sls;:
+   for &sls; &productnumber;:
   </para>
   <variablelist>
    <varlistentry>
@@ -402,7 +395,7 @@ softdog                16384  1</screen>
     <step>
      <para>
       Test your shared storage. This can be done by writing data with the
-      command <command>dd</command> on one node, and read the data on the
+      command <command>dd</command> on one node, and reading the data on the
       second node. For our test, the file <filename>/etc/hosts</filename>
       is used:
      </para>
@@ -437,7 +430,7 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
  <sect1 xml:id="sec.ha.inst.quick.setup.1st-node">
   <title>Setting Up the First Node</title>
   <para>
-   All commands from <!--the <xref linkend="vl.ha.inst.quick.common.cmds"/> list-->
+   All commands from
    the <package>ha-cluster-bootstrap</package> package execute bootstrap scripts
    that require only a minimum of time and manual intervention.
    The bootstrap scripts for initialization
@@ -449,11 +442,8 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
   </para>
 
   <procedure xml:id="pro.ha.inst.quick.setup.ha-cluster-init">
-   <title>Automatically Setting Up the First Node (&node1;)</title>
-   <para> The <command>ha-cluster-init</command> command checks for
-    configuration of NTP and guides you through configuration of the cluster
-    communication layer (&corosync;).
-   </para>
+   <title>Setting Up the First Node (<literal>&node1;</literal>) with
+    <command>ha-cluster-init</command></title>
    <para>For details about the script's range of functions, its options,
     and an overview of the files it can create and modify, refer to the
     <command>ha-cluster-init</command> man page.
@@ -483,7 +473,7 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
    </step>
    <step>
     <para>
-     To configure the cluster communication layer (&corosync;):
+     Configure the cluster communication layer (&corosync;):
     </para>
     <substeps>
      <step>
@@ -509,13 +499,13 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
     </substeps>
     <para>
      Finally, the script will start the &pace; service to bring the
-     one-node cluster online and enable the Web management interface
-     &hawk2;. The URL to use for &hawk2; is displayed on the screen.
+     one-node cluster online and enable &hawk2;.
+     The URL to use for &hawk2; is displayed on the screen.
     </para>
    </step>
    <step>
     <para>
-    To set up SBD as node fencing mechanism:</para>
+    Set up SBD as node fencing mechanism:</para>
     <substeps>
      <step>
       <para>Confirm with <literal>y</literal> that you want to use SBD.</para>
@@ -527,9 +517,11 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
      </step>
     </substeps>
    </step>
-   <step><!-- taroth 2015-09-22: fate#318549: cluster-init: configure virtual IP for HAWK  -->
-    <para>To configure a virtual IP address for cluster administration with
-    &hawk2; (which we will use for testing successful failover later on):</para>
+   <step xml:id="step.ha-cluster-init.ip">
+    <!-- taroth 2015-09-22: fate#318549: cluster-init: configure virtual IP for HAWK  -->
+    <para>Configure a virtual IP address for cluster administration with
+    &hawk2;. (We will use this virtual IP resource for testing successful
+    failover later on).</para>
     <substeps>
      <step>
       <para>Confirm with <literal>y</literal> that you want to configure a
@@ -574,13 +566,26 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
 
   <para>
    You now have a running one-node cluster. To view it, log in to &hawk2; from
-   any machine. Point the browser to the virtual IP we have configured above:</para>
+   any machine. Point the browser to the virtual IP we have configured in
+   <xref linkend="step.ha-cluster-init.ip" xrefstyle="select:label nopage"/>:</para>
   <screen>https://&subnetII;.1:7630/</screen>
   <para>On the login screen, enter the <guimenu>Username</guimenu> and
     <guimenu>Password</guimenu> of the
-   <systemitem>hacluster</systemitem> user and go to
-    <guimenu>Status</guimenu> link (see <xref linkend="fig.ha.inst.quick.one-node-status"/>). </para>
+   <systemitem>hacluster</systemitem> user.
+   View the <guimenu>Status</guimenu> screen which displays the current cluster
+   status at a glance, see <xref linkend="fig.ha.inst.quick.one-node-status"/>.
+  </para>
 
+  <important>
+   <title>Secure Password</title>
+   <para>
+    The bootstrap procedure creates a Linux user named
+    <systemitem class="username">hacluster</systemitem> with the password
+    <literal>linux</literal>. You need it for logging in to &hawk2;.
+    Replace the default password with a secure one as soon as possible:
+   </para>
+   <screen>&prompt.root;<command>passwd</command> hacluster</screen>
+  </important>
   <remark>toms 2016-07-22: Fix screenshot to show alice and bob</remark>
 
   <figure xml:id="fig.ha.inst.quick.one-node-status">
@@ -591,57 +596,21 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
     </imageobject>
    </mediaobject>
   </figure>
-
-  <important>
-   <title>Secure Password</title>
-   <para>
-    The bootstrap procedure creates a Linux user named
-    <systemitem class="username">hacluster</systemitem> with the password
-    <literal>linux</literal>. You need it for logging in to &hawk2;.
-    Replace the default password with a secure one as soon as possible:
-   </para>
-<screen>&prompt.root;<command>passwd</command> hacluster</screen>
-  </important>
  </sect1>
 
  <sect1 xml:id="sec.ha.inst.quick.setup.2nd-node">
-  <title>Adding the Second Node to the Existing Cluster</title>
+  <title>Adding the Second Node</title>
   <para>
     If you have a one-node cluster up and running, add the second cluster
     node with the <command>ha-cluster-join</command> bootstrap
-    script, described in <xref linkend="pro.ha.inst.quick.setup.ha-cluster-join"/>.
+    script, as described in <xref linkend="pro.ha.inst.quick.setup.ha-cluster-join"/>.
     The script only needs access to an existing cluster node and
     will complete the basic setup on the current machine automatically.
     For details, refer to the <command>ha-cluster-join</command> man page.
   </para>
   <procedure xml:id="pro.ha.inst.quick.setup.ha-cluster-join">
-   <title>Adding the Second Node &node2; to the Existing Cluster</title>
-   <!-- toms 2016-07-15: Disabled as we describe the crm shell interface only
-   <para>
-    If you have configured the existing cluster nodes with the &yast;
-    cluster module, make sure the following prerequisites are fulfilled
-    before you run <command>ha-cluster-join</command>:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      The &rootuser; user on the existing nodes has SSH keys in place for
-      passwordless login.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      &csync; is configured on the existing nodes. For details, refer to
-      <remark>FIXME Install Quick</remark> <!-\-<xref linkend="pro.ha.installation.setup.csync2.yast"/>-\->.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-    If you are logged in to the first node via &hawk2;, you can follow the
-    changes in cluster status and view the resources being activated in the
-    Web interface.
-   </para>
-   -->
+   <title>Adding the Second Node (<literal>&node2;</literal>) with
+    <command>ha-cluster-join</command></title>
    <step>
     <para>
      Log in as &rootuser; to the physical or virtual machine supposed to
@@ -691,7 +660,7 @@ Sep 22 17:01:00 &node1; sbd: [13412]: info: Received command test from &node1;</
    </step>
   </procedure>
 
-  <para>
+  <para><remark>taroth 2016-07-25: replace with Hawk2!</remark>
    Check the cluster status with <command>crm&nbsp;status</command>. If
    you have successfully added a second node, the output will be similar to
    the following:
@@ -717,95 +686,6 @@ Online: [ &node1; &node2; ]</screen>
   <screen>&prompt.root;<command>ha-cluster-remove</command> <option>-c</option> <replaceable>IP_ADDR_OR_HOSTNAME</replaceable></screen>
  </sect1>
 
-  <sect1 xml:id="sec.ha.inst.quick.stonith">
-   <title>Configuring a &stonith;-Resource</title>
-   <remark>toms 2016-07-15: @taroth: is this section really needed? In the
-    light of just saying "use a shared storage for SBD" we may probably
-    avoid this section alltogether.
-    taken from ha_config_cli.xml, xml:id=sec.ha.manual_create.stonith</remark>
-   <para>
-    From the <command>crm</command> perspective, a &stonith; device is
-    just another resource. To create a &stonith; resource, proceed as
-    follows:
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Log in as &rootuser; and start the <command>crm</command>
-      interactive shell:
-     </para>
-<screen>&prompt.root;<command>crm</command> configure</screen>
-    </step>
-    <step>
-     <para>
-      Get a list of all &stonith; types with the following command:
-     </para>
-<screen>&prompt.crm;<command>ra</command> list stonith
-apcmaster                  apcmastersnmp              apcsmart
-baytech                    bladehpi                   cyclades
-[... list pruned ...]</screen>
-    </step>
-    <step xml:id="st.ha.manual_create.stonith.type">
-     <para>
-      Choose a &stonith; type from the above list and view the list of
-      possible options. Use the following command:
-     </para>
-<screen>&prompt.crm;<command>ra</command> info stonith:external/ipmi
-IPMI STONITH external device (stonith:external/ipmi)
-
-ipmitool based power management. Apparently, the power off
-method of ipmitool is intercepted by ACPI which then makes
-a regular shutdown. If case of a split brain on a two-node
-it may happen that no node survives. For two-node clusters
-use only the reset method.
-
-Parameters (* denotes required, [] the default):
-
-hostname (string): Hostname
-    The name of the host to be managed by this STONITH device.
-...<!--
-ipaddr (string): IP Address
-    The IP address of the STONITH device.
-
-userid (string): Login
-    The username used for logging in to the STONITH device.
-
-passwd (string): Password
-    The password used for logging in to the STONITH device.
-
-interface (string, [lan]): IPMI interface
-    IPMI interface to use, such as "lan" or "lanplus".
-
-stonith-timeout (time, [60s]):
-    How long to wait for the STONITH action to complete. Overrides the stonith-timeout cluster property
-
-priority (integer, [0]):
-    The priority of the stonith resource. The lower the number, the higher the priority.
-
-Operations' defaults (advisory minimum):
-
-    start         timeout=15
-    stop          timeout=15
-    status        timeout=15
-    monitor_0     interval=15 timeout=15 start-delay=15--></screen>
-    </step>
-    <step>
-     <para>
-      Create the &stonith; resource with the <literal>stonith</literal>
-      class, the type you have chosen in
-      <xref linkend="st.ha.manual_create.stonith.type" xrefstyle="select:label nopage"/>,
-      and the respective parameters if needed, for example:
-     </para>
-<screen>&prompt.crm;<command>configure</command>
-&prompt.crm.conf;<command>primitive</command> my-stonith stonith:external/ipmi \
-    params hostname="&node1;" \
-    ipaddr="&subnetI;.221" \
-    userid="admin" passwd="secret" \
-    op monitor interval=60m timeout=120s  </screen>
-    </step>
-   </procedure>
-  </sect1>
-
   <sect1 xml:id="sec.ha.inst.quick.test">
    <title>Testing the Cluster</title>
    <para>
@@ -815,7 +695,7 @@ Operations' defaults (advisory minimum):
    <procedure>
     <step>
      <para>
-      Log in to &node2; and show the status of your cluster. It should be
+      Log in to <literal>&node2;</literal> and show the status of your cluster. It should be
       something like this:
      </para>
      <screen>&prompt.root;<command>crm</command> status
@@ -842,7 +722,7 @@ Full list of resources:
     </step>
     <step>
      <para>
-      Pull the plug on &node1;.
+      Pull the plug on <literal>&node1;</literal>.
      </para>
      <remark>toms 2016-07-18: Should we add an alternative method? I've tested
       it with "crm node standby NODE" to put the node "offline" temporarily.
@@ -854,7 +734,7 @@ Full list of resources:
     <step>
      <para>
       Rerun the <command>crm status</command> command. You should see the floating
-      virtual IP address moved to &node2;:
+      virtual IP address moved to <literal>&node2;</literal>:
      </para>
      <screen>&prompt.root;<command>crm</command> status
 [...]
@@ -887,9 +767,5 @@ Full list of resources:
     tasks.
    </para>
   </sect1>
-
-  <!--taroth 2016-07-08: @toms: sorry, I did not have time to add further sections yet,
-  please refer to https://fate.suse.com/320823 (feature description *and* the
-  respective comments by Kai, Kristoffer, and Antoine-->
  <xi:include href="common_legal.xml"/>
 </article>


### PR DESCRIPTION
- cleaning up: remove some commented snippets
- add missing <literal> tags for alice and bob
- replace some references to SLES Guides with direct URLs
- mention cluster scripts in titles of procedures
- modify section title for second node section
- pro.ha.inst.quick.setup.ha-cluster-init: rephrase some steps
- move important note about password to (hopefully) better place
- remove section about configuring a stonith device
  (already configured with SBD during ha-cluster-init)