### PR TITLE
Feature/sbd chapter

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -348,6 +348,18 @@
        </para>
       </listitem>
      </varlistentry>
+     <varlistentry>
+      <term><literal>stonith-watchdog-timeout</literal> in the CIB</term>
+      <listitem>
+       <para>
+        This timeout is set in the CIB as global cluster property.
+        It defines after how many seconds it is assumed that the fencing target
+        has already self-fenced. This value must be &gt;= the value of
+        <varname>SBD_WATCHDOG_TIMEOUT</varname> in
+        <filename>/etc/sysconfig/sbd</filename>.
+       </para>
+      </listitem>
+     </varlistentry>
     </variablelist>
   <para>
    If you change the watchdog timeout, you need to adjust the other two timeouts
@@ -625,7 +637,7 @@ Timeout (msgwait)  : 10
     then enable and start the respective services for the changes to take effect.
    </para>
    <procedure xml:id="pro.ha.storage.protect.sbd.config">
-   <title>Adding the Devices to the SBD Configuration File</title>
+   <title>Editing the SBD Configuration File</title>
     <step>
      <para>Open the file <filename>/etc/sysconfig/sbd</filename>.</para>
     </step>
@@ -644,7 +656,7 @@ Timeout (msgwait)  : 10
     <para> If the SBD device is not accessible, the daemon will fail to start and inhibit
      &corosync; start-up. </para>
    </step>
- </procedure>
+  </procedure>
 
  <para>After you have added your SBD devices to the SBD configuration file,
   enable the SBD daemon to start at boot time. The SBD daemon is a critical piece
@@ -805,8 +817,8 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
        make sure this parameter is set to <literal>true</literal>.</para>
      </callout>
      <callout arearefs="co.ha.sbd.watchdog-timeout">
-      <para>This property has to be consistent with the value of
-       <varname>SBD_WATCHDOG_TIMEOUT</varname> from <filename>/etc/sysconfig/sbd</filename>.
+      <para>This value needs to be &gt;= the value of
+       <varname>SBD_WATCHDOG_TIMEOUT</varname> in <filename>/etc/sysconfig/sbd</filename>.
       </para>
      </callout>
      <callout arearefs="co.ha.sbd.st.timeout">

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -21,11 +21,6 @@
     configurations that have reliable shared storage, but it can also used in
     <literal>diskless mode</literal>, that means, without any shored storage.
    </para>
-    <!--taroth 2018-04-20: commenting too not make the abstract too long,
-     maybe it can be sued in the diskless SBD section?
-     In this mode, a watchdog device will be used to reset the node in the following cases:
-    if it loses quorum, if any monitored daemon is lost and not recovered or if
-    Pacemaker decides that the node requires fencing.-->
    <para>
     The <package>ha-cluster-bootstrap</package> scripts provide a quick way to
     set up a cluster with the option of using SBD as fencing mechanism. The
@@ -352,12 +347,10 @@
       <term><literal>stonith-watchdog-timeout</literal> in the CIB</term>
       <listitem>
        <para>
-        This timeout is set in the CIB as global cluster property.
-        It defines after how many seconds it is assumed that the fencing target
-        has already self-fenced. This value must be &gt;= the value of
-        <varname>SBD_WATCHDOG_TIMEOUT</varname> in
-        <filename>/etc/sysconfig/sbd</filename>.
-       </para>
+        This timeout is set in the CIB as global cluster property. If not set
+        explicitly, it defaults to <literal>0</literal>, which is appropriate for
+        using SBD with 1-3 devices. For use of SBD in diskless mode, see FIXME
+        for more details.</para>
       </listitem>
      </varlistentry>
     </variablelist>
@@ -680,7 +673,7 @@ Timeout (msgwait)  : 10
   </procedure>
 
   <para>
-   As a final step, test the SBD devices as described in <xref
+   As next step, test the SBD devices as described in <xref
    linkend="pro.ha.storage.protect.sbd.test" xrefstyle="select:label"/>.
   </para>
 
@@ -708,67 +701,14 @@ Timeout (msgwait)  : 10
       that it is ready to receive messages. </para>
     </step>
    </procedure>
-  </sect1>
 
