### PR TITLE
Update Doc URLs

### DIFF
--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -225,9 +225,7 @@
    <filename>/var/log/ha-cluster-bootstrap.log</filename>. Check the log file
    for any details of the bootstrap process. Any options set during the
    bootstrap process can be modified later (by modifying booth settings,
-   modifying resources etc.). For details, see the
-   <literal>&geoguide;</literal>. It is available at
-   <link xlink:href="https://www.suse.com/documentation"/>.
+   modifying resources etc.). For details, see the <xref linkend="book-sleha-geo"/>.
   </para>
 
 <!--taroth 2017-07-03: the following is not really true by now, the man pages
@@ -266,11 +264,7 @@
    (or a local registration server) and have added the respective modules or
    installation media as an extension. For information on how to
    install extensions, see the <citetitle>&sle; &productnumber;
-   &deploy;</citetitle>, available at
-   <link xlink:href="&suse-onlinedoc;&doc-sles;"/>. Refer to chapter
-   <citetitle>Installing Modules, Extensions, and Third Party Add-On
-   Products</citetitle>.
-<!--taroth: need to use hard-coded link here as the target is not included in the same set-->
+   &deploy;</citetitle>: <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-add-ons.html"/>.
   </para>
   <para>
      To install the packages from both patterns via command line, use Zypper:
@@ -768,12 +762,10 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="&suse-onlinedoc;&doc-geo;"/>.
-     <!--<remark>taroth 2017-11-28: requested generic URL; see
-      https://bugzilla.suse.com/show_bug.cgi?id=1070134</remark>-->
-     The documentation also includes a comprehensive
-     <literal>&geoguide;</literal>. Refer to it for further configuration and
-     administration tasks.
+     xlink:href="&dsc-ha-15;"/>.
+     For further configuration and administration tasks, see the comprehensive
+     <citetitle>&geoguide;</citetitle>:
+     <link xlink:href="&dsc-ha-15;/html/SLE-HA-all/book-sleha-geo.html"></link>
     </para>
    </listitem>
    <listitem>
@@ -782,7 +774,7 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
      DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
      series:
      <link
-      xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>.
+      xlink:href="&dsc-sbp;/all/html/SBP-DRBD/index.html"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -270,10 +270,8 @@
     </para>
     <para>
       For information on how to install
-      extensions, see the <citetitle>&deploy;</citetitle> for &sle; &productnumber;,
-      chapter <citetitle>Installing Modules, Extensions, and Third Party Add-On Products</citetitle>.
-      It is available from <link
-      xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+      extensions, see the <citetitle>&deploy;</citetitle> for &sle; &productnumber;:
+     <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-add-ons.html"/>.
     </para>
 
     <procedure xml:id="pro-ha-inst-quick-pattern">
@@ -302,10 +300,8 @@
       </step>
       <step>
        <para>
-         Register the machines at &scc;. Find more information in the <citetitle>&deploy;</citetitle> for
-         &sls; &productnumber;, chapter <citetitle>Installing or Removing Software</citetitle>,
-         section <citetitle>Registering an Installed System</citetitle>. It is available from <link
-         xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+         Register the machines at &scc;. Find more information at <link
+         xlink:href="&dsc-sles-15;/html/SLES-all/cha-upgrade-offline.html#sec-update-registersystem"/>.
        </para>
       </step>
     </procedure>
@@ -353,8 +349,7 @@
 
   <para>
    For details of how to set up shared storage, refer to the <citetitle>&storage;</citetitle>
-   for &sls; &productnumber;. It is available from
-   <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+   for &sls; &productnumber;: <link xlink:href="&dsc-sles-15;/html/SLES-all/book-storage.html"/>.
   </para>
   <!--<remark>toms, 2016-07-30: (kai) miss a link to set up FC storage</remark>
   <remark>toms 2016-08-01: we don't have yet doc for FC storage.</remark>
@@ -797,14 +792,15 @@ softdog                16384  1</screen>
 
   <sect1 xml:id="sec-ha-inst-quick-moreinfo">
    <title>For More Information</title>
