### PR TITLE
Add missing meta interleave=true

### DIFF
--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -491,7 +491,8 @@ include /etc/drbd.d/*.res;</screen>
 <screen>&prompt.crm.conf;<command>primitive</command> nfsserver \
   systemd:nfs-server \
   op monitor interval="30s"
-&prompt.crm.conf;<command>clone</command> cl-nfsserver nfsserver
+&prompt.crm.conf;<command>clone</command> cl-nfsserver nfsserver \
+   meta interleave=true
 &prompt.crm.conf;<command>commit</command></screen>
    <para>
     After you have committed this configuration, Pacemaker should start the


### PR DESCRIPTION
This PR contains fixes to bsc#1098429:

* Add meta interleave=true to `clone` command