### PR TITLE
fix bsc#990412 and bsc#9906115

### DIFF
--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -313,8 +313,8 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
   on &node2; { <xref linkend="co.drbd.config.resname" xrefstyle="selec:nopage"/>
     address &subnetI;.11:7788; <xref linkend="co.drbd.config.address" xrefstyle="selec:nopage"/>
   }
-  syncer {
-    rate  7M; <co xml:id="co.drbd.config.syncer-rate"/>
+  disk {
+    resync-rate  7M; <co xml:id="co.drbd.config.syncer-rate"/>
   }
 }</screen>
       <calloutlist>

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -672,7 +672,7 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
         <step>
           <para>Create a new UUID on &node1; to shorten the initial resynchronization of
             DRBD resource:</para>
-          <screen>&prompt.root;<command>drbdadm</command> new-current-uuid --zeroout-devices r0</screen>
+          <screen>&prompt.root;<command>drbdadm</command> new-current-uuid --zeroout-devices r0/0</screen>
         </step>
         <step>
           <para>Switch to &node1; and make this side primary:</para>
@@ -680,16 +680,16 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
         </step>
         <step>
           <para> View the DRBD status by entering the following on each
-            node: </para>
+            node: (Skip the step 6 and step 7 of initial resynchronization)</para>
           <screen>&prompt.root;<command>cat</command> /proc/drbd</screen>
           <para> You should get something like this: </para>
           <screen>[... version string omitted ...]
-0: cs:Connected ro:Secondary/Secondary ds:Inconsistent/Inconsistent C r-----
+0: cs:Connected ro:Primary/Secondary ds:UpToDate/UpToDate C r-----
    ns:0 nr:0 dw:0 dr:0 al:0 bm:0 lo:0 pe:0 ua:0 ap:0 ep:1 wo:f oos:1048508</screen>
           <!-- Add short explanation? -->
         </step>
         <step>
-          <para> Start the resynchronization process on your intended primary node
+          <para> Or continue with step 2. Start the resynchronization process on your intended primary node
             (&node1; in this case): </para>
           <screen>&prompt.root;<command>drbdadm</command> -- --overwrite-data-of-peer primary r0</screen>
         </step>
@@ -707,7 +707,7 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
         <step>
           <para> Create your file system on top of your DRBD device, for
             example: </para>
-          <screen>&prompt.root;<command>mkfs.ext3</command> /dev/drbd/by-res/r0/0</screen>
+          <screen>&prompt.root;<command>mkfs.ext3</command> /dev/drbd/by-res/r0</screen>
         </step>
         <step>
           <para> Mount the file system and use it: </para>


### PR DESCRIPTION
Fix few issues in chapter "17.3.3 Initializing and Formatting DRBD Resource"

Replace obsolete "syncer" section to "disk" section.
Add volume id of resource to step3.
Step6~7 should followed with step2, either run step3~5 or step 6~7.
Status in step5 should be Primary/Secondary UpToDate/UpToDate.
Remove the volume id in step8.
