### PR TITLE
cluster lvm: avoid the usage of clvm term

### DIFF
--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -384,7 +384,7 @@
     </listitem>
     <listitem>
      <para> The SBD device <emphasis>must not</emphasis>
-      use host-based RAID, cLVM2, nor reside on a DRBD* instance.
+      use host-based RAID, LVM2, nor reside on a DRBD* instance.
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/book_sle_ha_guide.xml
+++ b/xml/book_sle_ha_guide.xml
@@ -90,7 +90,7 @@
   <xi:include href="ha_naming.xml"/>
 <!--<xi:include href="ha_example.xml" xmlns:xi="http://www.w3.org/2001/XInclude"/>-->
 <!--taroth 2014-08-28: commenting for now, needs alignment with changed
-   resource confguration in  OFCS2/GFS2/cLVM chapter-->
+   resource confguration in  OFCS2/GFS2/LVM2 chapter-->
   <xi:include href="ha_management.xml"/>
   <xi:include href="ha_crmreport_passl.xml"/>
 <!--taroth 2017-12-20: commenting docupdates because of major release,

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -37,7 +37,7 @@ Testcase Fate#314367:
 <!--taroth 2010-08-19: for next revision, see also Sander's book (chapter about
 cLVM) for more information and details to integrate here - really helpful-->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.ha.clvm">
- <title>Cluster Logical Volume Manager (cLVM)</title>
+ <title>Cluster Logical Volume Manager (cluster LVM)</title>
  <info>
       <abstract>
         <para>
@@ -78,38 +78,38 @@ cLVM) for more information and details to integrate here - really helpful-->
    <varlistentry>
     <term>Distributed Lock Manager (DLM)</term>
     <listitem>
-     <para> Coordinates disk access for cLVM and mediates metadata access
-      through locking.</para>
+     <para> Coordinates metadata access through cluster locking.</para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Logical Volume Manager2 (LVM2)</term>
+    <term>Logical Volume Manager (LVM2)</term>
     <listitem>
      <para>
       Enables flexible distribution of one file system over several disks.
-      LVM provides a virtual pool of disk space.
+      LVM2 provides a virtual pool of disk space.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Clustered Logical Volume Manager (cLVM)</term>
+    <term>Cluster Logical Volume Manager (cluster LVM2)</term>
     <listitem>
      <para>
-      Coordinates access to the LVM2 metadata so every node knows about
-      changes. cLVM does not coordinate access to the shared data itself; to
-      enable cLVM to do so, you must configure OCFS2 or other cluster-aware
-      applications on top of the cLVM-managed storage.
+      The term "cluster LVM2" indicates LVM2 is being used in cluster environment,
+      which needs some configuration adjustments to enable its cluster extension
+      to protect the LVM2 metadata on shared storage. From SLES15 onward, the cluster
+      extension is now changed to use <literal>lvmlockd</literal>, which replaces the old
+      well-known <literal>clvmd</literal>.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </sect1>
  <sect1 xml:id="sec.ha.clvm.config">
-  <title>Configuration of cLVM</title>
+  <title>Configuration of cluster LVM</title>
 
   <para>
    Depending on your scenario it is possible to create a RAID&nbsp;1
-   device with cLVM with the following layers:
+   device with the following layers:
   </para>
 
   <remark>toms 2010-03-12 (DEV): What are the advantages and disadvantages?</remark>
@@ -173,7 +173,7 @@ cLVM) for more information and details to integrate here - really helpful-->
    <listitem>
     <para>
      Check if the <systemitem class="daemon">lvmetad</systemitem> daemon is
-     disabled because it cannot work with cLVM. In <filename>/etc/lvm/lvm.conf</filename>,
+     disabled because it cannot work with cluster LVM. In <filename>/etc/lvm/lvm.conf</filename>,
      the keyword <literal>use_lvmetad</literal> must be set to <literal>0</literal>
      (the default is <literal>1</literal>).
      Copy the configuration to all nodes, if necessary.
@@ -295,7 +295,7 @@ cLVM) for more information and details to integrate here - really helpful-->
    </procedure>
 <!-- FATE#312248: -->
    <para>
-    The current cLVM can only handle one physical volume (PV) per mirror
+    The current cluster LVM can only handle one physical volume (PV) per mirror
     side. If one mirror is actually made up of several PVs that need to be
     concatenated or striped, <command>lvcreate</command> does not understand
     this. For this reason, <command>lvcreate</command> and
@@ -373,7 +373,7 @@ cLVM) for more information and details to integrate here - really helpful-->
   <sect2 xml:id="sec.ha.clvm.config.resources">
    <title>Creating the Cluster Resources</title>
    <para>
-    Preparing the cluster for use of cLVM includes the following basic
+    Preparing the cluster for use of cluster LVM includes the following basic
     steps:
    </para>
    <itemizedlist>
@@ -392,12 +392,12 @@ cLVM) for more information and details to integrate here - really helpful-->
     <title>Creating a DLM Resource</title>
 <!--bcn#633216 and lmb's setup proposal on [ha-devel]-->
     <note>
