### PR TITLE
Update Doc URLs

### DIFF
--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
   type="text/xml" 
   title="Profiling step"?>
@@ -263,10 +262,9 @@
    Both patterns are only available if you have registered your system at &scc;
    (or a local registration server) and have added the respective modules or
    installation media as an extension. For information on how to
-   install extensions, see the <citetitle>&sle; &productnumber;
-   &deploy;</citetitle>: <link
-    xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-deployment/#cha-add-ons">the <citetitle>&sle; &productnumber;
-     &deploy;</citetitle></link>.
+   install extensions, see the <link
+    xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-add-ons.html">
+    <citetitle>&deploy;</citetitle> for &sle; &productnumber;</link>.
   </para>
   <para>
      To install the packages from both patterns via command line, use Zypper:
@@ -766,17 +764,16 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
      <link
       xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
      For further configuration and administration tasks, see the comprehensive
-     <citetitle>&geoguide;</citetitle>:
-     <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/single-html/SLE-HA-geo-guide/#book-sleha-geo"></link>
+     <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/book-sleha-geo.html">
+      <citetitle>&geoguide;</citetitle></link>.
     </para>
    </listitem>
    <listitem>
     <para>
-     A document with detailed information how to on data replication via
-     DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
-     series:
+     Find information about data replication across &geo; clusters via DRBD in the following
      <link
-      xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>.
+      xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"><citetitle>&sbp;</citetitle>
+     document</link>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -264,7 +264,7 @@
    (or a local registration server) and have added the respective modules or
    installation media as an extension. For information on how to
    install extensions, see the <citetitle>&sle; &productnumber;
-   &deploy;</citetitle>: <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-add-ons.html"/>.
+    &deploy;</citetitle>: <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-deployment/#cha-add-ons"/>.
   </para>
   <para>
      To install the packages from both patterns via command line, use Zypper:
@@ -762,10 +762,10 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
     <para>
      More documentation for this product is available at
      <link
-     xlink:href="&dsc-ha-15;"/>.
+     xlink:href="&dsc-ha;/15-SP2"/>.
      For further configuration and administration tasks, see the comprehensive
      <citetitle>&geoguide;</citetitle>:
-     <link xlink:href="&dsc-ha-15;/html/SLE-HA-all/book-sleha-geo.html"></link>
+     <link xlink:href="&dsc-ha;/15-SP2/single-html/SLE-HA-geo-guide/#book-sleha-geo"></link>
     </para>
    </listitem>
    <listitem>

--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -264,7 +264,9 @@
    (or a local registration server) and have added the respective modules or
    installation media as an extension. For information on how to
    install extensions, see the <citetitle>&sle; &productnumber;
-    &deploy;</citetitle>: <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-deployment/#cha-add-ons"/>.
+   &deploy;</citetitle>: <link
+    xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-deployment/#cha-add-ons">the <citetitle>&sle; &productnumber;
+     &deploy;</citetitle></link>.
   </para>
   <para>
      To install the packages from both patterns via command line, use Zypper:
@@ -762,10 +764,10 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
     <para>
      More documentation for this product is available at
      <link
-     xlink:href="&dsc-ha;/15-SP2"/>.
+      xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
      For further configuration and administration tasks, see the comprehensive
      <citetitle>&geoguide;</citetitle>:
-     <link xlink:href="&dsc-ha;/15-SP2/single-html/SLE-HA-geo-guide/#book-sleha-geo"></link>
+     <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/single-html/SLE-HA-geo-guide/#book-sleha-geo"></link>
     </para>
    </listitem>
    <listitem>
@@ -774,7 +776,7 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
      DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
      series:
      <link
-      xlink:href="&dsc-sbp;/all/html/SBP-DRBD/index.html"/>.
+      xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
   type="text/xml" 
   title="Profiling step"?>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -272,8 +272,7 @@
       For information on how to install
       extensions, see <link
        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-add-ons.html">