-   <para>
-    Find more documentation for this product at <link
-     xlink:href="&suse-onlinedoc;&doc-ha;"/>. The
-    documentation also includes a comprehensive <citetitle>&admin;</citetitle> for
-    &productname;. Refer to it for further configuration and administration
-    tasks.
-   </para>
-  </sect1>
+    <para>
+     More documentation for this product is available at
+     <link
+     xlink:href="&dsc-ha-15;"/>.
+     For further configuration and administration tasks, see the comprehensive
+     <citetitle>&admin;</citetitle>:
+     <link xlink:href="&dsc-ha-15;/html/SLE-HA-all/SLE-HA-all/book-sleha-guide.html"></link>
+    </para>
+   </sect1>
  <xi:include href="common_copyright_quick.xml"/>
  <xi:include href="common_legal.xml"/>
 </article>

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -520,10 +520,7 @@ Full list of resources:
     </step>
     <step>
      <para>Create a KVM guest on <systemitem class="domainname"
-      >&node1;</systemitem>. For details refer to the
-      <citetitle>&virtual;</citetitle> for &sls; &productnumber;,
-      chapter <citetitle>Guest Installation</citetitle>. It is
-      available from <link xlink:href="&suse-onlinedoc;"/>.
+      >&node1;</systemitem>. For details see <link xlink:href="&dsc-sles-15/html/SLES-all/cha-kvm-inst.html"/>.
      </para>
     </step>
     <step>
@@ -772,13 +769,14 @@ Failed Actions:
 <sect1 xml:id="sec-ha-pmremote-more">
 <title>For More Information</title>
  <para>
-  Find more documentation for this product at <link
-  xlink:href="&suse-onlinedoc;&doc-ha;"/>. The
-  documentation also includes a comprehensive <citetitle>&admin;</citetitle> for
-  &productname;. Refer to it for further configuration and administration
-  tasks.
-  </para>
-  <para>Upstream documentation is available from <link
+  More documentation for this product is available at
+  <link xlink:href="&dsc-ha-15;"/>.
+  For further configuration and administration tasks, see the comprehensive
+  <citetitle>&admin;</citetitle>:
+  <link xlink:href="&dsc-ha-15;/html/SLE-HA-all/SLE-HA-all/book-sleha-guide.html"></link>
+ </para>
+ <para>
+  Upstream documentation is available from <link
     xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>. See the document
    <citetitle>Pacemaker Remote&mdash;Scaling High Availability Clusters</citetitle>.
   </para>

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -520,7 +520,7 @@ Full list of resources:
     </step>
     <step>
      <para>Create a KVM guest on <systemitem class="domainname"
-      >&node1;</systemitem>. For details see <link xlink:href="&dsc-sles-15/html/SLES-all/cha-kvm-inst.html"/>.
+      >&node1;</systemitem>. For details see <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-kvm-inst.html"/>.
      </para>
     </step>
     <step>

--- a/xml/book_sle_ha_geo.xml
+++ b/xml/book_sle_ha_geo.xml
@@ -30,13 +30,7 @@
  <xi:include href="geo_challenges_i.xml"/>
  <xi:include href="geo_concept_i.xml"/>
  <xi:include href="geo_requirements_i.xml"/>
- <!--taroth 2017-07-27: removing, DRBD setup for Geo now covered in:
-     &suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html
- <xi:include href="geo_overview_i.xml"/>-->
  <xi:include href="geo_booth_i.xml"/>
-<!--taroth 2017-07-27: removing, DRBD setup for Geo now covered in:
-    &suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html
- <xi:include href="geo_drbd_i.xml"/>-->
  <xi:include href="geo_sync_i.xml"/>
  <xi:include href="geo_resources_i.xml"/>
  <xi:include href="geo_ip_i.xml"/>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -30,7 +30,7 @@
   <title>Online Documentation and Latest Updates</title>
   <para>
    Documentation for our products is available at
