### PR TITLE
systemctl <start/stop> pacemaker --> crm cluster <start/stop/restart>

### DIFF
--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -329,8 +329,7 @@
       class="service">pacemaker</systemitem>
      service for the changes to take effect:
     </para>
-    <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen></listitem>
+    <screen>&prompt.root;<command>crm</command> cluster restart</screen></listitem>
    <listitem>
     <para>
      The necessary resources for booth and for all services that should be
@@ -352,7 +351,7 @@
     <para>
      Start the cluster with:
     </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
    </step>
    <step>
     <para>
@@ -436,7 +435,7 @@
     <para>
      Start the cluster with:
     </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
    </step>
    <step>
     <para>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -608,8 +608,7 @@
    <para>
     Stop and start the <systemitem
     class='service'>pacemaker</systemitem> service for the changes to take effect:
-   </para> <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen>
+   </para> <screen>&prompt.root;<command>systemctl</command> stop pacemaker</screen>
   </listitem>
  <listitem>
    <para>


### PR DESCRIPTION
In the SLE-15-SP1 we recommend users to use the crm shell to start/stop/restart
the cluster, instead of the systemctl.