### PR TITLE
fix bsc#1067156: adjust package name

### DIFF
--- a/xml/ha_lb_lvs.xml
+++ b/xml/ha_lb_lvs.xml
@@ -23,7 +23,8 @@
   <sect2 xml:id="sec.ha.lvs.overview.director">
    <title>Director</title>
    <para>
-    The main component of LVS is the ip_vs (or IPVS) Kernel code. It
+    The main component of LVS is the ip_vs (or IPVS) Kernel code. It is part of
+    the default Kernel and
     implements transport-layer load balancing inside the Linux Kernel
     (layer-4 switching). The node that runs a Linux Kernel including the
     IPVS code is called <emphasis>director</emphasis>. The IPVS code running
@@ -37,12 +38,6 @@
     director, it does not send acknowledgments. The director acts as a
     specialized router that forwards packets from end users to real servers
     (the hosts that run the applications that process the requests).
-   </para>
-   <para>
-    By default, the Kernel does not need the IPVS module installed. The IPVS
-    Kernel module is included in the
-    <package>kernel-default</package>
-    package.
    </para>
   </sect2>
 

--- a/xml/ha_lb_lvs.xml
+++ b/xml/ha_lb_lvs.xml
@@ -41,7 +41,7 @@
    <para>
     By default, the Kernel does not need the IPVS module installed. The IPVS
     Kernel module is included in the
-    <package>cluster-network-kmp-default</package>
+    <package>kernel-default</package>
     package.
    </para>
   </sect2>


### PR DESCRIPTION
- kernel modules formerly packaged in cluster-network-kmp
  are now part of kernel-default package (Fate#323221)

- any other content changes required?