### PR TITLE
Improve crm shell prompt

### DIFF
--- a/xml/common_intro_typografie_i.xml
+++ b/xml/common_intro_typografie_i.xml
@@ -37,6 +37,11 @@
    </para>
   </listitem>
   <listitem>
+   <screen><prompt>&crm.live;</prompt></screen>
+   <para>Commands executed in the interactive &crmshell;. For details,
+   see <xref linkend="cha.ha.manual_config"/>.</para>
+  </listitem>
+  <listitem>
    <para>
     <filename>/etc/passwd</filename>: directory names and file names
    </para>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -187,6 +187,9 @@ called pacemaker_remote, but the daemon pacemaker_remoted. :-(
 <!ENTITY prompt.user2    "<prompt xmlns='http://docbook.org/ns/docbook'>&exampleuserII_plain; &gt; </prompt>">
 
 <!ENTITY crm.live          "crm(live)">
+<!ENTITY crm.live.alice    "crm(live/&node1;)">
+<!ENTITY crm.live.bob      "crm(live/&node2;)">
+
 <!ENTITY crm.haproxy       "crm(haproxy-config)">
 <!ENTITY prompt.crm        "<prompt xmlns='http://docbook.org/ns/docbook' role='custom'>&crm.live;# </prompt>">
 <!ENTITY prompt.crmhp      "<prompt xmlns='http://docbook.org/ns/docbook' role='custom'>&crm.haproxy;# </prompt>">

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -187,6 +187,7 @@ called pacemaker_remote, but the daemon pacemaker_remoted. :-(
 <!ENTITY prompt.user2    "<prompt xmlns='http://docbook.org/ns/docbook'>&exampleuserII_plain; &gt; </prompt>">
 
 <!ENTITY crm.live          "crm(live)">
+<!ENTITY crm.live.host     "crm(live/HOSTNAME)">
 <!ENTITY crm.live.alice    "crm(live/&node1;)">
 <!ENTITY crm.live.bob      "crm(live/&node2;)">
 

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -92,15 +92,21 @@
     -->
 
   <tip>
-   <title>Distinguish Between Shell Prompt and Interactive crm Prompt</title>
-   <para>
-    To make all the code and examples more readable, this chapter distinguish
-    between the shell root prompt (&prompt.root;) and the interactive crm
-    prompt:
-   </para>
+   <title>Interactive crm Prompt</title>
+   <para> To make all the code and examples more readable, this chapter
+    distinguishes between the shell root prompt (&prompt.root;) and the
+    interactive crm prompt: </para>
    <screen>&prompt.crm;</screen>
-   <para> For readability reasons, we omit the host names in our books. The
-    correct crm prompt for the host &node1; looks like this: </para>
+   <para>By using crm without arguments (or with only one sublevel as
+    argument), the &crmshell; enters the interactive mode. This mode is
+    indicated by the following prompt:
+   </para>
+   <screen><prompt>&crm.live.host;</prompt></screen>
+   <para>
+    For readability reasons, we omit the host name in the interactive crm
+    prompts in our documentation. We only include the host name if you need
+    to run the interactive shell on a specific node, like &node1; for example:
+   </para>
    <screen><prompt>&crm.live.alice;</prompt></screen>
   </tip>
 

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -93,10 +93,6 @@
 
   <tip>
    <title>Interactive crm Prompt</title>
-   <para> To make all the code and examples more readable, this chapter
-    distinguishes between the shell root prompt (&prompt.root;) and the
-    interactive crm prompt: </para>
-   <screen>&prompt.crm;</screen>
    <para>By using crm without arguments (or with only one sublevel as
     argument), the &crmshell; enters the interactive mode. This mode is
     indicated by the following prompt:

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -94,25 +94,14 @@
   <tip>
    <title>Distinguish Between Shell Prompt and Interactive crm Prompt</title>
    <para>
-    To make all the code and examples more readable, this chapter uses the
-    following notations between shell prompts and the interactive crm
+    To make all the code and examples more readable, this chapter distinguish
+    between the shell root prompt (&prompt.root;) and the interactive crm
     prompt:
    </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      Shell prompt for user &rootuser;:
-     </para>
-<screen>&prompt.root;</screen>
-    </listitem>
-    <listitem>
-     <para>
-      Interactive &crmsh; prompt (displayed in green, if terminal
-      supports colors):
-     </para>
-<screen>&prompt.crm;</screen>
-    </listitem>
-   </itemizedlist>
+   <screen>&prompt.crm;</screen>
+   <para> For readability reasons, we omit the host names in our books. The
+    correct crm prompt for the host &node1; looks like this: </para>
+   <screen><prompt>&crm.live.alice;</prompt></screen>
   </tip>
 
   <sect2 xml:id="sec.ha.manual_config.crm.help">


### PR DESCRIPTION
During RC2, the crm shell prompt has been changed:

```
crm(live/alice) #
```

Former versions didn't include the host names. This PR includes the following changes:

* Add two additional entities to distinguish between the nodes `alice` and `bob`
* Explain our strategy why we use the crm prompt without the host name (readability reasons)
* Mention crm prompt in preface