### PR TITLE
Fix bsc#1150990 Rename Fujitsu watchdog driver

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -404,8 +404,9 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
    lists the most commonly used watchdog drivers. If your hardware is not listed there,
    the directory
    <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/watchdog</filename>
-   gives you a list of choices, too. Alternatively, ask your hardware vendor for
-   the name.</para>
+   gives you a list of choices, too. Alternatively, ask your hardware or
+   system vendor for details on system specific watchdog configuration.
+   </para>
 
      <table xml:id="tab-ha-storage-protect-watchdog-drivers">
         <title>Commonly Used Watchdog Drivers</title>
@@ -422,8 +423,12 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
            <entry><systemitem class="resource">hpwdt</systemitem></entry>
           </row>
           <row>
-           <entry>Dell, Fujitsu, Lenovo (Intel TCO)</entry>
+           <entry>Dell, Lenovo (Intel TCO)</entry>
            <entry><systemitem class="resource">iTCO_wdt</systemitem></entry>
+          </row>
+          <row>
+           <entry>Fujitsu</entry>
+           <entry><systemitem class="resource">ipmi_watchdog</systemitem></entry>
           </row>
           <row>
            <entry>VM on z/VM on IBM mainframe</entry>


### PR DESCRIPTION
## Description

* Rename driver for Fujitsu systems: `iTCO_wdt` -> `ipmi_watchdog`; add separate row
* Rephrase short sentence about whom to ask (hardware and system vendors)


### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLEHA12SP4
- [ ] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1

(Bug was filed against SLEHA15SP1; it's likely this needs backports for other releases too)