-     <title>DLM Resource for Both cLVM and OCFS2</title>
+     <title>DLM Resource for Both LVM2 and OCFS2</title>
      <para>
-      Both cLVM and OCFS2 need a DLM resource that runs on all nodes in the
+      Both LVM2 and OCFS2 need a DLM resource that runs on all nodes in the
       cluster and therefore is usually configured as a clone. If you have a
-      setup that includes both OCFS2 and cLVM, configuring
-      <emphasis>one</emphasis> DLM resource for both OCFS2 and cLVM is
+      setup that includes both OCFS2 and LVM2, configuring
+      <emphasis>one</emphasis> DLM resource for both OCFS2 and LVM2 is
       enough.
      </para>
     </note>
@@ -894,7 +894,7 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
   </para>-->
 
   <sect2 xml:id="sec.ha.clvm.scenario.drbd">
-   <title>Scenario: cLVM With DRBD</title>
+   <title>Scenario: LVM2 With DRBD</title>
    <para>
     The following scenarios can be used if you have data centers located in
     different parts of your city, country, or continent.

--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -133,11 +133,11 @@
     storage as needed. It supports Fibre Channel or iSCSI storage area
     networks (SANs). Shared disk systems are also supported, but they are
     not a requirement. &productname; also comes with a cluster-aware file
-    system and volume manager (OCFS2) and the clustered Logical Volume
-    Manager (cLVM). For replication of your data, you can use DRBD* to
-    mirror the data of a &ha; service from the active node of a cluster
-    to its standby node. Furthermore, &productname; also supports CTDB
-    (Clustered Trivial Database), a technology for Samba clustering.
+    system (OCFS2) and the cluster Logical Volume Manager (cluster LVM2).
+    For replication of your data, you can use DRBD* to mirror the data of
+    a &ha; service from the active node of a cluster to its standby node.
+    Furthermore, &productname; also supports CTDB (Cluster Trivial Database),
+    a technology for Samba clustering.
    </para>
   </sect2>
 
@@ -511,9 +511,9 @@
   </para>
 
   <important>
-   <title>Shared Disk Subsystem with cLVM</title>
+   <title>Shared Disk Subsystem with LVM2</title>
    <para>
-    When using a shared disk subsystem with cLVM, that subsystem must be
+    When using a shared disk subsystem with LVM2, that subsystem must be
     connected to all servers in the cluster from which it needs to be
     accessed.
    </para>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -190,7 +190,7 @@
     aware that this has impact on the support status for your product.
     Furthermore, with <literal>stonith-enabled="false"</literal>, resources
     like the Distributed Lock Manager (DLM) and all services depending on
-    DLM (such as cLVM2, GFS2, and OCFS2) will fail to start.
+    DLM (such as LVM2, GFS2, and OCFS2) will fail to start.
    </para>
    <important>
     <title>No Support Without &stonith;</title>

--- a/xml/ha_config_example.xml
+++ b/xml/ha_config_example.xml
@@ -6,7 +6,7 @@
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.ha.config.example">
- <title>Example Configuration for OCFS2 and cLVM</title>
+ <title>Example Configuration for OCFS2 and LVM2</title>
  <info>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:maintainer></dm:maintainer>
@@ -23,14 +23,14 @@
   here...</remark>
  <para>
   The following is an example configuration that can help you setting up
-  your resources for use of either OCFS2, cLVM, or both. The configuration
+  your resources for use of either OCFS2, LVM2, or both. The configuration
   below does not represent a complete cluster configuration but is only an
-  extract, including all resources needed for OCFS2 and cLVM, and ignoring
+  extract, including all resources needed for OCFS2 and LVM2, and ignoring
   any other resources that you might need. Attributes and attribute values
   may need adjustment to your specific setup.
  </para>
  <example xml:id="ex.ha.config.ocfs2.clvm">
-  <title>Cluster Configuration for OCFS2 and cLVM</title>
+  <title>Cluster Configuration for OCFS2 and LVM2</title>
 <screen>primitive ocf:heartbeat:clvm \
      op start interval="0" timeout="90" \
      op stop interval="0" timeout="100" \

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -201,7 +201,7 @@
    <para>
     The configuration consists of a base group that includes several
     primitives and a base clone. Both base group and base clone can be used
-    in various scenarios afterwards (for both GFS2 and cLVM, for example).
+    in various scenarios afterwards (for both GFS2 and LVM2, for example).
     You only need to extend the base group with the respective primitives as
     needed. As the base group has internal colocation and ordering, this
     facilitates the overall setup as you do not need to specify several

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -19,7 +19,7 @@
  * OCFS2
  * bonding
  * LVS
- * cLVM(2)
+ * cluster LVM2
  * SAN
  * UDP-->
 <!--taroth 2014-07-04: found this somewhere in my notes, check against current

--- a/xml/ha_intro.xml
+++ b/xml/ha_intro.xml
@@ -63,11 +63,11 @@
    <listitem>
     <para>
      &productname; ships with the cluster-aware file systems OCFS2 and
