### PR TITLE
Change pmremote MAIN to MAIN.SLEHA.xml

### DIFF
--- a/DC-SLE-HA-pmremote-quick
+++ b/DC-SLE-HA-pmremote-quick
@@ -4,7 +4,7 @@
 ## -----------------------------------
 ##
 ## Basics
-MAIN="art_sle_ha_pmremote.xml"
+MAIN="MAIN.SLEHA.xml"
 ROOTID="art_sle_ha_pmremote"
 
 ## Profiling


### PR DESCRIPTION
 ### Problem: 
 * `DC-SLE-HA-all` has the MAIN value set to `MAIN.SLEHA.xml` where we find  `book_sle_ha_techguides.xml` which includes `art_sle_ha_pmremote.xml`, which means that we build it with the whole set.

 * `DC-SLE-HA-pmremote-quick` has the MAIN value set to `art_sle_ha_pmremote.xml`, which normally means that we want to build it separately. That's not the case.

### Solution : Change `DC-SLE-HA-pmremote-quick`'s MAIN value to `MAIN.SLEHA.xml`


#### This needs to be done for:
 * 12 SP4
 * 12 SP3
 * 12 SP2


