### PR TITLE
clvm: use_lvmetad must be set to 0 when using clvm

### DIFF
--- a/xml/ha_clvm.xml
+++ b/xml/ha_clvm.xml
@@ -170,6 +170,14 @@ cLVM) for more information and details to integrate here - really helpful-->
      <literal>3</literal> (the default is <literal>1</literal>). Copy the configuration to all nodes, if necessary.
     </para>
    </listitem>
+   <listitem>
+    <para>
+     Check if the lvmetad daemon is disabled because it cannot work with clvm. The keyword
+     <literal>use_lvmetad</literal> in
+     <filename>/etc/lvm/lvm.conf</filename> must be set to
+     <literal>0</literal> (the default is <literal>1</literal>). Copy the configuration to all nodes, if necessary.
+    </para>
+   </listitem>
   </itemizedlist>
 
   <note>


### PR DESCRIPTION
bsc#1057178

Backports: sle12sp1,sle12sp2,sle12sp3

Signed-off-by: Eric Ren <zren@suse.com>