### PR TITLE
apply naming conventions to CTBD chapter

### DIFF
--- a/xml/ha_samba.xml
+++ b/xml/ha_samba.xml
@@ -304,10 +304,10 @@
     op start timeout="60" interval="0" \
     op stop timeout="60" interval="0" \
     op monitor interval="60" timeout="60"
-&prompt.crm.conf;<command>group</command> ctdb-group ctdb nmb smb
-&prompt.crm.conf;<command>clone</command> ctdb-clone ctdb-group meta interleave="true"
-&prompt.crm.conf;<command>colocation</command> ctdb-with-clusterfs inf: ctdb-clone c-clusterfs
-&prompt.crm.conf;<command>order</command> clusterfs-then-ctdb inf: c-clusterfs ctdb-clone
+&prompt.crm.conf;<command>group</command> g-ctdb ctdb nmb smb
+&prompt.crm.conf;<command>clone</command> cl-ctdb g-ctdb meta interleave="true"
+&prompt.crm.conf;<command>colocation</command> col-ctdb-with-clusterfs inf: cl-ctdb cl-clusterfs
+&prompt.crm.conf;<command>order</command> o-clusterfs-then-ctdb inf: cl-clusterfs cl-ctdb
 &prompt.crm.conf;<command>commit</command></screen>
    </step>
    <step>
@@ -319,10 +319,10 @@
     unique_clone_address="true" \
     op monitor interval="60" \
     meta resource-stickiness="0"
-&prompt.crm.conf;<command>clone</command> ip-clone ip \
+&prompt.crm.conf;<command>clone</command> cl-ip ip \
     meta interleave="true" clone-node-max="2" globally-unique="true"
-&prompt.crm.conf;<command>colocation</command> col-with-ctdb 0: ip-clone ctdb-clone
-&prompt.crm.conf;<command>order</command> o-with-ctdb 0: ip-clone ctdb-clone
+&prompt.crm.conf;<command>colocation</command> col-ip-with-ctdb 0: cl-ip cl-ctdb
+&prompt.crm.conf;<command>order</command> o-ip-then-ctdb 0: cl-ip cl-ctdb
 &prompt.crm.conf;<command>commit</command></screen>
     <para>
      If <literal>unique_clone_address</literal> is set to
@@ -343,16 +343,16 @@
      Check the result:
     </para>
 <screen>&prompt.root;<command>crm</command> status
-Clone Set: base-clone [dlm]
+Clone Set: cl-storage [dlm]
      Started: [ factory-1 ]
      Stopped: [ factory-0 ]
-Clone Set: c-clusterfs [clusterfs]
+Clone Set: cl-clusterfs [clusterfs]
      Started: [ factory-1 ]
      Stopped: [ factory-0 ]
- Clone Set: ctdb-clone [ctdb-group]
+ Clone Set: cl-ctdb [g-ctdb]
      Started: [ factory-1 ]
      Started: [ factory-0 ]
- Clone Set: ip-clone [ip] (unique)
+ Clone Set: cl-ip [ip] (unique)
      ip:0       (ocf:heartbeat:IPaddr2):       Started factory-0
      ip:1       (ocf:heartbeat:IPaddr2):       Started factory-1</screen>
    </step>
@@ -418,11 +418,11 @@ Clone Set: c-clusterfs [clusterfs]
    </step>
    <step>
     <para>
-     Edit the <literal>ctdb-group</literal> and insert
+     Edit the <literal>g-ctdb</literal> group and insert
      <literal>winbind</literal> between the <literal>nmb</literal> and
      <literal>smb</literal> resources:
     </para>
-<screen>&prompt.crm.conf;<command>edit</command> ctdb-group</screen>
+<screen>&prompt.crm.conf;<command>edit</command> g-ctdb</screen>
     <para>
      Save and close the editor with <keycombo> <keycap>:</keycap>
      <keycap>w</keycap> </keycombo> (<command>vim</command>).


### PR DESCRIPTION
- use correct prefixes for groups, clones, colocations and order constraints (see also `ha_naming.xml`)
- rename base-clone to cl-storage (DLM resource)  to comply with naming conventions and upcoming changes from PR#82 (which is not merged yet because of bsc#1089339#c15)