### PR TITLE
systemctl <start/stop> pacemaker --> crm cluster <start/stop/restart>

### DIFF
--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -421,7 +421,7 @@ ssh: connect to host &node3; port 3121: Connection refused</screen>
     <step>
      <para>Log in to each cluster node and make sure &pace; service is already
       started:</para>
-     <screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+     <screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
     <step>
      <para>On node <systemitem class="domainname">&node1;</systemitem>,
@@ -655,7 +655,7 @@ ssh: connect to host &node4; port 3121: Connection refused</screen>
     <step>
      <para>Log in to each cluster node and make sure &pace; service is already
       started:</para>
-     <screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+     <screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
      <step xml:id="st.ha.pmremote.integrate.guestsintocluster.virsh-dump">
      <para>Dump the XML configuration of the KVM guest(s) that you need

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -329,8 +329,7 @@
       class="service">pacemaker</systemitem>
      service for the changes to take effect:
     </para>
-    <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen></listitem>
+    <screen>&prompt.root;<command>crm</command> cluster restart</screen></listitem>
    <listitem>
     <para>
      The necessary resources for booth and for all services that should be
@@ -352,7 +351,7 @@
     <para>
      Start the cluster with:
     </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
    </step>
    <step>
     <para>
@@ -436,7 +435,7 @@
     <para>
      Start the cluster with:
     </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
    </step>
    <step>
     <para>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -608,8 +608,7 @@
    <para>
     Stop and start the <systemitem
     class='service'>pacemaker</systemitem> service for the changes to take effect:
-   </para> <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen>
+   </para> <screen>&prompt.root;<command>crm</command> cluster restart</screen>
   </listitem>
  <listitem>
    <para>


### PR DESCRIPTION
In SLE-15-SP1 we recommend users to use the crm shell to start/stop/restart
the cluster, instead of the systemctl.