### PR TITLE
systemctl start/stop/status pacemaker --> crm cluster start/stop/restart/status

### DIFF
--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -421,7 +421,7 @@ ssh: connect to host &node3; port 3121: Connection refused</screen>
     <step>
      <para>Log in to each cluster node and make sure &pace; service is already
       started:</para>
-     <screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+     <screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
     <step>
      <para>On node <systemitem class="domainname">&node1;</systemitem>,
@@ -655,7 +655,7 @@ ssh: connect to host &node4; port 3121: Connection refused</screen>
     <step>
      <para>Log in to each cluster node and make sure &pace; service is already
       started:</para>
-     <screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+     <screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
      <step xml:id="st.ha.pmremote.integrate.guestsintocluster.virsh-dump">
      <para>Dump the XML configuration of the KVM guest(s) that you need

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -329,8 +329,7 @@
       class="service">pacemaker</systemitem>
      service for the changes to take effect:
     </para>
-    <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen></listitem>
+    <screen>&prompt.root;<command>crm</command> cluster restart</screen></listitem>
    <listitem>
     <para>
      The necessary resources for booth and for all services that should be
@@ -352,7 +351,7 @@
     <para>
      Start the cluster with:
     </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
    </step>
    <step>
     <para>
@@ -436,7 +435,7 @@
     <para>
      Start the cluster with:
     </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
    </step>
    <step>
     <para>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -96,7 +96,7 @@ Node <replaceable>&node2;</replaceable>: standby
     <para>
      Stop the &pace; service on that node:
     </para>
-<screen>&prompt.root;systemctl stop pacemaker.service</screen>
+<screen>&prompt.root;crm cluster stop</screen>
    </step>
    <step>
     <para>
@@ -119,13 +119,13 @@ Node <replaceable>&node2;</replaceable>: standby
     <para>
      Check if the &pace; service has started:
     </para>
-<screen>&prompt.root;systemctl status pacemaker.service</screen>
+<screen>&prompt.root;crm cluster status</screen>
    </step>
    <step>
     <para>
      If not, start it:
     </para>
-<screen>&prompt.root;systemctl start pacemaker.service</screen>
+<screen>&prompt.root;crm cluster start</screen>
    </step>
    <step>
     <para>
@@ -566,7 +566,7 @@ Node <replaceable>&node2;</replaceable>: standby
     <para>
      Stop the &pace; service on that node:
     </para>
-<screen>&prompt.root;systemctl stop pacemaker.service</screen>
+<screen>&prompt.root;crm cluster stop</screen>
    </step>
    <step>
     <para>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -590,7 +590,7 @@
      <para>
       Log in to each node and start the cluster stack with:
      </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
     <step>
      <para>
@@ -649,7 +649,7 @@
      <para>
       Log in to each cluster node and stop the cluster stack with:
      </para>
-<screen>&prompt.root;<command>systemctl</command> stop pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster stop</screen>
     </step>
     <step>
      <para>
@@ -675,7 +675,7 @@
      <para>
       Start the cluster stack with:
      </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
     <step>
      <para>
@@ -733,7 +733,7 @@
       Log in as &rootuser; on the node that you want to upgrade and stop the
       cluster stack:
      </para>
-<screen>&prompt.root;<command>systemctl</command> stop pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster stop</screen>
     </step>
     <step xml:id="step.ha.migration.upgrade.tolatest">
      <para>
@@ -748,7 +748,7 @@
       Restart the cluster stack on the upgraded node to make the node rejoin
       the cluster:
      </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster restart</screen>
     </step>
     <step>
      <para>
@@ -807,7 +807,7 @@
        If <literal>yes</literal>: Stop the cluster stack on
        the node before starting the software update:
       </para>
-<screen>&prompt.root;<command>systemctl</command> stop pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster stop</screen>
      </listitem>
      <listitem>
       <para>
@@ -815,7 +815,7 @@
        Stop the cluster stack on the node before starting the software
        update:
       </para>
-<screen>&prompt.root;<command>systemctl</command> stop pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster stop</screen>
      </listitem>
      <listitem>
       <para>
@@ -846,7 +846,7 @@
        Either start the cluster stack on the respective node (if you
        stopped it in <xref linkend="step.update.check"/>):
       </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
      </listitem>
      <listitem>
       <para>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -681,8 +681,7 @@ Timeout (msgwait)  : 10
    </step>
    <step>
     <para>Restart the cluster stack on each node:</para>
-    <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen>
+    <screen>&prompt.root;<command>crm</command> cluster restart</screen>
     <para> This automatically triggers the start of the SBD daemon. </para>
    </step>
   </procedure>
@@ -880,8 +879,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     </step>
     <step>
      <para>Restart the cluster stack on each node:</para>
-     <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen>
+     <screen>&prompt.root;<command>crm</command> cluster restart</screen>
      <para> This automatically triggers the start of the SBD daemon. </para>
     </step>
     <step>

--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -106,12 +106,12 @@
       Usually, starting &pace; also starts the &corosync; service. To
       check if both services are running:
      </para>
-<screen>&prompt.root;<command>systemctl</command> status pacemaker corosync</screen>
+<screen>&prompt.root;<command>crm</command> cluster status</screen>
      <para>
       In case they are not running, start them by executing the following
       command:
      </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/xml/ha_yast_cluster.xml
+++ b/xml/ha_yast_cluster.xml
@@ -986,7 +986,7 @@ Finished with 1 errors.</screen>
       you must start &pace; manually each time this node is booted. To
       start &pace; manually, use the command:
      </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
     <step>
      <para>
@@ -1038,11 +1038,11 @@ Finished with 1 errors.</screen>
      <para>
       Check if the service is already running:
      </para>
-<screen>&prompt.root;<command>systemctl</command> status pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster status</screen>
      <para>
       If not, start &pace; now:
      </para>
-<screen>&prompt.root;<command>systemctl</command> start pacemaker</screen>
+<screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
     <step>
      <para>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -608,8 +608,7 @@
    <para>
     Stop and start the <systemitem
     class='service'>pacemaker</systemitem> service for the changes to take effect:
-   </para> <screen>&prompt.root;<command>systemctl</command> stop pacemaker
-&prompt.root;<command>systemctl</command> start pacemaker</screen>
+   </para> <screen>&prompt.root;<command>crm</command> cluster restart</screen>
   </listitem>
  <listitem>
    <para>


### PR DESCRIPTION
In SLE-15-SP1 we recommend users to use the crm shell to start/stop/restart the cluster or query its status, instead of using systemctl.