-       <citetitle>&deploy;</citetitle> for &sle; &productnumber;, chapter
-       <citetitle>Installing Modules, Extensions, and Third Party Add-On Products</citetitle></link>.
+       <citetitle>&deploy;</citetitle> for &sls; &productnumber;</link>.
     </para>
 
     <procedure xml:id="pro-ha-inst-quick-pattern">
@@ -304,7 +303,7 @@
        <para>
          Register the machines at &scc;. Find more information in the <link
           xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-offline.html#sec-update-registersystem">
-         <citetitle>&upguide;</citetitle> for &sle; &productnumber;</link>.
+         <citetitle>&upguide;</citetitle> for &sls; &productnumber;</link>.
        </para>
       </step>
     </procedure>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -271,7 +271,7 @@
     <para>
       For information on how to install
       extensions, see the <citetitle>&deploy;</citetitle> for &sle; &productnumber;:
-     <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-deployment/#cha-add-ons"/>.
+     <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-deployment/#cha-add-ons"/>.
     </para>
 
     <procedure xml:id="pro-ha-inst-quick-pattern">
@@ -301,7 +301,7 @@
       <step>
        <para>
          Register the machines at &scc;. Find more information at <link
-          xlink:href="&dsc-sles;/15-SP2/single-html/SLES-upgrade/#sec-update-registersystem"/>.
+          xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-upgrade/#sec-update-registersystem"/>.
        </para>
       </step>
     </procedure>
@@ -349,7 +349,7 @@
 
   <para>
    For details of how to set up shared storage, refer to the <citetitle>&storage;</citetitle>
-   for &sls; &productnumber;: <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-storage/#book-storage"/>.
+   for &sls; &productnumber;: <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-storage/#book-storage"/>.
   </para>
   <!--<remark>toms, 2016-07-30: (kai) miss a link to set up FC storage</remark>
   <remark>toms 2016-08-01: we don't have yet doc for FC storage.</remark>
@@ -795,10 +795,10 @@ softdog                16384  1</screen>
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="&dsc-ha;/15-SP2"/>.
+      xlink:href="https://documentation.suse.com/sleha/15-SP2"/>.
      For further configuration and administration tasks, see the comprehensive
      <citetitle>&admin;</citetitle>:
-     <link xlink:href="&dsc-ha;/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
+     <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
     </para>
    </sect1>
  <xi:include href="common_copyright_quick.xml"/>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -270,8 +270,10 @@
     </para>
     <para>
       For information on how to install
-      extensions, see the <citetitle>&deploy;</citetitle> for &sle; &productnumber;:
-     <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-deployment/#cha-add-ons"/>.
+      extensions, see <link
+       xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-add-ons.html">
+       <citetitle>&deploy;</citetitle> for &sle; &productnumber;, chapter
+       <citetitle>Installing Modules, Extensions, and Third Party Add-On Products</citetitle></link>.
     </para>
 
     <procedure xml:id="pro-ha-inst-quick-pattern">
@@ -300,8 +302,9 @@
       </step>
       <step>
        <para>
-         Register the machines at &scc;. Find more information at <link
-          xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-upgrade/#sec-update-registersystem"/>.
+         Register the machines at &scc;. Find more information in the <link
+          xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-offline.html#sec-update-registersystem">
+         <citetitle>&upguide;</citetitle> for &sle; &productnumber;</link>.
        </para>
       </step>
     </procedure>
@@ -348,8 +351,10 @@
    </itemizedlist>
 
   <para>
-   For details of how to set up shared storage, refer to the <citetitle>&storage;</citetitle>
-   for &sls; &productnumber;: <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-storage/#book-storage"/>.
+   For details of how to set up shared storage, refer to the
+   <link
+    xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/book-storage.html">
+    <citetitle>&storage;</citetitle> for &sls; &productnumber;</link>.
   </para>
   <!--<remark>toms, 2016-07-30: (kai) miss a link to set up FC storage</remark>
   <remark>toms 2016-08-01: we don't have yet doc for FC storage.</remark>
