### PR TITLE
ha_cluster_md: add the description for raid10

### DIFF
--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -14,8 +14,10 @@
  <info>
       <abstract>
         <para>The cluster multi-device (Cluster MD) is a software based RAID
-   storage solution for a cluster. Cluster MD provides the redundancy of
-   RAID1 mirroring to the cluster. Currently, only RAID1 is supported now.
+   storage solution for a cluster. Currently, Cluster MD provides the redundancy of
+   RAID1 mirroring to the cluster. With &productname; &productnumber;, RAID10 is
+   included as technical preview. If you want to try RAID10, replace <literal>mirror</literal>
+   with <literal>10</literal> in the related <command>mdadm</command> command.
    This chapter shows you how to create and use Cluster MD.
    </para>
       </abstract>


### PR DESCRIPTION
Since raid10 is supported as technical preview,
modify the doc accordingly.

Signed-off-by: Guoqing Jiang <gqjiang@suse.com>