### PR TITLE
Feature/update geo guide

### DIFF
--- a/xml/book_sle_ha_geo.xml
+++ b/xml/book_sle_ha_geo.xml
@@ -52,6 +52,8 @@
  <xi:include href="geo_trouble_i.xml"/>
  <xi:include href="geo_upgrade_i.xml"/>
  <xi:include href="geo_more_i.xml"/>
- <xi:include href="geo_docupdates.xml"/>
+<!--taroth 2018-05-25: commenting docupdates because of major release,
+    to be enabled again for next maintenance update or SP1-->
+ <!--<xi:include href="geo_docupdates.xml"/>-->
  <xi:include href="common_legal.xml"/>
 </book>

--- a/xml/geo_concept_i.xml
+++ b/xml/geo_concept_i.xml
@@ -53,11 +53,16 @@
  </para>
  <para>
   The most common scenario probably is a &geo; cluster with two sites and a
-  single arbitrator on a third site. This requires three booth instances, see
-  <xref linkend="fig.ha.geo.example.setup"/>.
+  single arbitrator on a third site. This requires three booth instances.
  </para>
+  <para>
+   It is also possible to run a two-site &geo; cluster <emphasis>without</emphasis>
+   an arbitrator. In this case, a &geo; cluster administrator needs to manually manage
+   the tickets. If a ticket should be granted to more than one site at the same time,
+   booth displays a warning.
+  </para>
  <figure xml:id="fig.ha.geo.example.setup">
-  <title>Two-Site Cluster (2x2 Nodes + Arbitrator)</title>
+  <title>Two-Site Cluster&mdash;2x2 Nodes + Arbitrator (Optional)</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="ha_geocluster.svg" width="100%" format="SVG"/>
@@ -78,7 +83,7 @@
     <para>
      Each site runs one booth instance that is responsible for communicating
      with the other sites. If you have a setup with an even number of sites,
-     you need an additional instance to reach consensus about decisions such as
+     it is useful to have an additional instance to reach consensus about decisions such as
      failover of resources across sites. In this case, add one or more
      arbitrators running at additional sites. Arbitrators are single machines
      that run a booth instance in a special mode. As all booth instances
@@ -227,7 +232,13 @@
      from the ticket owner in a sufficiently long time, one of the remaining
      sites will acquire the ticket. This is what is called ticket failover. If
      the remaining members cannot form a majority, then the ticket cannot fail
-     over.
+     over (if managed by booth).
+    </para>
+    <para>
+      If automatic failover in case of a split brain scenario is
+      <emphasis>not</emphasis> required, administrators can also manually grant
+      tickets to the healthy site. How to manage tickets from command line is
+      described in <xref linkend="sec.ha.geo.manage.cli" xrefstyle="select:label"/>.
     </para>
    </listitem>
   </varlistentry>

--- a/xml/geo_drbd_i.xml
+++ b/xml/geo_drbd_i.xml
@@ -159,8 +159,7 @@
    <xref linkend="sec.ha.geo.booth.sync.csync2.setup"/>. Note that the DRBD
    configuration snippets below are bare-bones&mdash;they do not include any
    performance tuning options or similar. For details on how to tune DRBD, see
-   the <citetitle>DRBD</citetitle> chapter in the &productname; &admin;,
-   available from <link xlink:href="&suse-onlinedoc;"/>.
+   <xref linkend="cha.ha.drbd"/>.
   </para>
   <example xml:id="ex.ha.geo.drbd.cfg.site1">
    <title>DRBD Configuration Snippet for Site 1 (&cluster1;)</title>

--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -48,9 +48,8 @@
      our customers and the kind of setup that is needed here)?</remark>
     More information on how to set up DNS, including dynamic update of zone
     data, can be found the &sle; <citetitle>&admin;</citetitle>, chapter
-    <citetitle>The Domain Name System</citetitle>.
-    <remark>taroth 2017-11-28: ToDo SLE 15: check!</remark>It is available from
-    <link xlink:href="&suse-onlinedoc;"/>.
+    <citetitle>The Domain Name System</citetitle>. It is available from
+    <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
    </para>
   </listitem>
   <listitem>