-  <sect1 xml:id="sec.ha.storage.protect.diskless-sbd">
-   <title>Setting Up Diskless SBD</title>
-   <para>SBD can be operated in a diskless mode.</para>
-    <important>
-     <title>Number of Cluster Nodes</title>
-       <para>
-         Do <emphasis>not</emphasis> use diskless SBD as fencing mechanism
-         for two-node clusters. Use it only in clusters with three or more
-         nodes. SBD in diskless mode cannot handle split brain
-         scenarios for two-node clusters.
-      </para>
-   </important>
-   <para>
-    When setting up SBD, you need to take several timeout values into account.
-    For details, see <xref linkend="sec.ha.storage.protect.watchdog.timings"/>.
-   </para>
+  <para>
+   As final step, you need to adjust the cluster configuration as described in
+   <xref linkend="pro.ha.storage.protect.fencing" xrefstyle="select:label"/>.
+  </para>
 
-   <procedure xml:id="pro.ha.storage.protect.confdiskless">
-    <title>Configuring Diskless SBD</title>
-    <step>
-     <remark>toms 2018-04-25: Move the para and screen into section about
-     1-3 devices too?</remark>
-     <para>Open the file <filename>/etc/sysconfig/sbd</filename> and use
-      the following entries:</para>
-     <screen>SBD_PACEMAKER=yes
-SBD_STARTMODE=always
-SBD_DELAY_START=no
-SBD_WATCHDOG_DEV=/dev/watchdog
-SBD_WATCHDOG_TIMEOUT=5</screen>
-      <para>
-       The <varname>SBD_DEVICE</varname> entry is not needed as not shared
-       disk is used.
-      </para>
-    </step>
-    <step>
-     <para>On each node, enable the SBD service to start at boot time: </para>
-     <screen>&prompt.root;<command>systemctl</command> enable sbd</screen>
-    </step>
-    <step>
-     <para>Restart the cluster stack on each node to ensure that the
-      <systemitem>sbd</systemitem> service is started:</para>
-     <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen>
-     <para> This automatically triggers the start of the SBD daemon. </para>
-    </step>
-    <step>
-      <para>
-       Check if the parameter <parameter>have-watchdog=true</parameter> has
-       been automatically set:
-      </para>
-      <screen>&prompt.root;<command>crm</command> configure show | grep have-watchdog
-         have-watchdog=true \</screen>
-     <para>This means, that the cluster has detected SBD.</para>
-    </step>
-   </procedure>
-  </sect1>
-
-  <sect1 xml:id="pro.ha.storage.protect.fencing">
-   <title>Configuring the Cluster to Use SBD</title>
+<procedure xml:id="pro.ha.storage.protect.fencing">
+ <title>Configuring the Cluster to Use SBD</title>
    <para>
     To configure the use of SBD in the cluster, you need to do the following in
     the cluster configuration:
@@ -790,7 +730,6 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
      For the calculation of the <parameter>stonith-timeout</parameter> refer to
      <xref linkend="sec.ha.storage.protect.watchdog.timings"/>.
    </para>
- <procedure>
    <step>
     <para>
      Start a shell and log in as &rootuser; or equivalent.
@@ -805,7 +744,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     <para>Enter the following:</para>
     <screen>
 &prompt.crm.conf;<command>property</command> stonith-enabled="true" <co xml:id="co.ha.sbd.st.enabled"/>
-&prompt.crm.conf;<command>property</command> stonith-watchdog-timeout=5 <co xml:id="co.ha.sbd.watchdog-timeout"/>
+&prompt.crm.conf;<command>property</command> stonith-watchdog-timeout=0 <co xml:id="co.ha.sbd.watchdog-timeout"/>
 &prompt.crm.conf;<command>property</command> stonith-timeout="40s" <co xml:id="co.ha.sbd.st.timeout"/>
 &prompt.crm.conf;<command>primitive</command> stonith_sbd stonith:external/sbd <co xml:id="co.ha.sbd.st.rsc"/>\
   params pcmk_delay_max=30 <co xml:id="co.ha.sbd.pm_delay_max"/></screen>
@@ -817,8 +756,8 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
        make sure this parameter is set to <literal>true</literal>.</para>
      </callout>
      <callout arearefs="co.ha.sbd.watchdog-timeout">