@@ -797,8 +802,9 @@ softdog                16384  1</screen>
      <link
       xlink:href="https://documentation.suse.com/sleha/15-SP2"/>.
      For further configuration and administration tasks, see the comprehensive
-     <citetitle>&admin;</citetitle>:
-     <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
+     <link
+      xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/SLE-HA-all/book-sleha-guide.html">
+      <citetitle>&admin;</citetitle></link>.
     </para>
    </sect1>
  <xi:include href="common_copyright_quick.xml"/>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -270,7 +270,7 @@
     </para>
     <para>
       For information on how to install
-      extensions, see <link
+      extensions, see the <link
        xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-add-ons.html">
        <citetitle>&deploy;</citetitle> for &sls; &productnumber;</link>.
     </para>
@@ -799,10 +799,10 @@ softdog                16384  1</screen>
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="https://documentation.suse.com/sleha/15-SP2"/>.
+      xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
      For further configuration and administration tasks, see the comprehensive
      <link
-      xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/SLE-HA-all/book-sleha-guide.html">
+      xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/book-sleha-guide.html">
       <citetitle>&admin;</citetitle></link>.
     </para>
    </sect1>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -271,7 +271,7 @@
     <para>
       For information on how to install
       extensions, see the <citetitle>&deploy;</citetitle> for &sle; &productnumber;:
-     <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-add-ons.html"/>.
+     <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-deployment/#cha-add-ons"/>.
     </para>
 
     <procedure xml:id="pro-ha-inst-quick-pattern">
@@ -301,7 +301,7 @@
       <step>
        <para>
          Register the machines at &scc;. Find more information at <link
-         xlink:href="&dsc-sles-15;/html/SLES-all/cha-upgrade-offline.html#sec-update-registersystem"/>.
+          xlink:href="&dsc-sles;/15-SP2/single-html/SLES-upgrade/#sec-update-registersystem"/>.
        </para>
       </step>
     </procedure>
@@ -349,7 +349,7 @@
 
   <para>
    For details of how to set up shared storage, refer to the <citetitle>&storage;</citetitle>
-   for &sls; &productnumber;: <link xlink:href="&dsc-sles-15;/html/SLES-all/book-storage.html"/>.
+   for &sls; &productnumber;: <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-storage/#book-storage"/>.
   </para>
   <!--<remark>toms, 2016-07-30: (kai) miss a link to set up FC storage</remark>
   <remark>toms 2016-08-01: we don't have yet doc for FC storage.</remark>
@@ -795,10 +795,10 @@ softdog                16384  1</screen>
     <para>
      More documentation for this product is available at
      <link
-     xlink:href="&dsc-ha-15;"/>.
+      xlink:href="&dsc-ha;/15-SP2"/>.
      For further configuration and administration tasks, see the comprehensive
      <citetitle>&admin;</citetitle>:
-     <link xlink:href="&dsc-ha-15;/html/SLE-HA-all/SLE-HA-all/book-sleha-guide.html"></link>
+     <link xlink:href="&dsc-ha;/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
     </para>
    </sect1>
  <xi:include href="common_copyright_quick.xml"/>

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -520,7 +520,9 @@ Full list of resources:
     </step>
     <step>
      <para>Create a KVM guest on <systemitem class="domainname"
-      >&node1;</systemitem>. For details see <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-virtualization/#cha-kvm-inst"/>.
+      >&node1;</systemitem>. For details see the <link
+       xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-kvm-inst.html">
+       <citetitle>&virtual;</citetitle> for &sls; &productnumber;</link>.
      </para>
     </step>
     <step>
@@ -763,8 +765,9 @@ Failed Actions:
   More documentation for this product is available at
   <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
   For further configuration and administration tasks, see the comprehensive
