### PR TITLE
clvm: we prefer to use ocf:heartbeat:clvm now

### DIFF
--- a/xml/ha_clvm.xml
+++ b/xml/ha_clvm.xml
@@ -207,9 +207,9 @@ cLVM) for more information and details to integrate here - really helpful-->
       <command>clvmd</command>, and &stonith;:
      </para>
 <screen>&prompt.root;<command>crm</command> configure
-&prompt.crm.conf;<command>primitive</command> clvmd ocf:lvm2:clvmd \
-        op stop interval="0" timeout="100" \
+&prompt.crm.conf;<command>primitive</command> clvmd ocf::heartbeat:clvm \
         op start interval="0" timeout="90" \
+        op stop interval="0" timeout="100" \
         op monitor interval="20" timeout="60"
 &prompt.crm.conf;<command>primitive</command> dlm ocf:pacemaker:controld \
         op start interval="0" timeout="90" \
@@ -435,10 +435,10 @@ cLVM) for more information and details to integrate here - really helpful-->
      <para>
       Configure a cLVM resource as follows:
      </para>
-<screen>&prompt.crm.conf;<command>primitive</command> clvm ocf:lvm2:clvmd \
-      params daemon_timeout="30"</screen>
-<!--taroth 2012-01-12: removing the monitoring op as suggested by xwhu-->
-<!--op monitor interval="60" timeout="60"-->
+<screen>&prompt.crm.conf;<command>primitive</command> clvm ocf::heartbeat:clvm \
+      op start interval="0" timeout="90" \
+      op stop interval="0" timeout="100" \
+      op monitor interval="20" timeout="60"</screen>
     </step>
     <step>
      <para>

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -1909,7 +1909,7 @@ primitive admin_addr IPaddr2 \
   ...
 Resource Group: dlm-clvm:1
          dlm:1  (ocf::pacemaker:controld) Started 
-         clvm:1 (ocf::lvm2:clvmd) Started
+         clvm:1 (ocf::heartbeat:clvm) Started
          cmirrord:1     (ocf::lvm2:cmirrord) Started</screen>
     </step>
     <step>

--- a/xml/ha_config_example.xml
+++ b/xml/ha_config_example.xml
@@ -31,11 +31,10 @@
  </para>
  <example xml:id="ex.ha.config.ocfs2.clvm">
   <title>Cluster Configuration for OCFS2 and cLVM</title>
-<!--taroth 2010-08-28: according to lmb, Xin Wei 
-   extended the clvm RA to always just start cmirrord as well,
-   so it doesn't need to be manually configured anymore.-->
-<screen>primitive clvm ocf:lvm2:clvmd \
-     params daemon_timeout="30" 
+<screen>primitive ocf::heartbeat:clvm \
+     op start interval="0" timeout="90" \
+     op stop interval="0" timeout="100" \
+     op monitor interval="20" timeout="60"
 primitive dlm ocf:pacemaker:controld \
      op monitor interval="60" timeout="60"
 <!--primitive o2cb ocf:ocfs2:o2cb \


### PR DESCRIPTION
The resource agent for clvm from lvm2 package is
kind of deprecated now. Prefer to use ocf:heartbeat:clvm
from upstream instead.

Signed-off-by: Eric Ren <zren@suse.com>