-      <para>This value needs to be &gt;= the value of
-       <varname>SBD_WATCHDOG_TIMEOUT</varname> in <filename>/etc/sysconfig/sbd</filename>.
+      <para>If not explicitly set, this value default to <literal>0</literal>,
+        which is appropriate for use of SBD with 1-3 devices.
       </para>
      </callout>
      <callout arearefs="co.ha.sbd.st.timeout">
@@ -854,21 +793,128 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
 
    <para> After the resource has started, your cluster is successfully
     configured for use of SBD and will use this method in case a
-    node needs to be fenced. </para>
+    node needs to be fenced.</para>
+  </sect1>
+
+  <sect1 xml:id="sec.ha.storage.protect.diskless-sbd">
+   <title>Setting Up Diskless SBD</title>
+   <para>SBD can be operated in a diskless mode. In this mode, a watchdog device
+    will be used to reset the node in the following cases: if it loses quorum,
+    if any monitored daemon is lost and not recovered or if Pacemaker decides
+    that the node requires fencing. Diskless SBD is basically based on
+     <quote>self-fencing</quote> of a node, depending on the status of the quorum
+     and some reasonable assumptions.</para>
+    <important>
+     <title>Number of Cluster Nodes</title>
+       <para>
+         Do <emphasis>not</emphasis> use diskless SBD as fencing mechanism
+         for two-node clusters. Use it only in clusters with three or more
+         nodes. SBD in diskless mode cannot handle split brain
+         scenarios for two-node clusters.
+      </para>
+   </important>
+
+   <procedure xml:id="pro.ha.storage.protect.confdiskless">
+    <title>Configuring Diskless SBD</title>
+    <step>
+     <para>Open the file <filename>/etc/sysconfig/sbd</filename> and use
+      the following entries:</para>
+     <screen>SBD_PACEMAKER=yes
+SBD_STARTMODE=always
+SBD_DELAY_START=no
+SBD_WATCHDOG_DEV=/dev/watchdog
+SBD_WATCHDOG_TIMEOUT=5</screen>
+      <para>
+       The <varname>SBD_DEVICE</varname> entry is not needed as no shared
+       disk is used. When this parameter is missing, the <systemitem>sbd</systemitem>
+       service does not start any watcher process for SBD devices.
+      </para>
+    </step>
+    <step>
+     <para>On each node, enable the SBD service to start at boot time: </para>
+     <screen>&prompt.root;<command>systemctl</command> enable sbd</screen>
+    </step>
+    <step>
+     <para>Restart the cluster stack on each node to ensure that the
+      <systemitem>sbd</systemitem> service is started:</para>
+     <screen>&prompt.root;<command>systemctl</command> stop pacemaker
+&prompt.root;<command>systemctl</command> start pacemaker</screen>
+     <para> This automatically triggers the start of the SBD daemon. </para>
+    </step>
+    <step>
+      <para>
+       Check if the parameter <parameter>have-watchdog=true</parameter> has
+       been automatically set:
+      </para>
+      <screen>&prompt.root;<command>crm</command> configure show | grep have-watchdog
+         have-watchdog=true</screen>
+    </step>
+    <step>
+     <para>Run <command>crm configure</command> and set the following cluster
+      properties on the &crmshell;:</para>
+<screen>&prompt.crm.conf;<command>property</command> stonith-enabled="true" <xref
+        linkend="co.ha.sbd.st.enabled" xrefstyle="select:label"/>
+&prompt.crm.conf;<command>property</command> stonith-watchdog-timeout=5 <co
+        xml:id="co.ha.sbd.diskless.watchdog-timeout"/></screen>
+    <calloutlist>
+     <callout arearefs="co.ha.sbd.st.enabled">
+      <para>
+       This is the default configuration, because clusters with &stonith; are not supported.
+       But in case &stonith; had been deactivated for testing purposes,
+       make sure this parameter is set to <literal>true</literal>.</para>
+     </callout>
+     <callout arearefs="co.ha.sbd.watchdog-timeout">
+      <para>For diskless SBD, this parameter must not equal zero.
+       It defines after how long it is assumed that the fencing target has already
+       self-fenced. Therefore its value needs to be &gt;= the value of
+       <varname>SBD_WATCHDOG_TIMEOUT</varname> in <filename>/etc/sysconfig/sbd</filename>.
+       Starting with &productname; 15, if you set it to a negative value, Pacemaker
+       will automatically calculate an appropriate timeout based on the value of
+       <parameter>SBD_WATCHDOG_TIMEOUT</parameter> that is configured in
+       <filename>/etc/sysconfig/sbd</filename>.
+      </para>
+     </callout>
+    </calloutlist>
+   </step>
+  <step>
+    <para>
+     Review your changes with <command>show</command>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Submit your changes with <command>commit</command> and leave the crm live
+     configuration with <command>exit</command>.
+    </para>
+   </step>
+  </procedure>
   </sect1>
 
   <sect1 xml:id="sec.ha.storage.protect.test">
    <title>Testing SBD and Fencing</title>
    <para>To test if the combination of SBD and fencing works, use one or all
     of the following methods to check them:
+<remark>taroth 2018-04-25: not sure if itemizedlist is the best way to present this,
+as soon as we also mention the expected results, this might be overloaded...</remark>
    </para>
    <itemizedlist>
     <listitem>
      <para>Manually trigger fencing for node <replaceable>NODENAME</replaceable>:</para>
      <screen>&prompt.root;<command>crm</command> node fence <replaceable>NODENAME</replaceable></screen>
+    <para>
+      <remark>taroth 2018-04-25: What should be the result of this test? Would
+       be good to mention it, too. - according to ygao: Agreed. For example,
+       the fencing target should be fenced and the online nodes consider the
+       fencing target has been fenced after the time stonith-watchdog-timeout.</remark></para>
     </listitem>
     <listitem>
-     <para>Simulate a SBD failure on the SBD inquisitor and use its process ID:</para>
+     <para>Simulate a SBD failure on the SBD inquisitor and use its process ID:
+      <remark>taroth 2018-04-28: struggling a little bit with the order of this...
+      How about the following? "Simulate an SBD failure by killing the SBD
+      inquisitor process: 1. Identify the process ID of the SBD inquisitor with
+      the following command: [...] 2. Kill the process: [...] Also here, would
+      be useful to mention the expected result.</remark>
+    </para>
      <screen>&prompt.root;<command>systemctl</command> status sbd
 ● sbd.service - Shared-storage based fencing daemon
 
@@ -891,12 +937,18 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
       about this step. Taken from FATE entry, developers could add more info.
      </remark>
      <para>
+      <remark>taroth 2018-04-28: I would list this as steps:
+       1. Configure a <property>on-fail=fence</property> property for a resource monitor operation: [...]
+          (not sure if giving the line is enough, perhaps also mention command with which to set this property?)
+       2. Produce a failure of the monitoring operation (how???).
+        This failure triggers a fencing action (result).
+     </remark>
       Produce a failure of resource operation. This failure triggers a
       fencing action. For example, produce a failure of resource stop
       operation or configure <property>on-fail=fence</property> for a
       resource monitor operation like:
      </para>
-     <screen>op monitor interval=10 on-fail=fenc</screen>
+     <screen>op monitor interval=10 on-fail=fence</screen>
     </listitem>
    </itemizedlist>
   </sect1>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -19,7 +19,7 @@
     mechanism from changes in firmware version or dependencies on specific
     firmware controllers. SBD can be used as a &stonith; mechanism in all
     configurations that have reliable shared storage, but it can also used in
-    <literal>diskless mode</literal>, that means, without any shored storage.
+    <emphasis>diskless</emphasis> mode, that means, without any shored storage.
    </para>
    <para>
     The <package>ha-cluster-bootstrap</package> scripts provide a quick way to
@@ -200,7 +200,7 @@
    <itemizedlist>
    <listitem>
     <para>You can use up to three SBD devices for storage-based fencing.
-     When using 1-3 devices, the shared storage must be accessible from all nodes.</para>
+     When using one to three devices, the shared storage must be accessible from all nodes.</para>
    </listitem>
    <listitem>
     <para>The path to the shared storage device must be persistent and
@@ -349,8 +349,8 @@
        <para>
         This timeout is set in the CIB as global cluster property. If not set
         explicitly, it defaults to <literal>0</literal>, which is appropriate for
-        using SBD with 1-3 devices. For use of SBD in diskless mode, see FIXME
-        for more details.</para>
+        using SBD with one to three devices. For use of SBD in diskless mode, see <xref
+        linkend="pro.ha.storage.protect.confdiskless"/> for more details.</para>
       </listitem>
      </varlistentry>
     </variablelist>