-  <citetitle>&admin;</citetitle>:
-  <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
+  <link
+   xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/book-sleha-guide.html">
+   <citetitle>&admin;</citetitle></link>.
  </para>
  <para>
   Upstream documentation is available from <link

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -520,7 +520,7 @@ Full list of resources:
     </step>
     <step>
      <para>Create a KVM guest on <systemitem class="domainname"
-      >&node1;</systemitem>. For details see <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-kvm-inst.html"/>.
+      >&node1;</systemitem>. For details see <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-virtualization/#cha-kvm-inst"/>.
      </para>
     </step>
     <step>
@@ -761,10 +761,10 @@ Failed Actions:
 <title>For More Information</title>
  <para>
   More documentation for this product is available at
-  <link xlink:href="&dsc-ha-15;"/>.
+  <link xlink:href="&dsc-ha;/15-SP2"/>.
   For further configuration and administration tasks, see the comprehensive
   <citetitle>&admin;</citetitle>:
-  <link xlink:href="&dsc-ha-15;/html/SLE-HA-all/SLE-HA-all/book-sleha-guide.html"></link>
+  <link xlink:href="&dsc-ha;/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
  </para>
  <para>
   Upstream documentation is available from <link

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -520,7 +520,7 @@ Full list of resources:
     </step>
     <step>
      <para>Create a KVM guest on <systemitem class="domainname"
-      >&node1;</systemitem>. For details see <link xlink:href="&dsc-sles;/15-SP2/single-html/SLES-virtualization/#cha-kvm-inst"/>.
+      >&node1;</systemitem>. For details see <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-virtualization/#cha-kvm-inst"/>.
      </para>
     </step>
     <step>
@@ -761,10 +761,10 @@ Failed Actions:
 <title>For More Information</title>
  <para>
   More documentation for this product is available at
-  <link xlink:href="&dsc-ha;/15-SP2"/>.
+  <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
   For further configuration and administration tasks, see the comprehensive
   <citetitle>&admin;</citetitle>:
-  <link xlink:href="&dsc-ha;/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
+  <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/single-html/SLE-HA-guide/#book-sleha-guide"></link>
  </para>
  <para>
   Upstream documentation is available from <link

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -30,7 +30,7 @@
   <title>Online Documentation and Latest Updates</title>
   <para>
    Documentation for our products is available at
