### PR TITLE
Adjust Terminology for Upgrading the Cluster (bsc#1150382)

### DIFF
--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -750,10 +750,7 @@ Failed Actions:
   <title>Upgrading the Cluster and Pacemaker_remote Nodes</title>
   <!-- toms 2017-04-18: Pacemaker version in different SLEHA:
   GA (1.1.12), SP1(1.1.13), SP2(1.1.15)-->
-  <!--taroth 2017-08-11: according to ygao, a link to
-   https://wiki.clusterlabs.org/wiki/Upgrading_to_Pacemaker_1.1.15_or_later_from_an_earlier_version
-  is not needed, because we did a maintenance update for SP1 to make the
-  rolling upgrade easier-->
+
   <para>
    Find comprehensive information on different scenarios and supported upgrade
    paths at <xref linkend="cha-ha-migration"/>.
@@ -762,12 +759,6 @@ Failed Actions:
    <link xlink:href="https://www.suse.com/releasenotes/"/>.
    </para>
 
-  <!--
-  <para>
-   In the future, rolling upgrades from SP2 to SP3 needs only the last two
-   steps.
-  </para>
-  -->
  </sect1>
 <sect1 xml:id="sec-ha-pmremote-more">
 <title>For More Information</title>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -814,6 +814,12 @@
       SLE&nbsp;HA&nbsp;12&nbsp;SP3
      </para>
     </listitem>
+    <listitem>
+     <para>
+      Upgrading from SLE&nbsp;HA&nbsp;12&nbsp;SP3 to
+      SLE&nbsp;HA&nbsp;12&nbsp;SP4
+     </para>
+    </listitem>
      <listitem>
      <para>
       Upgrading from SLE&nbsp;HA&nbsp;15 to

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -372,7 +372,7 @@
          SLE&nbsp;HA&nbsp;(Geo)&nbsp;12&nbsp;SP3</para>
        </entry>
        <entry>
-        <para>Rolling Upgrade</para>
+        <para>Cluster Rolling Upgrade</para>
        </entry>
        <entry>
         <itemizedlist>
@@ -404,7 +404,7 @@
          SLE&nbsp;HA&nbsp;(Geo)&nbsp;12&nbsp;SP4</para>
        </entry>
        <entry>
-        <para>Rolling Upgrade</para>
+        <para>Cluster Rolling Upgrade</para>
        </entry>
        <entry>
         <itemizedlist>
@@ -436,7 +436,7 @@
          SLE&nbsp;HA&nbsp;(Geo)&nbsp;15</para>
        </entry>
        <entry>
-        <para>Offline Migration</para>
+        <para>Cluster Offline Upgrade</para>
        </entry>
        <entry>
         <itemizedlist>
@@ -469,7 +469,7 @@
          SLE&nbsp;HA&nbsp;(Geo)&nbsp;15&nbsp;SP1</para>
        </entry>
        <entry>
-        <para>Offline Migration</para>
+        <para>Cluster Offline Upgrade</para>
        </entry>
        <entry>
         <itemizedlist>
@@ -502,7 +502,7 @@
          SLE&nbsp;HA&nbsp;(Geo)&nbsp;15&nbsp;SP1</para>
        </entry>
        <entry>
-        <para>Rolling Upgrade</para>
+        <para>Cluster Rolling Upgrade</para>
        </entry>
        <entry>
         <itemizedlist>
@@ -558,7 +558,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ha-migration-upgrade-offline">
-   <title>Offline Migration</title>
+   <title>Cluster Offline Upgrade</title>
    <para>
     This section applies to the following scenarios:
    </para>
@@ -600,13 +600,13 @@
    <para>
     The &hasi; 12 cluster stack comes with major changes in various
     components (for example, &corosync.conf;, disk formats of OCFS2).
-    Therefore, a <literal>rolling upgrade</literal> from any &productname;
+    Therefore, a <literal>cluster rolling upgrade</literal> from any &productname;
     11 version is not supported. Instead, all cluster nodes must be offline
-    and the cluster needs to be migrated as a whole as described in
+    and the cluster needs to be upgraded as a whole as described in
     <xref linkend="pro-ha-migration-offline"/>.
    </para>
    <procedure xml:id="pro-ha-migration-offline">
-    <title>Upgrading from Product Version 11 to 12: Cluster-Wide Offline Migration</title>
+    <title>Upgrading from Product Version 11 to 12: Cluster Offline Upgrade</title>
     <step>
      <para>
       Log in to each cluster node and stop the cluster stack with:
@@ -732,7 +732,7 @@
    </note>
 
 <procedure xml:id="pro-ha-migration-offline-12-15">
-    <title>Upgrading from Product Version 12 to 15: Cluster-Wide Offline Migration</title>
+    <title>Upgrading from Product Version 12 to 15: Cluster Offline Upgrade</title>
    <important>
      <title>Installation from Scratch</title>
      <para>If you decide to install the cluster nodes from scratch (instead
@@ -745,7 +745,7 @@
     </important>
     <step>
      <para>
-      Before starting the offline migration to &productname; 15, manually
+      Before starting the offline upgrade to &productname; 15, manually
       upgrade the CIB syntax in your current cluster as described in
       <xref linkend="note-ha-cib-upgrade"/>.
      </para>
@@ -792,7 +792,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ha-migration-upgrade-rolling">
-   <title>Rolling Upgrade</title>
+   <title>Cluster Rolling Upgrade</title>
    <para>
     This section applies to the following scenarios:
    </para>
@@ -837,7 +837,7 @@
     </para>
    </warning>
    <procedure xml:id="pro-ha-migration-rolling-upgrade">
-    <title>Performing a Cluster-wide Rolling Upgrade</title>
+    <title>Performing a Cluster Rolling Upgrade</title>
 <!--https://bugzilla.novell.com/show_bug.cgi?id=573817#c6-->
     <step>
      <para>
@@ -874,13 +874,13 @@
     </step>
    </procedure>
    <important>
-    <title>Time Limit for Rolling Upgrade</title>
+    <title>Time Limit for Cluster Rolling Upgrade</title>
     <para>
      The new features shipped with the latest product version will only be
      available after <emphasis>all</emphasis> cluster nodes have been
      upgraded to the latest product version. Mixed version clusters are only
-     supported for a short time frame during the rolling upgrade. Complete
-     the rolling upgrade within one week.
+     supported for a short time frame during the cluster rolling upgrade. Complete
+     the cluster rolling upgrade within one week.
     </para>
    </important>
    <para>The &hawk2; <guimenu>Status</guimenu> screen also shows a warning if
@@ -893,7 +893,7 @@
   <warning>
    <title>Active Cluster Stack</title>
    <para>
-    Before starting an update for a node, either <emphasis>stop</emphasis>
+    Before starting a package update for a node, either <emphasis>stop</emphasis>
     the cluster stack <emphasis>on that node</emphasis> or put the
     <emphasis>node into maintenance mode</emphasis>, depending on whether the
     cluster stack is affected or not. See <xref linkend="step-update-check"/>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -597,16 +597,16 @@
     that can be used as a source for upgrading to the desired target
     version.
    </para>
-   <para>
-    The &hasi; 12 cluster stack comes with major changes in various
-    components (for example, &corosync.conf;, disk formats of OCFS2).
-    Therefore, a <literal>cluster rolling upgrade</literal> from any &productname;
-    11 version is not supported. Instead, all cluster nodes must be offline
-    and the cluster needs to be upgraded as a whole as described in
-    <xref linkend="pro-ha-migration-offline"/>.
-   </para>
+
    <procedure xml:id="pro-ha-migration-offline">
     <title>Upgrading from Product Version 11 to 12: Cluster Offline Upgrade</title>
+    <para>
+     The &hasi; 12 cluster stack comes with major changes in various
+     components (for example, &corosync.conf;, disk formats of OCFS2).
+     Therefore, a <literal>cluster rolling upgrade</literal> from any &productname;
+     11 version is not supported. Instead, all cluster nodes must be offline
+     and the cluster needs to be upgraded as a whole as described below.
+    </para>
     <step>
      <para>
       Log in to each cluster node and stop the cluster stack with:
@@ -836,6 +836,16 @@
      nodes.
     </para>
    </warning>
+   <important>
+    <title>Time Limit for Cluster Rolling Upgrade</title>
+    <para>
+     The new features shipped with the latest product version will only be
+     available after <emphasis>all</emphasis> cluster nodes have been
+     upgraded to the latest product version. Mixed version clusters are only
+     supported for a short time frame during the cluster rolling upgrade. Complete
+     the cluster rolling upgrade within one week.
+    </para>
+   </important>
    <procedure xml:id="pro-ha-migration-rolling-upgrade">
     <title>Performing a Cluster Rolling Upgrade</title>
 <!--https://bugzilla.novell.com/show_bug.cgi?id=573817#c6-->
@@ -871,20 +881,12 @@
       Check the cluster status with <command>crm status</command> or with
       &hawk2;.
      </para>
+     <para>
+      The &hawk2; <guimenu>Status</guimenu> screen also shows a warning if
+      different CRM versions are detected for your cluster nodes.
+     </para>
     </step>
    </procedure>
-   <important>
-    <title>Time Limit for Cluster Rolling Upgrade</title>
-    <para>
-     The new features shipped with the latest product version will only be
-     available after <emphasis>all</emphasis> cluster nodes have been
-     upgraded to the latest product version. Mixed version clusters are only
-     supported for a short time frame during the cluster rolling upgrade. Complete
-     the cluster rolling upgrade within one week.
-    </para>
-   </important>
-   <para>The &hawk2; <guimenu>Status</guimenu> screen also shows a warning if
-    different CRM versions are detected for your cluster nodes.</para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-ha-migration-update">

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -70,21 +70,21 @@
     </listitem>
    </varlistentry>
    <varlistentry xml:id="vle-upgrade-offline">
-    <term>Offline Migration</term>
+    <term>Cluster Offline Upgrade</term>
     <listitem>
      <para>
       If a new product version includes major changes that are backward
-      incompatible, the cluster needs to be upgraded by an offline migration.
-      You need to take all nodes offline and upgrade the cluster as a whole,
+      incompatible, the cluster needs to be upgraded by a cluster offline
+      upgrade. You need to take all nodes offline and upgrade the cluster as a whole,
       before you can bring all nodes back online.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="vle-upgrade-rolling">
-    <term>Rolling Upgrade</term>
+    <term>Cluster Rolling Upgrade</term>
     <listitem>
      <para>
-      In a rolling upgrade one cluster node at a time is upgraded while the
+      In a cluster rolling upgrade one cluster node at a time is upgraded while the
       rest of the cluster is still running. You take the first node offline,
       upgrade it and bring it back online to join the cluster. Then you
       continue one by one until all cluster nodes are upgraded to a major
@@ -136,14 +136,14 @@
   <itemizedlist>
    <listitem>
     <para>
-     Rolling upgrades are only supported within the same major release (from the
+     Cluster rolling upgrades are only supported within the same major release (from the
      GA of a product version to the next service pack, and from one service pack
      to the next).
     </para>
    </listitem>
    <listitem>
     <para>
-     Offline migrations are required to upgrade from one major release to
+     Cluster offline upgrades are required to upgrade from one major release to
      the next (for example, from SLE&nbsp;HA&nbsp;12 to
      SLE&nbsp;HA&nbsp;15) or from a service pack within one major
      release to the next major release (for example, from
@@ -230,7 +230,7 @@
        </entry>
        <entry>
         <para>
-         Offline Migration
+         Cluster Offline Upgrade
         </para>
        </entry>
        <entry>
@@ -267,7 +267,7 @@
        </entry>
        <entry>
         <para>
-         Offline Migration
+         Cluster Offline Upgrade
         </para>
        </entry>
        <entry>
@@ -303,7 +303,7 @@
        </entry>
        <entry>
         <para>
-         Rolling Upgrade
+         Cluster Rolling Upgrade
         </para>
        </entry>
        <entry>
@@ -336,7 +336,7 @@
          SLE&nbsp;HA&nbsp;(Geo)&nbsp;12&nbsp;SP2</para>
        </entry>
        <entry>
-        <para>Rolling Upgrade</para>
+        <para>Cluster Rolling Upgrade</para>
        </entry>
        <entry>
         <itemizedlist>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -410,9 +410,8 @@
         <itemizedlist>
          <listitem>
           <para>
-           Base System: <citetitle>&sls;&nbsp;12&nbsp;SP4
-            &deploy;</citetitle>, part <citetitle>Updating and Upgrading
-             &sle;</citetitle>
+           Base System: <citetitle>&deploy;</citetitle> for &slsa;&nbsp;12&nbsp;SP4,
+           part <citetitle>Updating and Upgrading &sle;</citetitle>
           </para>
          </listitem>
          <listitem>
@@ -423,8 +422,9 @@
          </listitem>
          <listitem>
           <para>
-           SLE&nbsp;HA&nbsp;Geo: <citetitle>&hageo; 12 SP4
-            &geoquick;</citetitle>, section <citetitle>Upgrading to the Latest Product Version</citetitle>
+           SLE&nbsp;HA&nbsp;Geo: <citetitle>&geoquick;</citetitle> for
+           SLE&nbsp;HA&nbsp;12&nbsp;SP4, section <citetitle>Upgrading to the
+           Latest Product Version</citetitle>
           </para>
          </listitem>
         </itemizedlist>

--- a/xml/ha_requirements.xml
+++ b/xml/ha_requirements.xml
@@ -76,8 +76,7 @@
 <?dbfo-need height="10em"?>
  <sect1 xml:id="sec-ha-requirements-sw">
   <title>Software Requirements</title>
-<!--taroth 2011-11-02: for the records, we do *not* support mixed clusters
-       (SP1/SP2), exception: during rolling upgrade (info by lmb@ha-devel)-->
+
   <para>
    All nodes that will be part of the cluster need at least the following modules
    and extensions:


### PR DESCRIPTION
### Description

From  bsc#115038:
"The inconsistent terminology for the upgrade scenarios between the base product (SLE) and SLE HA is also a point of confusion, both internally and for our customers."

Implementing a proposal by Yan for the SLE HA docs:

- Rolling Upgrade -> Cluster Rolling Upgrade
- Offline Migration -> Cluster Offline Upgrade

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