@@ -517,7 +517,7 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
  </sect1>
 
  <sect1 xml:id="sec.ha.storage.protect.fencing.setup">
-  <title>Setting Up SBD with 1-3 Devices</title>
+  <title>Setting Up SBD with Devices</title>
   <para>
    The following steps are necessary for setup:
   </para>
@@ -542,6 +542,11 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
    <step>
     <para>
      <xref linkend="pro.ha.storage.protect.sbd.test" xrefstyle="select:title"/>
+    </para>
+   </step>
+   <step>
+    <para>
+     <xref linkend="pro.ha.storage.protect.fencing" xrefstyle="select:title"/>
     </para>
    </step>
   </procedure>
@@ -629,6 +634,7 @@ Timeout (msgwait)  : 10
     After you have initialized the SBD devices, edit the SBD configuration file,
     then enable and start the respective services for the changes to take effect.
    </para>
+
    <procedure xml:id="pro.ha.storage.protect.sbd.config">
    <title>Editing the SBD Configuration File</title>
     <step>
@@ -758,7 +764,7 @@ Timeout (msgwait)  : 10
      </callout>
      <callout arearefs="co.ha.sbd.watchdog-timeout">
       <para>If not explicitly set, this value default to <literal>0</literal>,
-        which is appropriate for use of SBD with 1-3 devices.
+        which is appropriate for use of SBD with one to three devices.
       </para>
      </callout>
      <callout arearefs="co.ha.sbd.st.timeout">
@@ -801,7 +807,7 @@ Timeout (msgwait)  : 10
    <title>Setting Up Diskless SBD</title>
    <para>SBD can be operated in a diskless mode. In this mode, a watchdog device
     will be used to reset the node in the following cases: if it loses quorum,
-    if any monitored daemon is lost and not recovered or if Pacemaker decides
+    if any monitored daemon is lost and not recovered, or if Pacemaker decides
     that the node requires fencing. Diskless SBD is basically based on
     <quote>self-fencing</quote> of a node, depending on the status of the cluster,
     the quorum and some reasonable assumptions.</para>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -652,7 +652,7 @@ Timeout (msgwait)  : 10
   </procedure>
 
  <para>After you have added your SBD devices to the SBD configuration file,
-  enable the SBD daemon to start at boot time. The SBD daemon is a critical piece
+  enable the SBD daemon. The SBD daemon is a critical piece
   of the cluster stack. It needs to be running when the cluster stack is running.
   Thus, the <systemitem>sbd</systemitem> service is started as a dependency whenever
   the <systemitem>pacemaker</systemitem> service is started.</para>
@@ -660,12 +660,13 @@ Timeout (msgwait)  : 10
   <procedure xml:id="pro.ha.storage.protect.sbd.services">
    <title>Enabling and Starting the SBD Service</title>
    <step>
-    <para>On each node, enable the SBD service to start at boot time: </para>
+    <para>On each node, enable the SBD service:</para>
     <screen>&prompt.root;<command>systemctl</command> enable sbd</screen>
+    <para>It will be started together with the Corosync service whenever the Pacemaker
+     service is started.</para>
    </step>
    <step>
-    <para>Restart the cluster stack on each node to ensure that the
-     <systemitem>sbd</systemitem> service is started:</para>
+    <para>Restart the cluster stack on each node:</para>
     <screen>&prompt.root;<command>systemctl</command> stop pacemaker
 &prompt.root;<command>systemctl</command> start pacemaker</screen>
     <para> This automatically triggers the start of the SBD daemon. </para>
@@ -802,8 +803,8 @@ Timeout (msgwait)  : 10
     will be used to reset the node in the following cases: if it loses quorum,
     if any monitored daemon is lost and not recovered or if Pacemaker decides
     that the node requires fencing. Diskless SBD is basically based on
-     <quote>self-fencing</quote> of a node, depending on the status of the quorum
-     and some reasonable assumptions.</para>
+    <quote>self-fencing</quote> of a node, depending on the status of the cluster,
+    the quorum and some reasonable assumptions.</para>
     <important>
      <title>Number of Cluster Nodes</title>
        <para>
@@ -831,12 +832,13 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
       </para>
     </step>
     <step>