-   <link xlink:href="&dsc;"/>, where you can also
+   <link xlink:href="https://documentation.suse.com/"/>, where you can also
    find the latest updates, and browse or download the documentation in various formats.
    The latest documentation updates can usually be found in the English language version.
   </para>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -164,34 +164,6 @@ called pacemaker_remote, but the daemon pacemaker-remoted. :-(
 <!ENTITY dc             "doc comment #">
 
 <!-- ============================================================= -->
-<!--              documentation.suse.com links                     -->
-<!-- ============================================================= -->
-
-<!ENTITY dsc            "https://documentation.suse.com">
-<!ENTITY dsc-sles       "&dsc;/sles">
-<!ENTITY dsc-sles-11    "&dsc;/sles-11">
-<!ENTITY dsc-sles-12    "&dsc;/sles-12">
-<!ENTITY dsc-sles-15    "&dsc;/sles-15">
-<!ENTITY dsc-sled       "&dsc;/sled">
-<!ENTITY dsc-sled-11    "&dsc;/sled-11">
-<!ENTITY dsc-sled-12    "&dsc;/sled-12">
-<!ENTITY dsc-sled-15    "&dsc;/sled-15">
-<!ENTITY dsc-ha         "&dsc;/sle-ha">
-<!ENTITY dsc-ha-11      "&dsc;/sle-ha-11">
-<!ENTITY dsc-ha-12      "&dsc;/sle-ha-12">
-<!ENTITY dsc-ha-15      "&dsc;/sle-ha-15">
-<!ENTITY dsc-sap        "&dsc;/sles-sap">
-<!ENTITY dsc-sap-11     "&dsc;/sles-sap-11">
-<!ENTITY dsc-sap-12     "&dsc;/sles-sap-12">
-<!ENTITY dsc-sap-15     "&dsc;/sles-sap-15">
-<!ENTITY dsc-rt         "&dsc;/sle-rt">
-<!ENTITY dsc-sbp        "&dsc;/sbp">
-<!ENTITY dsc-ses        "&dsc;/ses">
-<!ENTITY dsc-suma       "&dsc;/suma">
-<!ENTITY dsc-suma-retail "&dsc;/suma-retail">
-<!ENTITY dsc-vmdp       "&dsc;/sle-vmdp">
-
-<!-- ============================================================= -->
 <!--                    Platforms                                  -->
 <!-- ============================================================= -->
 

--- a/xml/geo_booth_i.xml
+++ b/xml/geo_booth_i.xml
@@ -239,7 +239,7 @@ ticket = "&ticket2;" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle="se
       For example, the ticket <literal>&ticket3;</literal> specified here can
       be used for failover of NFS and DRBD as explained in
       <link
-       xlink:href="&dsc;/sbp/all/html/SBP-DRBD/index.html"/>.
+       xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>.
      </para>
     </callout>
    <callout arearefs="co-ha-geo-booth-mode">

--- a/xml/geo_booth_i.xml
+++ b/xml/geo_booth_i.xml
@@ -239,7 +239,7 @@ ticket = "&ticket2;" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle="se
       For example, the ticket <literal>&ticket3;</literal> specified here can
       be used for failover of NFS and DRBD as explained in
       <link
-       xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>.
+       xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"/>.
      </para>
     </callout>
    <callout arearefs="co-ha-geo-booth-mode">

--- a/xml/geo_docupdates.xml
+++ b/xml/geo_docupdates.xml
@@ -38,7 +38,7 @@
       <para>
       The documentation for &geo; clustering with &productnamereg; has been
       split up into two documents. Both are available from <link
-       xlink:href="&dsc;"/>.
+       xlink:href="https://documentation.suse.com/"/>.
      </para>
      <formalpara>
       <title><citetitle>&geoquick;</citetitle></title>

--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -36,9 +36,8 @@
     <remark>taroth 2014-11-21: lmb, would you consider the aforementioned link appropriate (WRT to
      our customers and the kind of setup that is needed here)?</remark>
     More information on how to set up DNS, including dynamic update of zone
-    data, can be found in the &sle; <citetitle>&admin;</citetitle>, chapter
-    <citetitle>The Domain Name System</citetitle>. It is available from
-    <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-dns.html"/>.
+    data, can be found in at <link
+     xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-dns"/>.
    </para>
   </listitem>
   <listitem>
@@ -50,7 +49,7 @@
 <screen>&prompt.root;<command>dnssec-keygen</command> -a hmac-md5 -b 128 -n USER geo-update</screen>
    <para>
     For more information, see the <command>dnssec-keygen</command> man page or
-    <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-dns.html#sec-dns-tsig"/>.
+    <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#sec-dns-tsig"/>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -36,8 +36,9 @@
     <remark>taroth 2014-11-21: lmb, would you consider the aforementioned link appropriate (WRT to
      our customers and the kind of setup that is needed here)?</remark>
     More information on how to set up DNS, including dynamic update of zone
-    data, can be found in at <link
-     xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-dns"/>.
+    data, can be found in the <link
+     xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-dns.html">
+     <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
    </para>
   </listitem>
   <listitem>
@@ -48,8 +49,10 @@
    </para>
 <screen>&prompt.root;<command>dnssec-keygen</command> -a hmac-md5 -b 128 -n USER geo-update</screen>
    <para>
-    For more information, see the <command>dnssec-keygen</command> man page or
-    <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#sec-dns-tsig"/>.
+    For more information, see the <command>dnssec-keygen</command> man page or the
+    <link
+     xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-dns.html#sec-dns-tsig">
+     <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/geo_more_i.xml
+++ b/xml/geo_more_i.xml
@@ -25,12 +25,11 @@
    </listitem>
    <listitem>
     <para>
-     A document with detailed information how to on data replication via
-     DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
-     series:
-     <link
-      xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>.
-    </para>
-   </listitem>
+     Find information about data replication across &geo; clusters via DRBD in the following
+      <link
+       xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"><citetitle>&sbp;</citetitle>
+       document</link>.
+     </para>
+    </listitem>
   </itemizedlist>
  </chapter>

--- a/xml/geo_more_i.xml
+++ b/xml/geo_more_i.xml
@@ -15,7 +15,7 @@
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="&dsc-ha-15;"/>.
+      xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
      For example, the <citetitle>&geoquick;</citetitle> guides you through
      the basic setup of a &geo; cluster, using the &geo; bootstrap scripts
      provided by the <systemitem xmlns='http://docbook.org/ns/docbook'
@@ -29,7 +29,7 @@
      DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
      series:
      <link
-      xlink:href="&dsc;/sbp/all/html/SBP-DRBD/index.html"/>.
+      xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -366,9 +366,10 @@
       <para>
        Any resources and constraints of your specific setup that you need on
        all sites of the &geo; cluster (for example, resources for DRBD as
-       described in
+       described in the
        <link
-        xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>).
+        xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"><citetitle>&sbp;</citetitle>
+       document</link>).
       </para>
      </callout>
      <callout arearefs="co-geo-rsc-booth">

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -368,7 +368,7 @@
        all sites of the &geo; cluster (for example, resources for DRBD as
        described in
        <link
-          xlink:href="&dsc;/sbp/all/html/SBP-DRBD/index.html"/>).
+        xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-DRBD/index.html"/>).
       </para>
      </callout>
      <callout arearefs="co-geo-rsc-booth">

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -828,9 +828,9 @@ vdc                                   253:32   0   20G  0 disk
        option) and allocated on the same device as the mirror leg?</title>
       <para> (For example, this might be the case if you have created the
        logical volume for a cmirrord setup on &productname; 11 or 12 as
-       described in <link
-        xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#sec-ha-clvm-config-cmirrord"
-       />.)</para>
+       described in the <link
+        xlink:href="https://documentation.suse.com/sle-ha/12-SP5/html/SLE-HA-all/cha-ha-clvm.html#sec-ha-clvm-config-cmirrord">
+        <citetitle>&admin;</citetitle> for those versions</link>.)</para>
      </formalpara>
      <para>
       By default, <command>mdadm</command> reserves a certain amount of space

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -829,7 +829,7 @@ vdc                                   253:32   0   20G  0 disk
       <para> (For example, this might be the case if you have created the
        logical volume for a cmirrord setup on &productname; 11 or 12 as
        described in <link
-        xlink:href="&dsc-ha-12;/html/SLE-HA-all/cha-ha-clvm.html#sec-ha-clvm-config-cmirrord"
+        xlink:href="https://documentation.suse.com/sle-ha/12-SP5/single-html/SLE-HA-guide/#sec-ha-clvm-config-cmirrord"
        />.)</para>
      </formalpara>
      <para>