@@ -64,9 +63,8 @@
     For more information, see the <command>dnssec-keygen</command> man page or
     the  &sle; <citetitle>&admin;</citetitle>, chapter
     <citetitle>The Domain Name System</citetitle>, section <citetitle>Secure
-     Transactions</citetitle>.
-    <remark>taroth 2017-11-28: ToDo SLE 15: check!</remark>It is available from
-    <link xlink:href="&suse-onlinedoc;"/>.
+     Transactions</citetitle>. It is available from
+    <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/geo_more_i.xml
+++ b/xml/geo_more_i.xml
@@ -16,8 +16,6 @@
      More documentation for this product is available at
      <link
       xlink:href="&suse-onlinedoc;&doc-geo;"/>.
-     <remark>taroth 2017-11-28: requested generic URL; see
-     https://bugzilla.suse.com/show_bug.cgi?id=1070134</remark>
      For example, the <citetitle>&geoquick;</citetitle> guides you through
      the basic setup of a &geo; cluster, using the &geo; bootstrap scripts
      provided by the <systemitem xmlns='http://docbook.org/ns/docbook'

--- a/xml/geo_requirements_i.xml
+++ b/xml/geo_requirements_i.xml
@@ -22,8 +22,24 @@
   </dm:docmanager>
  </info>
 
- &geo-clusters-req-sw;
-
+ <itemizedlist>
+  <title>Software Requirements</title>
+  <listitem>
+   <para>
+    All machines (cluster nodes and arbitrators) that will be part of the cluster
+    need at least the following modules and extensions:
+   </para>
+   &sys-req-sw-modules;
+   </listitem>
+   <listitem>
+    <para>
+     When installing the machines, select <literal>HA GEO Node</literal> as 
+     <systemitem>system role</systemitem>. This leads to the installation of a
+     minimal system where the packages from the pattern <literal>&geo; Clustering
+     for &ha; (ha_geo)</literal> are installed by default.
+   </para>
+  </listitem>
+ </itemizedlist>
  <itemizedlist>
   <title>Network Requirements</title>
   &geo-clusters-req-netw-vip;

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -32,7 +32,7 @@
   This chapter focuses on tasks specific to &geo; clusters. For an introduction
   to your preferred cluster management tool and general instructions on how to
   configure resources and constraints with it, refer to one of the following
-  chapters in the <citetitle>&haguide;</citetitle> for &productname;:
+  chapters:
  </para>
  <itemizedlist>
   <listitem>

--- a/xml/geo_sync_i.xml
+++ b/xml/geo_sync_i.xml
@@ -50,9 +50,7 @@
 
   <para>
    How to set up &csync; for individual clusters with &yast; is explained in
-   the <citetitle>&haguide;</citetitle> for &productname;, chapter
-   <citetitle>Using the &yast; Cluster Module</citetitle>, section
-   <citetitle>Transferring the Configuration to All Nodes</citetitle>. However,
+   <xref linkend="sec.ha.installation.setup.csync2"/>. However,
    &yast; cannot handle more complex &csync; setups, like those that are needed
    for &geo; clusters. For the following setup, as shown in
    <xref linkend="fig.ha.geo.csync.config"/>, configure &csync; manually by

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -590,7 +590,7 @@
     All cluster nodes on all sites should synchronize to an NTP server outside
     the cluster. For more information, see the <citetitle>&admin;</citetitle>
     for &sls; &productnumber;, available at
-    <link xlink:href='http://www.suse.com/documentation/'/>. Refer to the
+    <link xlink:href='http://www.suse.com/documentation/&doc-sles;'/>. Refer to the
     chapter <citetitle>Time Synchronization with NTP</citetitle>.
    </para>
    <para>


### PR DESCRIPTION
Started to update the Geo Clustering Guide. The changes include:
* conceptual oview: mention manual ticket failover (as intro for fate#322100, 
   the details need to be added in CLI section)
* requirements: update software requirements (to be in sync with Geo Quick)
* check all pointers to SLE books for correct book|chapter|section titles
* replace links to HA Admin Guide with xrefs (possible, because in same set now)
* disable docupdate appendix (because of major release) 

@tomschr : Please review and merge if OK. Handing over to you from here on. :) 
See you in two weeks. 

Remaining ToDos on my side (after I'm back):
* [ ] adjust upgrade chapter to match latest changes in HA Admin Guide 