### PR TITLE
Re-add docupdate appendix for SLE HA 15 (bsc#1102199)

### DIFF
--- a/xml/book_sle_ha_guide.xml
+++ b/xml/book_sle_ha_guide.xml
@@ -97,7 +97,7 @@
   <xi:include href="ha_crmreport_passl.xml"/>
 <!--taroth 2017-12-20: commenting docupdates because of major release,
     to be enabled again for next maintenance update or SP1-->
-  <!--<xi:include href="ha_docupdates.xml"/>-->
+  <xi:include href="ha_docupdates.xml"/>
  </part>
 
  <xi:include href="ha_glossary.xml"/>

--- a/xml/ha_docupdates.xml
+++ b/xml/ha_docupdates.xml
@@ -25,5 +25,31 @@
  </info>
  <para> This chapter lists content changes for this document. </para>
  <para> This manual was updated on the following dates: </para>
+ <!--list of xrefs, latest date sorted upmost-->
+ <itemizedlist>
+  <listitem>
+   <para>
+    <xref linkend="sec.ha.docupdates.sle15_ga" xrefstyle="SectTitleOnPage"/>
+   </para>
+  </listitem>
+ </itemizedlist>
+
+ <sect1 xml:id="sec.ha.docupdates.sle15_ga">
+  <title>July 2018 (Initial Release of &productname; 15)</title>
+  <variablelist>
+   <varlistentry>
+    <term>General</term>
+    <listitem>
+     <itemizedlist>
+      <listitem>
+       <para>Clarify that no STONITH SBD resource primitive is needed
+        (<link xlink:href="http://bugzilla.suse.com/show_bug.cgi?id=1102199"/>).
+       </para>
+      </listitem>
+     </itemizedlist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect1>
 
 </appendix>

--- a/xml/ha_docupdates.xml
+++ b/xml/ha_docupdates.xml
@@ -4,94 +4,26 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<!-- Converted by suse-upgrade version 1.1 -->
 
-<!-- DO NOT LIST ANY CHANGES HERE for SLE HA 15! -->
 
-<appendix xml:id="app.ha.docupdates" version="5.0"
+<appendix xml:id="app.ha.docupdates" version="5.1"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
-<title>Documentation Updates</title>
+ <title>Documentation Updates</title>
  <info>
-      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-        <dm:maintainer/>
-        <dm:status>editing</dm:status>
-        <dm:deadline/>
-        <dm:priority/>
-        <dm:translation>yes</dm:translation>
-        <dm:languages/>
-        <dm:release/>
-        <dm:repository/>
-      </dm:docmanager>
-    </info>
-    <para>
-  This chapter lists content changes for this document.
- </para>
- <para>
-  It was updated on the following dates:
- </para>
-<!--list of xrefs, latest date sorted upmost-->
- <itemizedlist>
-  <listitem>
-   <para>
-    <xref linkend="sec.ha.docupdates.sle12_sp3" xrefstyle="SectTitleOnPage"/>
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    <xref linkend="sec.ha.docupdates.sle12_sp2_maint_3" xrefstyle="SectTitleOnPage"/>
-   </para>
-  </listitem>
- </itemizedlist>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:maintainer/>
+   <dm:status>editing</dm:status>
+   <dm:deadline/>
+   <dm:priority/>
+   <dm:translation>yes</dm:translation>
+   <dm:languages/>
+   <dm:release/>
+   <dm:repository/>
+  </dm:docmanager>
+ </info>
+ <para> This chapter lists content changes for this document. </para>
+ <para> This manual was updated on the following dates: </para>
 
- <sect1 xml:id="sec.ha.docupdates.sle12_sp3">
-  <title>September 2017 (Initial Release of &productname; 12 SP3)</title>
-  <variablelist>
-   <varlistentry>
-    <term>General Changes to this Guide</term>
-    <listitem>
-     <para>
-     </para>
-    </listitem>
-   </varlistentry>
-   <!-- LIST OF CHAPTERS THAT HAVE BEEN CHANGED-->
-   <varlistentry>
-   <term><!--XREF TO CHAPTER ID--></term>
-    <listitem>
-     <para>
-       In <!--XREF TO SECTION-->, changed/added/removed FOO BAR (Fate#12345 |
-       doc comment #12345 | <link
-       xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=12345)"/>).  
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Bugfixes</term>
-    <listitem>
-     <itemizedlist>
-      <listitem>
-       <para>
-        In <!--XREF TO SECTION-->, changed/added/removed FOO BAR
-        (Fate#12345 | doc comment #12345 | <link
-         xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=12345)"/>).
-       </para>
-      </listitem>
-     </itemizedlist>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </sect1>
-
- <sect1 xml:id="sec.ha.docupdates.sle12_sp2_maint_3">
-  <title>April 2017 (Maintenance Update of &productname; 12 SP2)</title>
-  <variablelist>
-   <varlistentry>
-    <term></term>
-    <listitem>
-     <para></para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </sect1>
 </appendix>


### PR DESCRIPTION
The changes in this PR are:

* re-add the docupdate appendix for SLE HA 15
* add a new section there for the upcoming maintenance update
* add the docupdate entry to this section
