### PR TITLE
Clean up <info/> elements

### DIFF
--- a/xml/MAIN.SLEHA.xml
+++ b/xml/MAIN.SLEHA.xml
@@ -23,7 +23,7 @@
        <dm:docmanager>
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:product>SUSE Linux Enterprise High Availability 15 SP2</dm:product>
+          <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
           <dm:component>Documentation</dm:component>
         </dm:bugtracker>
          <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>

--- a/xml/MAIN.SLEHA.xml
+++ b/xml/MAIN.SLEHA.xml
@@ -13,7 +13,7 @@
   xmlns:dm="urn:x-suse:ns:docmanager"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-<!-- SLE HA Guide -->
+<!-- HA Guide, Geo Guide -->
 <!--Quick Starts-->
  <title>&productname; Documentation</title>
  <info>

--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -25,11 +25,6 @@
    </para>
   </abstract>
   <dm:docmanager>
-   <dm:bugtracker>
-    <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-    <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP1</dm:product>
-    <dm:component>Documentation</dm:component>
-   </dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -14,8 +14,7 @@
   xmlns:dm="urn:x-suse:ns:docmanager"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <!--https://fate.suse.com/320823: [DOC] HA quick start document-->
-  <title>&instquick;</title>
+ <title>&instquick;</title>
  <subtitle>&productname; &productnumber;</subtitle>
  <info>
   <productnumber>&productnumber;</productnumber>
@@ -27,10 +26,6 @@
     &abstract-instquick;
    </para>
   </abstract>
-  <!-- fs 2016-11-04:
-       Does not get correctly convertes to NovDoc when generating online-docs
-       Commenting until thios is solved
-<xi:include href="ha_authors.xml"/> -->
   <dm:docmanager>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -32,11 +32,6 @@
        Commenting until thios is solved
 <xi:include href="ha_authors.xml"/> -->
   <dm:docmanager>
-   <dm:bugtracker>
-    <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-    <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP1</dm:product>
-    <dm:component>Documentation</dm:component>
-   </dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>

--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -34,13 +34,7 @@
        Does not get correctly convertes to NovDoc when generating online-docs
        Commenting until thios is solved
 <xi:include href="ha_authors.xml"/> -->
-   <dm:docmanager>
-    <dm:bugtracker>
-      <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP1</dm:product>
-      <dm:component>Documentation</dm:component>
-    </dm:bugtracker>
-  </dm:docmanager>
- </info>
+  </info>
  <sect1 xml:id="sec-ha-quick-nfs-usagescenario">
   <title>Usage Scenario</title>
   <para>

--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -30,10 +30,6 @@
     &abstract-nfsquick;
    </para>
   </abstract>
-  <!-- fs 2016-11-04:
-       Does not get correctly convertes to NovDoc when generating online-docs
-       Commenting until thios is solved
-<xi:include href="ha_authors.xml"/> -->
   </info>
  <sect1 xml:id="sec-ha-quick-nfs-usagescenario">
   <title>Usage Scenario</title>

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -28,15 +28,7 @@
    <abstract>
     <para>&abstract-pcmkremquick;</para>
    </abstract>
-   <dm:docmanager>
-    <dm:bugtracker>
-     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-     <dm:product>SUSE Linux Enterprise High Availability 15 SP1</dm:product>
-     <dm:component>Documentation</dm:component>
-    </dm:bugtracker>
-    <dm:translation>yes</dm:translation>
-   </dm:docmanager>
-   </info>
+  </info>
 
  <sect1 xml:id="sec-ha-pmremote-concept">
    <title>Conceptual Overview and Terminology</title>

--- a/xml/book_sle_ha_geo.xml
+++ b/xml/book_sle_ha_geo.xml
@@ -25,15 +25,7 @@
     </para>
     </abstract>
    <xi:include href="ha_authors.xml"/>
-      <dm:docmanager>
-        <dm:bugtracker>
-          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:product>SUSE Linux Enterprise High Availability 15 SP1</dm:product>
-          <dm:component>Documentation</dm:component>
-        </dm:bugtracker>
-        <dm:translation>yes</dm:translation>
-      </dm:docmanager>
-    </info>
+  </info>
 
  <xi:include href="geo_challenges_i.xml"/>
  <xi:include href="geo_concept_i.xml"/>

