### PR TITLE
Geo Quick: Remove extra trailing slash

### DIFF
--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -532,7 +532,7 @@ meta target-role=Stopped<co xml:id="co.geo.quick.rsc.stopped"/></screen>
     </para>
 <screen>&prompt.root;<command>ha-cluster-geo-join</command> \
   --cluster-node<co xml:id="co.geo.join.cluster-node"/> &geo-vip-site1;\
-  --clusters<co xml:id="co.geo.join.clusters"/> "&cluster1;=&geo-vip-site1; &cluster2;=&geo-vip-site2;" \
+  --clusters<co xml:id="co.geo.join.clusters"/> "&cluster1;=&geo-vip-site1; &cluster2;=&geo-vip-site2;"
      </screen>
     <calloutlist>
      <callout arearefs="co.geo.join.cluster-node">


### PR DESCRIPTION
Just a small thing,but the geo-join command had an extra trailing slash at the end. :)