### PR TITLE
Mention --name for ha-cluster-init script

### DIFF
--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -275,6 +275,16 @@
      <para>It opens the ports in the firewall that are needed for cluster communication.</para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <term>Cluster Name</term>
+    <listitem>
+     <para>It defines a name for the cluster, by default
+        <systemitem>cluster<replaceable>NUMBER</replaceable></systemitem>. This
+      is optional and usefuly for &geo; clusters only. Usually, the cluster
+      name reflects its location and makes it easier to distinguish a site
+      inside a &geo; clusters.</para>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </sect1>
 
@@ -533,7 +543,13 @@ info: Received command test from &node1; on disk <replaceable>SBDDEVICE</replace
     <para>
      Start the bootstrap script by executing:
     </para>
-    <screen>&prompt.root;<command>ha-cluster-init</command></screen>
+    <screen>&prompt.root;<command>ha-cluster-init</command> --name <replaceable>CLUSTER_NAME</replaceable></screen>
+    <para>It is recommended to replace the <replaceable>CLUSTER_NAME</replaceable>
+     placeholder with the name of your geographical location (like
+     (<literal>&cluster1;</literal> or <literal>&cluster2;</literal>).
+     This name is required if you create a &geo; cluster later as it simplifies
+     the identification of a site.
+    </para>
     <remark>toms 2016-08-11: the following para relates to
      (a) FATE#320604 allow unicast,
      (b) FATE#320605 identify AWS and use unicast</remark>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -280,9 +280,9 @@
     <listitem>
      <para>It defines a name for the cluster, by default
         <systemitem>cluster<replaceable>NUMBER</replaceable></systemitem>. This
-      is optional and usefuly for &geo; clusters only. Usually, the cluster
-      name reflects its location and makes it easier to distinguish a site
-      inside a &geo; clusters.</para>
+      is optional and mostly usefuly for &geo; clusters. Usually, the cluster
+      name reflects the location and makes it easier to distinguish a site
+      inside a &geo; cluster.</para>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
This PR integrates two things:

* Mention in section "*Overview of the Bootstrap Scripts*" (`xml:id=sec.ha.inst.quick.bootstrap`) the cluster name at the first time.
* Add the `--name` option in procedure "*Setting Up the First Node (alice)*" (`xml:id=pro.ha.inst.quick.setup.ha-cluster-init`) and recommends its usage.

@taroth21 Let me know what you think. 😉 Thanks!