-     <para>On each node, enable the SBD service to start at boot time: </para>
+     <para>On each node, enable the SBD service:</para>
      <screen>&prompt.root;<command>systemctl</command> enable sbd</screen>
+     <para>It will be started together with the Corosync service whenever the Pacemaker
+      service is started.</para>
     </step>
     <step>
-     <para>Restart the cluster stack on each node to ensure that the
-      <systemitem>sbd</systemitem> service is started:</para>
+     <para>Restart the cluster stack on each node:</para>
      <screen>&prompt.root;<command>systemctl</command> stop pacemaker
 &prompt.root;<command>systemctl</command> start pacemaker</screen>
      <para> This automatically triggers the start of the SBD daemon. </para>
@@ -854,7 +856,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
       properties on the &crmshell;:</para>
 <screen>&prompt.crm.conf;<command>property</command> stonith-enabled="true" <xref
         linkend="co.ha.sbd.st.enabled" xrefstyle="select:label"/>
-&prompt.crm.conf;<command>property</command> stonith-watchdog-timeout=5 <co
+&prompt.crm.conf;<command>property</command> stonith-watchdog-timeout=10 <co
         xml:id="co.ha.sbd.diskless.watchdog-timeout"/></screen>
     <calloutlist>
      <callout arearefs="co.ha.sbd.st.enabled">
@@ -863,15 +865,15 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
        But in case &stonith; had been deactivated for testing purposes,
        make sure this parameter is set to <literal>true</literal>.</para>
      </callout>
-     <callout arearefs="co.ha.sbd.watchdog-timeout">
+     <callout arearefs="co.ha.sbd.diskless.watchdog-timeout">
       <para>For diskless SBD, this parameter must not equal zero.
        It defines after how long it is assumed that the fencing target has already
        self-fenced. Therefore its value needs to be &gt;= the value of
        <varname>SBD_WATCHDOG_TIMEOUT</varname> in <filename>/etc/sysconfig/sbd</filename>.
        Starting with &productname; 15, if you set it to a negative value, Pacemaker
-       will automatically calculate an appropriate timeout based on the value of
-       <parameter>SBD_WATCHDOG_TIMEOUT</parameter> that is configured in
-       <filename>/etc/sysconfig/sbd</filename>.
+       will automatically calculate an appropriate timeout. In that case, it will
+       be set to twice the value of <parameter>SBD_WATCHDOG_TIMEOUT</parameter>
+       that is configured in <filename>/etc/sysconfig/sbd</filename>.
       </para>
      </callout>
     </calloutlist>
@@ -892,30 +894,26 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
 
   <sect1 xml:id="sec.ha.storage.protect.test">
    <title>Testing SBD and Fencing</title>
-   <para>To test if the combination of SBD and fencing works, use one or all
-    of the following methods to check them:
-<remark>taroth 2018-04-25: not sure if itemizedlist is the best way to present this,
-as soon as we also mention the expected results, this might be overloaded...</remark>
+   <para>To test if SBD works as expected for node fencing purposes, use one or all
+    of the following methods:
    </para>
-   <itemizedlist>
+  <variablelist>
+   <varlistentry>
+    <term>Manually Triggering Fencing of a Node</term>
     <listitem>
-     <para>Manually trigger fencing for node <replaceable>NODENAME</replaceable>:</para>
-     <screen>&prompt.root;<command>crm</command> node fence <replaceable>NODENAME</replaceable></screen>
-    <para>
-      <remark>taroth 2018-04-25: What should be the result of this test? Would
-       be good to mention it, too. - according to ygao: Agreed. For example,
-       the fencing target should be fenced and the online nodes consider the
-       fencing target has been fenced after the time stonith-watchdog-timeout.</remark></para>
+     <para>To trigger a fencing action for node <replaceable>NODENAME</replaceable>:</para>
+ <screen>&prompt.root;<command>crm</command> node fence <replaceable>NODENAME</replaceable></screen>
+     <para>Check if the node is fenced and if the other nodes consider the node as fenced
+      after the <parameter>stonith-watchdog-timeout</parameter>.</para>
     </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Simulating an SBD Failure</term>
     <listitem>
