### PR TITLE
contradictory RAID description against Cluster MD

### DIFF
--- a/xml/ha_requirements.xml
+++ b/xml/ha_requirements.xml
@@ -190,8 +190,6 @@
     <para>
      The disks contained in the shared disk system should be configured to
      use mirroring or RAID to add fault tolerance to the shared disk system.
-     Hardware-based RAID is recommended. Host-based software RAID is not
-     supported for all configurations.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
We should just delete the following line in SLE12SP4+ and SLE15 code
stream. It is outdated back in SLE11 and contradictory nowadays against
Cluster MD feature in the product.

"Hardware-based RAID is recommended. Host-based software RAID is not
supported for all configurations."

### Description

bsc#1152414 for discussion as well,  if any.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLEHA12SP4
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