--- a/xml/geo_challenges_i.xml
+++ b/xml/geo_challenges_i.xml
@@ -16,16 +16,6 @@
     communication between the sites. That leads to the following challenges:
    </para>
   </abstract>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
  </info>
  <itemizedlist>
   <listitem>

--- a/xml/geo_concept_i.xml
+++ b/xml/geo_concept_i.xml
@@ -18,17 +18,7 @@
     the booth cluster ticket manager (in the following called booth).
    </para>
   </abstract>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
+  </info>
  <para>
   Each of the parties involved in a &geo; cluster runs a service, the &boothd;.
   It connects to the booth daemons running at the other sites and exchanges

--- a/xml/geo_docupdates.xml
+++ b/xml/geo_docupdates.xml
@@ -11,18 +11,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
 <!--list of xrefs, latest date sorted upmost-->
  <title>Documentation Updates</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
+
  <para>
   This chapter lists content changes for this document.
  </para>

--- a/xml/geo_drbd_i.xml
+++ b/xml/geo_drbd_i.xml
@@ -8,19 +8,6 @@
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-ha-geo-drbd">
  <title>Setting Up DRBD</title>
 
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
-
  <para>
   For a description of the overall scenario, see
   <xref linkend="sec-ha-geo-oview"/>. Assuming that you have two cluster sites

--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -9,18 +9,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ha-geo-ip-relocation">
 <!--taroth 2014-1120: https://fate.suse.com/316112-->
  <title>Setting Up IP Relocation via DNS Update</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
+
  <para>
   In case one site of your &geo; cluster is down and a ticket failover appears,
   you usually need to adjust the network routing accordingly (or you need to

--- a/xml/geo_manage_i.xml
+++ b/xml/geo_manage_i.xml
@@ -9,18 +9,7 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ha-geo-manage">
  <title>Managing &geo; Clusters</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
+
  <para>
   Before booth can manage a certain ticket within the &geo; cluster, you
   initially need to grant it to a site manually&mdash;either with the booth

--- a/xml/geo_requirements_i.xml
+++ b/xml/geo_requirements_i.xml
@@ -9,18 +9,6 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ha-geo-req">
  <title>Requirements</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
 
  <itemizedlist>
   <title>Software Requirements</title>

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -9,18 +9,6 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ha-geo-rsc">
  <title>Configuring Cluster Resources and Constraints</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
  <para>
   Apart from the resources and constraints that you need to define for your
   specific cluster setup, &geo; clusters require additional resources and

--- a/xml/geo_sync_i.xml
+++ b/xml/geo_sync_i.xml
@@ -10,18 +10,6 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ha-geo-sync">
  <title>Synchronizing Configuration Files Across All Sites and Arbitrators</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
  <para>
   To replicate important configuration files across all nodes in the cluster
   and across &geo; clusters, use &csync;.

--- a/xml/geo_trouble_i.xml
+++ b/xml/geo_trouble_i.xml
@@ -10,18 +10,6 @@
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ha-geo-trouble">
 <!--taroth 2013-04-24: fix for bnc#753625-->
  <title>Troubleshooting</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
  <para>
   Booth
 <!--logs to <filename>/var/log/messages</filename> and -->

--- a/xml/geo_upgrade_i.xml
+++ b/xml/geo_upgrade_i.xml
@@ -10,18 +10,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
  xml:id="cha-ha-geo-upgrade">
  <title>Upgrading to the Latest Product Version</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:maintainer/>
-   <dm:status>editing</dm:status>
-   <dm:deadline/>
-   <dm:priority/>
-   <dm:translation>yes</dm:translation>
-   <dm:languages/>
-   <dm:release/>
-   <dm:repository/>
-  </dm:docmanager>
- </info>
+
  <para>
    For instructions on how to upgrade the cluster nodes, refer to <xref
   linkend="cha-ha-migration"/>. The chapter also describes which preparations


### PR DESCRIPTION
### Description

Remove  ```<dm:docmanager>``` and ```<inof/>``` elements where not needed: Bugtracking info is inherited from the MAIN file. As all deliverables have moved into the same set meanwhile, removed bugtracking info from individual deliverables - this avoids having to adjust the bugtracking info multiple times. Also corrected bugtracking info in MAIN (word 'Extension' was missing in Bugzilla string).  In addition, some files (especially *Geo Guide*) contained (wrong) info about translation for historical reasons, removed this info to avoid confusion.  

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLEHA12SP4
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