-     <para>Simulate a SBD failure on the SBD inquisitor and use its process ID:
-      <remark>taroth 2018-04-28: struggling a little bit with the order of this...
-      How about the following? "Simulate an SBD failure by killing the SBD
-      inquisitor process: 1. Identify the process ID of the SBD inquisitor with
-      the following command: [...] 2. Kill the process: [...] Also here, would
-      be useful to mention the expected result.</remark>
-    </para>
-     <screen>&prompt.root;<command>systemctl</command> status sbd
+     <procedure>
+      <step>
+       <para>Identify the process ID of the SBD inquisitor:</para>
+       <screen>&prompt.root;<command>systemctl</command> status sbd
 ● sbd.service - Shared-storage based fencing daemon
 
    Loaded: loaded (/usr/lib/systemd/system/sbd.service; enabled; vendor preset: disabled)
@@ -927,31 +925,38 @@ as soon as we also mention the expected results, this might be overloaded...</re
    CGroup: /system.slice/sbd.service
            ├─<emphasis role="strong">1859 sbd: inquisitor</emphasis>
 [...]</screen>
-     <para>Use the process ID (in our example, <literal>1859</literal>) and
-      kill the SBD inquisitor:
-     </para>
-     <screen>&prompt.root;<command>kill</command> -9 1859 </screen>
+      </step>
+      <step>
+       <para>Simulate an SBD failure by killing the SBD inquisitor process.
+       In our example, the process ID of the SBD inquisitor is
+         <literal>1859</literal>):</para>
+       <screen>&prompt.root;<command>kill</command> -9 1859 </screen>
+       <para>
+        <remark>taroth 2018-04-28: @DEVs, What is the expected result?</remark>
+       </para>
+      </step>
+     </procedure>
     </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Producing a Failure of a Resource Operation</term>
     <listitem>
-     <remark>toms 2018-04-24: This is a bit vague and I'm not entirely sure
-      about this step. Taken from FATE entry, developers could add more info.
-     </remark>
-     <para>
-      <remark>taroth 2018-04-28: I would list this as steps:
-       1. Configure a <property>on-fail=fence</property> property for a resource monitor operation: [...]
-          (not sure if giving the line is enough, perhaps also mention command with which to set this property?)
-       2. Produce a failure of the monitoring operation (how???).
-        This failure triggers a fencing action (result).
-     </remark>
-      Produce a failure of resource operation. This failure triggers a
-      fencing action. For example, produce a failure of resource stop
-      operation or configure <property>on-fail=fence</property> for a
-      resource monitor operation like:
-     </para>
-     <screen>op monitor interval=10 on-fail=fence</screen>
+     <procedure>
+      <step>
+       <para>Configure a <property>on-fail=fence</property> property for a resource monitor
+        operation:</para>
+       <screen>op monitor interval=10 on-fail=fence</screen>
+      </step>
+      <step>
+       <para> Produce a failure of the monitoring operation (for example, by killing the respective
+        daemon, if the resource relates to a service).</para>
+       <para>This failure should trigger a fencing action.</para>
+      </step>
+     </procedure>
     </listitem>
-   </itemizedlist>
-  </sect1>
+   </varlistentry>
+  </variablelist>
+ </sect1>
 
  <sect1 xml:id="sec.ha.storage.protect.morestuff">
   <title>Additional Mechanisms for Storage Protection</title>


### PR DESCRIPTION
 @gao-yan, @tomschr : please review! Thanks in advance!

Summary of Changes: Add missing information and corrections by ygao (as discusssed on ML/IRC/PR#72 today)
-  diskless SBD needs no fencing resource
-> move config of fencing rsc and cluster props to dedicated section about SBD with 1-3 devices
-> add required steps about cluster props to procedure for diskless SBD
- mention more details about stonith-watchdog-timeout:
  * for SBD with devices (set to zero)
  * for diskless SBD: >= SBD_WATCHDOG_TIMEOUT (or set to negative value for auto-calculation, Fate#324508)
- move commented information from abstract to diskless SBD section for better understanding plus add some information by ygao
- add remarks to testing section (remaining comments  from PR#72 that have not been solved yet)


DRAFT PDF version attached [cha.ha.storage.protect_remarks_color_draft_en.pdf](https://github.com/SUSE/doc-sleha/files/1947419/cha.ha.storage.protect_remarks_color_draft_en.pdf)
