### PR TITLE
clvm: we prefer to use ocf:heartbeat:clvm now

### DIFF
--- a/xml/ha_clvm.xml
+++ b/xml/ha_clvm.xml
@@ -207,9 +207,10 @@ cLVM) for more information and details to integrate here - really helpful-->
       <command>clvmd</command>, and &stonith;:
      </para>
 <screen>&prompt.root;<command>crm</command> configure
-&prompt.crm.conf;<command>primitive</command> clvmd ocf:lvm2:clvmd \
-        op stop interval="0" timeout="100" \
+&prompt.crm.conf;<command>primitive</command> clvmd ocf::heartbeat:clvm \
+        params with_cmirrord=true \
         op start interval="0" timeout="90" \
+        op stop interval="0" timeout="100" \
         op monitor interval="20" timeout="60"
 &prompt.crm.conf;<command>primitive</command> dlm ocf:pacemaker:controld \
         op start interval="0" timeout="90" \
@@ -233,13 +234,13 @@ cLVM) for more information and details to integrate here - really helpful-->
           Pacemaker to have started dlmd and clvmd-->
      </para>
 <screen>&prompt.root;<command>pvcreate</command> /dev/sda /dev/sdb
-&prompt.root;<command>vgcreate</command> -cy vg /dev/sda /dev/sdb</screen>
+&prompt.root;<command>vgcreate</command> -cy vg1 /dev/sda /dev/sdb</screen>
     </step>
     <step>
      <para>
       Create a mirrored-log logical volume (LV) in your cluster:
      </para>
-<screen>&prompt.root;<command>lvcreate</command> -nLv -m1 -l10%VG vg --mirrorlog mirrored</screen>
+<screen>&prompt.root;<command>lvcreate</command> -n lv1 -m1 -l10%VG vg1 --mirrorlog mirrored</screen>
     </step>
     <step>
      <para>
@@ -250,13 +251,13 @@ cLVM) for more information and details to integrate here - really helpful-->
     </step>
     <step xml:id="st.ha.clvm.config.cmirrord.test">
      <para>
-      To test the clustered volume <filename>/dev/vg/lv</filename>, use the
+      To test the clustered volume <filename>/dev/vg1/lv1</filename>, use the
       following steps:
      </para>
      <substeps performance="required">
       <step>
        <para>
-        Read or write to <filename>/dev/vg/lv</filename>.
+        Read or write to <filename>/dev/vg1/lv1</filename>.
        </para>
       </step>
       <step>
@@ -435,10 +436,10 @@ cLVM) for more information and details to integrate here - really helpful-->
      <para>
       Configure a cLVM resource as follows:
      </para>
-<screen>&prompt.crm.conf;<command>primitive</command> clvm ocf:lvm2:clvmd \
-      params daemon_timeout="30"</screen>
-<!--taroth 2012-01-12: removing the monitoring op as suggested by xwhu-->
-<!--op monitor interval="60" timeout="60"-->
+<screen>&prompt.crm.conf;<command>primitive</command> clvm ocf::heartbeat:clvm \
+      op start interval="0" timeout="90" \
+      op stop interval="0" timeout="100" \
+      op monitor interval="20" timeout="60"</screen>
     </step>
     <step>
      <para>

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -1909,8 +1909,7 @@ primitive admin_addr IPaddr2 \
   ...
 Resource Group: dlm-clvm:1
          dlm:1  (ocf::pacemaker:controld) Started 
-         clvm:1 (ocf::lvm2:clvmd) Started
-         cmirrord:1     (ocf::lvm2:cmirrord) Started</screen>
+         clvm:1 (ocf::heartbeat:clvm) Started</screen>
     </step>
     <step>
      <para>

--- a/xml/ha_config_example.xml
+++ b/xml/ha_config_example.xml
@@ -31,11 +31,10 @@
  </para>
  <example xml:id="ex.ha.config.ocfs2.clvm">
   <title>Cluster Configuration for OCFS2 and cLVM</title>
-<!--taroth 2010-08-28: according to lmb, Xin Wei 
-   extended the clvm RA to always just start cmirrord as well,
-   so it doesn't need to be manually configured anymore.-->
-<screen>primitive clvm ocf:lvm2:clvmd \
-     params daemon_timeout="30" 
+<screen>primitive ocf::heartbeat:clvm \
+     op start interval="0" timeout="90" \
+     op stop interval="0" timeout="100" \
+     op monitor interval="20" timeout="60"
 primitive dlm ocf:pacemaker:controld \
      op monitor interval="60" timeout="60"
 <!--primitive o2cb ocf:ocfs2:o2cb \


### PR DESCRIPTION
The resource agent for clvm from lvm2 package is
kind of deprecated now. Prefer to use ocf:heartbeat:clvm
from upstream instead.

bsc#1030841
update for SLE-HA-12-SP2 at least, recommended for all SLE12
branches, if possible.

Signed-off-by: Eric Ren <zren@suse.com>