### PR TITLE
README: switch 'develop' -> 'master'

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,10 +50,9 @@ master branch. ***
 [options="header"]
 |================================================
 | Name            | Purpose
-| `master`         | doc development (latest development version)
-| `maintenance/*`  | maintenance for released versions
-| `trans/*`        | translations for released versions
-| 
+| `master`        | doc development (latest development version)
+| `maintenance/*` | maintenance for released versions
+| `trans/*`       | translations for released versions
 |================================================
 
 == Reporting Bugs


### PR DESCRIPTION
### Description

We have changed to a new branching model in this repository. We have switched the default branch from `develop` to `master` and have deleted `develop` on the server. 

@aginies @aleksei-burlakov @ChrisKowalczyk @cjschroder @froh @fsundermeyer @GuoqingJiang @keichwa @krig @liangxin1300 @ls-zhu @mschnitzer @renzhengeek
@sknorr @svenseeberg @tomschr @Werkov @zzhou1

This is just for your information. If you want to continue contributing to this repository, please see the latest version of the README for instructions on how to update your local repository after the switch.