### PR TITLE
check and update external links

### DIFF
--- a/xml/ha_acl.xml
+++ b/xml/ha_acl.xml
@@ -636,7 +636,7 @@
   <title>For More Information</title>
 
   <para>
-   See <ulink url="http://www.clusterlabs.org/doc/acls.html"/>.
+   See <ulink url="http://www.clusterlabs.org/pacemaker/doc/acls.html"/>.
   </para>
  </sect1>-->
 </chapter>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -50,7 +50,7 @@
    <title>Overview</title>
    <para>
     For an overview of all global cluster options and their default values,
-    see &paceex;, available from <link xlink:href="http://www.clusterlabs.org/doc/"/>. Refer to section
+    see &paceex;, available from <link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>. Refer to section
     <citetitle>Available Cluster Options</citetitle>.
    </para>
    <para>
@@ -286,9 +286,7 @@
        <filename>/usr/lib/ocf/resource.d/<replaceable>provider</replaceable>/</filename>.
        Their functionality is similar to that of LSB scripts. However, the
        configuration is always done with environmental variables which allow
-       them to accept and process parameters easily. The OCF specification
-       (as it relates to resource agents) can be found at
-       <link xlink:href="http://www.opencf.org/cgi-bin/viewcvs.cgi/specs/ra/resource-agent-api.txt?rev=HEAD&amp;content-type=text/vnd.viewcvs-markup"/>.
+       them to accept and process parameters easily.
        OCF specifications have strict definitions of which exit codes must
        be returned by actions, see <xref linkend="sec.ha.errorcodes"/>. The
        cluster follows these specifications exactly.
@@ -673,7 +671,7 @@
     <para>
      When configuring resource monitoring or constraints, clones have
      different requirements than simple resources. For details, see
-     &paceex;, available from <link xlink:href="http://www.clusterlabs.org/doc/"/>. Refer to section
+     &paceex;, available from <link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>. Refer to section
      <citetitle>Clones - Resources That Get Active on Multiple
      Hosts</citetitle>.
     </para>
@@ -1762,7 +1760,7 @@ monitor_0     interval=5s timeout=20s</screen>
     <para>
      For more information on configuring constraints and detailed background
      information about the basic concepts of ordering and colocation, refer
-     to the following documents. They are available at <link xlink:href="http://www.clusterlabs.org/doc/"/>:
+     to the following documents. They are available at <link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>:
     </para>
     <itemizedlist>
      <listitem>
@@ -2432,7 +2430,7 @@ group g-vm1-and-services vm1 vm1-sshd \
     service, including multiple use cases with detailed setup instructions
     in <citetitle>Pacemaker Remote&mdash;Extending High Availability into
     Virtual Nodes</citetitle>, available at
-    <link xlink:href="http://www.clusterlabs.org/doc/"/>.
+    <link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>.
    </para>
   </sect2>
  </sect1>
@@ -2686,7 +2684,7 @@ group g-vm1-and-services vm1 vm1-sshd \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><link xlink:href="http://www.clusterlabs.org/doc/"/> 
+    <term><link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>
     </term>
     <listitem>
      <para>
@@ -2700,12 +2698,13 @@ group g-vm1-and-services vm1 vm1-sshd \
         for reference.
        </para>
       </listitem>
-      <listitem>
+     <!--taroth 2015-05-06: commenting for now since it is a little bit outdated
+       (clones are still used in stonith configuration examples)<listitem>
        <para>
         <citetitle>Configuring Fencing with crmsh</citetitle>: How to
         configure and use &stonith; devices.
        </para>
-      </listitem>
+      </listitem>-->
       <listitem>
        <para>
         <citetitle>Colocation Explained</citetitle>
@@ -2717,15 +2716,6 @@ group g-vm1-and-services vm1 vm1-sshd \
        </para>
       </listitem>
      </itemizedlist>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><link xlink:href="http://linux-ha.org"/>
-    </term>
-    <listitem>
-     <para>
-      Home page of the The High Availability Linux Project.
-     </para>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/xml/ha_fencing.xml
+++ b/xml/ha_fencing.xml
@@ -746,7 +746,7 @@ hostlist</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><link xlink:href="http://www.clusterlabs.org/doc/"/>
+    <term><link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>
     </term>
     <listitem>
      <itemizedlist>

--- a/xml/ha_hawk2_cons_i.xml
+++ b/xml/ha_hawk2_cons_i.xml
@@ -486,7 +486,7 @@
    information about the basic concepts of ordering and colocation, refer to
    the documentation available at
    <link
-     xlink:href="http://www.clusterlabs.org/doc/"/>:
+     xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>:
   </para>
   <itemizedlist>
    <listitem>

--- a/xml/ha_hawk2_manage_i.xml
+++ b/xml/ha_hawk2_manage_i.xml
@@ -378,7 +378,7 @@
   <para>
    For more information, see &paceex;, available from
    <link
-     xlink:href="http://www.clusterlabs.org/doc/"/>. Refer to section
+     xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>. Refer to section
    <citetitle>Resource Migration</citetitle>.
   </para>
  </sect2>

--- a/xml/ha_hawk2_rsc_i.xml
+++ b/xml/ha_hawk2_rsc_i.xml
@@ -635,7 +635,7 @@
    When configuring resource monitoring or constraints, multi-state resources
    have different requirements than simple resources. For details, see
    &paceex;, available from
-   <link xlink:href="http://www.clusterlabs.org/doc/"/>. Refer to section
+   <link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>. Refer to section
    <citetitle>Multi-state - Resources That Have Multiple Modes</citetitle>.
   </para>
   <note>

--- a/xml/ha_hawk_rsc_config_i.xml
+++ b/xml/ha_hawk_rsc_config_i.xml
@@ -1143,7 +1143,8 @@
   <para>
    For more information on configuring constraints and detailed background
    information about the basic concepts of ordering and colocation, refer to
-   the documentation available at <link xlink:href="http://www.clusterlabs.org/doc/"/>:
+   the documentation available at <link
+   xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>:
   </para>
   <itemizedlist>
    <listitem>

--- a/xml/ha_hawk_rsc_manage_i.xml
+++ b/xml/ha_hawk_rsc_manage_i.xml
@@ -371,7 +371,8 @@
   </procedure>
   <para>
    For more information, see the <command>crm_resource</command> man page or
-   &paceex;, available from <link xlink:href="http://www.clusterlabs.org/doc/"/>. Refer to section
+   &paceex;, available from <link
+   xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>. Refer to section
    <citetitle>Resource Migration</citetitle>.
   </para>
  </sect2>

--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -208,7 +208,8 @@ Operations:
       * Node &node1;:</screen>
      </example>
      <para>
-      The &paceex; PDF, available at <link xlink:href="http://www.clusterlabs.org/doc/"/>, covers three
+      The &paceex; PDF, available at <link
+      xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>, covers three
       different recovery types in the <citetitle>How are OCF Return Codes
       Interpreted?</citetitle> section.
      </para>


### PR DESCRIPTION
- run daps checklink for all documents
- update most links to clusterlabs.org:
  http://www.clusterlabs.org/doc/ changed to
  http://www.clusterlabs.org/pacemaker/doc/
- remove outdated link to http://www.linux-ha.org/
  (the page itself point to clusterlabs.org),
  keeping links to some of its subpages though because they are
  still ok)