-   <link xlink:href="&suse-onlinedoc;"/>, where you can also
+   <link xlink:href="&dsc;"/>, where you can also
    find the latest updates, and browse or download the documentation in various formats.
    The latest documentation updates can usually be found in the English language version.
   </para>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -176,6 +176,7 @@ called pacemaker_remote, but the daemon pacemaker-remoted. :-(
 <!ENTITY dsc-sled-11    "&dsc;/sled-11">
 <!ENTITY dsc-sled-12    "&dsc;/sled-12">
 <!ENTITY dsc-sled-15    "&dsc;/sled-15">
+<!ENTITY dsc-ha         "&dsc;/sle-ha">
 <!ENTITY dsc-ha-11      "&dsc;/sle-ha-11">
 <!ENTITY dsc-ha-12      "&dsc;/sle-ha-12">
 <!ENTITY dsc-ha-15      "&dsc;/sle-ha-15">

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -169,6 +169,33 @@ called pacemaker_remote, but the daemon pacemaker-remoted. :-(
 <!ENTITY dc             "doc comment #">
 
 <!-- ============================================================= -->
+<!--              documentation.suse.com links                     -->
+<!-- ============================================================= -->
+
+<!ENTITY dsc            "https://documentation.suse.com">
+<!ENTITY dsc-sles       "&dsc;/sles">
+<!ENTITY dsc-sles-11    "&dsc;/sles-11">
+<!ENTITY dsc-sles-12    "&dsc;/sles-12">
+<!ENTITY dsc-sles-15    "&dsc;/sles-15">
+<!ENTITY dsc-sled       "&dsc;/sled">
+<!ENTITY dsc-sled-11    "&dsc;/sled-11">
+<!ENTITY dsc-sled-12    "&dsc;/sled-12">
+<!ENTITY dsc-sled-15    "&dsc;/sled-15">
+<!ENTITY dsc-ha-11      "&dsc;/sle-ha-11">
+<!ENTITY dsc-ha-12      "&dsc;/sle-ha-12">
+<!ENTITY dsc-ha-15      "&dsc;/sle-ha-15">
+<!ENTITY dsc-sap        "&dsc;/sles-sap">
+<!ENTITY dsc-sap-11     "&dsc;/sles-sap-11">
+<!ENTITY dsc-sap-12     "&dsc;/sles-sap-12">
+<!ENTITY dsc-sap-15     "&dsc;/sles-sap-15">
+<!ENTITY dsc-rt         "&dsc;/sle-rt">
+<!ENTITY dsc-sbp        "&dsc;/sbp">
+<!ENTITY dsc-ses        "&dsc;/ses">
+<!ENTITY dsc-suma       "&dsc;/suma">
+<!ENTITY dsc-suma-retail "&dsc;/suma-retail">
+<!ENTITY dsc-vmdp       "&dsc;/sle-vmdp">
+
+<!-- ============================================================= -->
 <!--                    Platforms                                  -->
 <!-- ============================================================= -->
 

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -159,11 +159,6 @@ called pacemaker_remote, but the daemon pacemaker-remoted. :-(
 <!ENTITY wypublic       "/srv/www/yast/public/">
 <!ENTITY corosync.conf  "<filename xmlns='http://docbook.org/ns/docbook'>/etc/corosync/corosync.conf</filename>">
 <!ENTITY booth.conf     "<filename xmlns='http://docbook.org/ns/docbook'>/etc/booth/booth.conf</filename>">
-<!--do not use http_s_ in the URL below for the sake of Chinese customers-->
-<!ENTITY suse-onlinedoc "http://www.suse.com/documentation/">
-<!ENTITY doc-ha         "sle-ha">
-<!ENTITY doc-geo        "sle-ha-geo">
-<!ENTITY doc-sles       "sles">
 <!ENTITY bsc            "https://bugzilla.suse.com/show_bug.cgi?id=">
 <!ENTITY fate           "Fate #">
 <!ENTITY dc             "doc comment #">

--- a/xml/geo_booth_i.xml
+++ b/xml/geo_booth_i.xml
@@ -239,7 +239,7 @@ ticket = "&ticket2;" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle="se
       For example, the ticket <literal>&ticket3;</literal> specified here can
       be used for failover of NFS and DRBD as explained in
       <link
-       xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>.
+       xlink:href="&dsc;/sbp/all/html/SBP-DRBD/index.html"/>.
      </para>
     </callout>
    <callout arearefs="co-ha-geo-booth-mode">

--- a/xml/geo_docupdates.xml
+++ b/xml/geo_docupdates.xml
@@ -38,7 +38,7 @@
       <para>
       The documentation for &geo; clustering with &productnamereg; has been
       split up into two documents. Both are available from <link
-       xlink:href="https://www.suse.com/documentation"/>.
+       xlink:href="&dsc;"/>.
      </para>
      <formalpara>
       <title><citetitle>&geoquick;</citetitle></title>

--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -38,7 +38,7 @@
     More information on how to set up DNS, including dynamic update of zone
     data, can be found in the &sle; <citetitle>&admin;</citetitle>, chapter
     <citetitle>The Domain Name System</citetitle>. It is available from
-    <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+    <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-dns.html"/>.
    </para>
   </listitem>
   <listitem>
@@ -50,10 +50,7 @@
 <screen>&prompt.root;<command>dnssec-keygen</command> -a hmac-md5 -b 128 -n USER geo-update</screen>
    <para>
     For more information, see the <command>dnssec-keygen</command> man page or
-    the  &sle; <citetitle>&admin;</citetitle>, chapter
-    <citetitle>The Domain Name System</citetitle>, section <citetitle>Secure
-     Transactions</citetitle>. It is available from
-    <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+    <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-dns.html#sec-dns-tsig"/>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/geo_more_i.xml
+++ b/xml/geo_more_i.xml
@@ -15,7 +15,7 @@
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="&suse-onlinedoc;&doc-geo;"/>.
+      xlink:href="&dsc-ha-15;"/>.
      For example, the <citetitle>&geoquick;</citetitle> guides you through
      the basic setup of a &geo; cluster, using the &geo; bootstrap scripts
      provided by the <systemitem xmlns='http://docbook.org/ns/docbook'
@@ -29,7 +29,7 @@
      DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
      series:
      <link
-      xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>.
+      xlink:href="&dsc;/sbp/all/html/SBP-DRBD/index.html"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/geo_overview_i.xml
+++ b/xml/geo_overview_i.xml
@@ -84,12 +84,6 @@
    </listitem>
   </itemizedlist>
  </example>
-<!--
- <para>This document assumes that you have installed the required software
-  and set up a basic &geo; cluster as described in the &geoquick;, available
-  from <link xlink:href="&suse-onlinedoc;"/>.
-  Completing the setup for the scenario above takes the following basic steps:
- </para>-->
 
  <variablelist>
   <varlistentry>

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -368,7 +368,7 @@
        all sites of the &geo; cluster (for example, resources for DRBD as
        described in
        <link
-          xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>).
+          xlink:href="&dsc;/sbp/all/html/SBP-DRBD/index.html"/>).
       </para>
      </callout>
      <callout arearefs="co-geo-rsc-booth">

--- a/xml/ha_acl.xml
+++ b/xml/ha_acl.xml
@@ -51,7 +51,7 @@
    If you have upgraded from &productname; 11 SPx and kept your former
    CIB version, refer to the <citetitle>Access Control List</citetitle>
    chapter in the <citetitle>&haguide;</citetitle> for &productname; 11 SP3 or earlier. It is
-   available from <link xlink:href="&suse-onlinedoc;"/>.
+   available from <!--<link xlink:href="&dsc-ha-11;"/>-->.
    </para>
  </note>
  <sect1 xml:id="sec-ha-acl-require">

--- a/xml/ha_acl.xml
+++ b/xml/ha_acl.xml
@@ -47,12 +47,14 @@
    how to check this and upgrade the CIB version, see
    <xref linkend="note-ha-cib-upgrade"/>.
   </para>
-  <para>
+  <!--taroth 2020-03-11: commenting the following because we currently only publish 
+    11 SP4 docs (the others are out of maintenance)-->
+   <!--<para>
    If you have upgraded from &productname; 11 SPx and kept your former
    CIB version, refer to the <citetitle>Access Control List</citetitle>
    chapter in the <citetitle>&haguide;</citetitle> for &productname; 11 SP3 or earlier. It is
-   available from <!--<link xlink:href="&dsc-ha-11;"/>-->.
-   </para>
+   available from FIXME.
+   </para>-->
  </note>
  <sect1 xml:id="sec-ha-acl-require">
   <title>Requirements and Prerequisites</title>

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -829,7 +829,7 @@ vdc                                   253:32   0   20G  0 disk
       <para> (For example, this might be the case if you have created the
        logical volume for a cmirrord setup on &productname; 11 or 12 as
        described in <link
-        xlink:href="https://www.suse.com/documentation/sle-ha-12/singlehtml/book_sleha/book_sleha.html#sec.ha.clvm.config.cmirrord"
+        xlink:href="&dsc-ha-12;/html/SLE-HA-all/cha-ha-clvm.html#sec-ha-clvm-config-cmirrord"
        />.)</para>
      </formalpara>
      <para>

--- a/xml/ha_install.xml
+++ b/xml/ha_install.xml
@@ -61,8 +61,7 @@
 
    <para>
     For detailed instructions on how to use &ay; in various scenarios,
-    see the <citetitle>&sle; &productnumber; &ayguide;</citetitle>, available
-    from <link xlink:href="&suse-onlinedoc;"/>.
+    see <link xlink:href="&dsc-sles-15;/html/SLES-all/book-autoyast.html"/>.
    </para>
 
    <important>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -161,17 +161,12 @@
    <itemizedlist>
     <listitem>
      <para>
-      <link xlink:href="&suse-onlinedoc;&doc-sles;"/>
+      <link xlink:href="&dsc-sles;"/>
      </para>
     </listitem>
     <listitem>
      <para>
-      <link xlink:href="&suse-onlinedoc;&doc-ha;"/>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <link xlink:href="&suse-onlinedoc;&doc-geo;"/>
+      <link xlink:href="&dsc-ha;"/>
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -485,8 +485,7 @@
    <step>
     <para>
      Set up an NFS server with &yast; as described in the &sls;
-     &productnumber; <citetitle>&admin;</citetitle>, chapter <citetitle>Sharing File Systems
-     with NFS</citetitle>. It is available from <link xlink:href="&suse-onlinedoc;"/>.
+     &productnumber; <citetitle>&admin;</citetitle>: <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-nfs.html"/>.
     </para>
    </step>
    <step>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -416,10 +416,8 @@
    <para>
      Cluster nodes must synchronize to an NTP server outside the cluster.
      Since &productname; 15, chrony is the default implementation of NTP.
-     For more information, see the <citetitle>&admin;</citetitle> for
-     &sls; &productnumber;, chapter <citetitle>Time Synchronization with
-     NTP</citetitle>. It is available from
-     <link xlink:href='http://www.suse.com/documentation/'/>.
+     For more information, see
+     <link xlink:href='&dsc-sles-15;/html/SLES-all/cha-ntp.html'/>.
     </para>
     <para>
      If nodes are not synchronized, the cluster may not work properly.
@@ -567,10 +565,8 @@
   <listitem>
    <para>
     All cluster nodes on all sites should synchronize to an NTP server outside
-    the cluster. For more information, see the <citetitle>&admin;</citetitle>
-    for &sls; &productnumber;, available at
-    <link xlink:href='http://www.suse.com/documentation/&doc-sles;'/>. Refer to the
-    chapter <citetitle>Time Synchronization with NTP</citetitle>.
+    the cluster. For more information, see
+    <link xlink:href='&dsc-sles-15;/html/SLES-all/cha-ntp.html'/>.
    </para>
    <para>
     If nodes are not synchronized, log files and cluster reports are very hard


### PR DESCRIPTION
### Description

Updating the links to our doc pages from www.suse.com/documentation to www.documentation.suse.com.

For QA, I checked the HTML build for SLE-HA-all, no www.suse.com/documentation occurrences found. Also ran ```daps checklink```. no broken links to documentation.suse.com reported. 