--- a/xml/ha_install.xml
+++ b/xml/ha_install.xml
@@ -61,7 +61,7 @@
 
    <para>
     For detailed instructions on how to use &ay; in various scenarios,
-    see <link xlink:href="&dsc-sles-15;/html/SLES-all/book-autoyast.html"/>.
+    see <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-autoyast/#book-autoyast"/>.
    </para>
 
    <important>

--- a/xml/ha_install.xml
+++ b/xml/ha_install.xml
@@ -61,7 +61,9 @@
 
    <para>
     For detailed instructions on how to use &ay; in various scenarios,
-    see <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-autoyast/#book-autoyast"/>.
+    see the <link
+     xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/book-autoyast.html">
+     <citetitle>&ayguide;</citetitle> for &sls; &productnumber;</link>.
    </para>
 
    <important>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -161,12 +161,12 @@
    <itemizedlist>
     <listitem>
      <para>
-      <link xlink:href="&dsc-sles;"/>
+      <link xlink:href="https://documentation.suse.com/sles"/>
      </para>
     </listitem>
     <listitem>
      <para>
-      <link xlink:href="&dsc-ha;"/>
+      <link xlink:href="https://documentation.suse.com/sle-ha"/>
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -484,8 +484,10 @@
   <procedure>
    <step>
     <para>