-     GFS2, and the clustered Logical Volume Manager (cLVM). For replication
-     of your data, use DRBD*. It lets you mirror the data of a &ha;
-     service from the active node of a cluster to its standby node.
-     Furthermore, a clustered Samba server also provides a &ha; solution
-     for heterogeneous environments.
+     GFS2, and the cluster Logical Volume Manager (cluster LVM2). For
+     replication of your data, use DRBD*. It lets you mirror the data
+     of a &ha; service from the active node of a cluster to its standby
+     node. Furthermore, a clustered Samba server also provides a &ha;
+     solution for heterogeneous environments.
     </para>
    </listitem>
   </varlistentry>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -6,7 +6,7 @@
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
 <!--taroth 2010-08-19: for next revision, see also Sander's book 
-(chapter about cLVM) for more information and details to integrate here-->
+(chapter about cluster LVM) for more information and details to integrate here-->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.ha.ocfs2">
  <title>&ocfs;</title>
  <info>
@@ -268,12 +268,12 @@
   </para>
 
   <note>
-   <title>DLM Resource for Both cLVM and &ocfs;</title>
+   <title>DLM Resource for Both LVM2 and &ocfs;</title>
    <para>
-    Both cLVM and &ocfs; need a DLM resource that runs on all nodes in
+    Both LVM2 and &ocfs; need a DLM resource that runs on all nodes in
     the cluster and therefore usually is configured as a clone. If you have
-    a setup that includes both &ocfs; and cLVM, configuring
-    <emphasis>one</emphasis> DLM resource for both &ocfs; and cLVM is
+    a setup that includes both &ocfs; and LVM2, configuring
+    <emphasis>one</emphasis> DLM resource for both &ocfs; and LVM2 is
     enough.
    </para>
   </note>
@@ -332,7 +332,7 @@
    <para>
     The configuration consists of a base group that includes several
     primitives and a base clone. Both base group and base clone can be used
-    in various scenarios afterwards (for both &ocfs; and cLVM, for
+    in various scenarios afterwards (for both &ocfs; and LVM2, for
     example). You only need to extended the base group with the respective
     primitives as needed. As the base group has internal colocation and
     ordering, this simplifies the overall setup as you do not need to

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -64,7 +64,7 @@
       <para>
         The primary component contributing to this goal is node
         fencing/&stonith; since it ensures that all other access prior to
-        storage activation is terminated. Other mechanisms are cLVM2 exclusive
+        storage activation is terminated. Other mechanisms are LVM2 exclusive
         activation or OCFS2 file locking support to protect your system against
         administrative or application faults. Combined appropriately for your
         setup, these can reliably prevent split brain scenarios from causing
@@ -153,7 +153,7 @@
         </listitem>
         <listitem>
           <para> The shared storage segment <emphasis>must not</emphasis>
-            use host-based RAID, cLVM2, nor DRBD*. DRBD can be splitted which is
+            use host-based RAID, LVM2, nor DRBD*. DRBD can be splitted which is
             problematic for SBD as there cannot be two states in SBD.
             Cluster multi-device (Cluster MD) cannot be used for SBD.
           </para>
@@ -778,7 +778,7 @@ Timeout (msgwait)  : 40
     <para>
      Usually you should use the above resource with the
      <literal>Filesystem</literal> resource, for example, MD-RAID, LVM, and
-      Ext2/3/4/XFS. &ocfs; and cLVM do not need it. In this
+      Ext2/3/4/XFS. &ocfs; and cluster LVM do not need it. In this
      case, you need to perform the following steps:
     </para>
     <procedure>
@@ -879,7 +879,7 @@ Timeout (msgwait)  : 40
      </listitem>
      <listitem>
       <para>
-       Using a cLVM2 logical volume is possible.
+       Using a LVM2 logical volume is possible.
       </para>
      </listitem>
     </itemizedlist>

--- a/xml/nfs_quick_clusterscript.xml
+++ b/xml/nfs_quick_clusterscript.xml
@@ -148,7 +148,7 @@
         Death</emphasis>) setup. It is appropriate for clusters
       where all of your data is on the same shared storage. The shared
       storage segment <emphasis>must not</emphasis> use host-based RAID,
-      cLVM2, nor DRBD*. See <xref linkend="cha.ha.storage.protect"/> and
+      LVM2, nor DRBD*. See <xref linkend="cha.ha.storage.protect"/> and
         <xref linkend="cha.ha.fencing"/> for further details. Proceed as
       follows: </para>
 


### PR DESCRIPTION
With FATE#323203 - "Enable lvmlockd", we will use lvmlockd
to replace the old "clvmd" daemon. People get used to see
"clvm" acronym the same as "clvmd". So, we'd better remove
all "clvm" acronym. Like cluster MD, we tend to use cluster
LVM instead.

Well, manay clvm/cLVM still exist. Anyway, I will remove the
cmirror setction and some configuration steps in the consequent
commits.

Signed-off-by: Eric Ren <zren@suse.com>