-     Set up an NFS server with &yast; as described in 
-     <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-nfs"/>.
+     Set up an NFS server with &yast; as described in the
+     <link
+      xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-nfs.html">
+      <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
     </para>
    </step>
    <step>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -484,8 +484,8 @@
   <procedure>
    <step>
     <para>
-     Set up an NFS server with &yast; as described in the &sls;
-     &productnumber; <citetitle>&admin;</citetitle>: <link xlink:href="&dsc-sles-15;/html/SLES-all/cha-nfs.html"/>.
+     Set up an NFS server with &yast; as described in 
+     <link xlink:href="https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-nfs"/>.
     </para>
    </step>
    <step>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -417,7 +417,7 @@
      Cluster nodes must synchronize to an NTP server outside the cluster.
      Since &productname; 15, chrony is the default implementation of NTP.
      For more information, see
-     <link xlink:href='&dsc-sles-15;/html/SLES-all/cha-ntp.html'/>.
+     <link xlink:href='https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-ntp'/>.
     </para>
     <para>
      If nodes are not synchronized, the cluster may not work properly.
@@ -566,7 +566,7 @@
    <para>
     All cluster nodes on all sites should synchronize to an NTP server outside
     the cluster. For more information, see
-    <link xlink:href='&dsc-sles-15;/html/SLES-all/cha-ntp.html'/>.
+    <link xlink:href='https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-ntp'/>.
    </para>
    <para>
     If nodes are not synchronized, log files and cluster reports are very hard

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -416,8 +416,10 @@
    <para>
      Cluster nodes must synchronize to an NTP server outside the cluster.
      Since &productname; 15, chrony is the default implementation of NTP.
-     For more information, see
-     <link xlink:href='https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-ntp'/>.
+     For more information, see the
+     <link
+     xlink:href='https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-ntp.html'>
+     <citetitle xmlns='http://docbook.org/ns/docbook'>&admin;</citetitle> for &sls; &productnumber;</link>.
     </para>
     <para>
      If nodes are not synchronized, the cluster may not work properly.
@@ -565,8 +567,11 @@
   <listitem>
    <para>
     All cluster nodes on all sites should synchronize to an NTP server outside
-    the cluster. For more information, see
-    <link xlink:href='https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#cha-ntp'/>.
+    the cluster. For more information, see the
+    <link
+     xlink:href='https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-ntp.html'>
+     <citetitle xmlns='http://docbook.org/ns/docbook'>&admin;</citetitle>
+     for &sls; &productnumber;</link>.
    </para>
    <para>
     If nodes are not synchronized, log files and cluster reports are very hard


### PR DESCRIPTION
### Description

Updating the links to our doc pages from www.suse.com/documentation to www.documentation.suse.com (again), based on the following guidelines:

- *without* using entities (entities for parts of the URL make it harder to copy/paste/replace complete URLs, plus they will be resolved during translation anyway)
-> this way the URLs are the same in the English versions *and*
   translation branches and can replaced the same way if needed
- using upcoming 15-SP2 URLs  (even if they will only work after FCS, to avoid need to update them in the translation branches after FCS)
- use links to html instead of single-html (shorter download times, SEO)
- use descriptive text for links to mention book name (in case deeplink is broken, customers know at least where to search for the information) 

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLEHA12SP4
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA15SP1
