### PR TITLE
Update Doc URLs for SLE HA 15

### DIFF
--- a/xml/art_sle_ha_geo_quick.xml
+++ b/xml/art_sle_ha_geo_quick.xml
@@ -225,9 +225,7 @@
    <filename>/var/log/ha-cluster-bootstrap.log</filename>. Check the log file
    for any details of the bootstrap process. Any options set during the
    bootstrap process can be modified later (by modifying booth settings,
-   modifying resources etc.). For details, see the
-   <literal>&geoguide;</literal>. It is available at
-   <link xlink:href="https://www.suse.com/documentation"/>.
+   modifying resources etc.). For details, see the <xref linkend="book-sleha-geo"/>.
   </para>
 
 <!--taroth 2017-07-03: the following is not really true by now, the man pages
@@ -265,12 +263,9 @@
    Both patterns are only available if you have registered your system at &scc;
    (or a local registration server) and have added the respective modules or
    installation media as an extension. For information on how to
-   install extensions, see the <citetitle>&sle; &productnumber;
-   &deploy;</citetitle>, available at
-   <link xlink:href="&suse-onlinedoc;&doc-sles;"/>. Refer to chapter
-   <citetitle>Installing Modules, Extensions, and Third Party Add-On
-   Products</citetitle>.
-<!--taroth: need to use hard-coded link here as the target is not included in the same set-->
+   install extensions, see the <link
+    xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-add-ons.html">
+    <citetitle>&deploy;</citetitle> for &sle; &productnumber;</link>.
   </para>
   <para>
      To install the packages from both patterns via command line, use Zypper:
@@ -768,21 +763,18 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="&suse-onlinedoc;&doc-geo;"/>.
-     <!--<remark>taroth 2017-11-28: requested generic URL; see
-      https://bugzilla.suse.com/show_bug.cgi?id=1070134</remark>-->
-     The documentation also includes a comprehensive
-     <literal>&geoguide;</literal>. Refer to it for further configuration and
-     administration tasks.
+      xlink:href="https://documentation.suse.com/sle-ha/15-GA"/>.
+     For further configuration and administration tasks, see the comprehensive
+     <link xlink:href="https://documentation.suse.com/sle-ha/15-GA/html/SLE-HA-all/book-sleha-geo.html">
+      <citetitle>&geoguide;</citetitle></link>.
     </para>
    </listitem>
    <listitem>
     <para>
-     A document with detailed information how to on data replication via
-     DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
-     series:
+     Find information about data replication across &geo; clusters via DRBD in the following
      <link
-      xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>.
+      xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"><citetitle>&sbp;</citetitle>
+     document</link>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -270,10 +270,9 @@
     </para>
     <para>
       For information on how to install
-      extensions, see the <citetitle>&deploy;</citetitle> for &sle; &productnumber;,
-      chapter <citetitle>Installing Modules, Extensions, and Third Party Add-On Products</citetitle>.
-      It is available from <link
-      xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+      extensions, see the <link
+       xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-add-ons.html">
+       <citetitle>&deploy;</citetitle> for &sls; &productnumber;</link>.
     </para>
 
     <procedure xml:id="pro-ha-inst-quick-pattern">
@@ -302,10 +301,9 @@
       </step>
       <step>
        <para>
-         Register the machines at &scc;. Find more information in the <citetitle>&deploy;</citetitle> for
-         &sls; &productnumber;, chapter <citetitle>Installing or Removing Software</citetitle>,
-         section <citetitle>Registering an Installed System</citetitle>. It is available from <link
-         xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+         Register the machines at &scc;. Find more information in the <link
+          xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-upgrade-offline.html#sec-update-registersystem">
+         <citetitle>&upguide;</citetitle> for &sls; &productnumber;</link>.
        </para>
       </step>
     </procedure>
@@ -352,9 +350,10 @@
    </itemizedlist>
 
   <para>
-   For details of how to set up shared storage, refer to the <citetitle>&storage;</citetitle>
-   for &sls; &productnumber;. It is available from
-   <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+   For details of how to set up shared storage, refer to the
+   <link
+    xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/book-storage.html">
+    <citetitle>&storage;</citetitle> for &sls; &productnumber;</link>.
   </para>
   <!--<remark>toms, 2016-07-30: (kai) miss a link to set up FC storage</remark>
   <remark>toms 2016-08-01: we don't have yet doc for FC storage.</remark>
@@ -797,14 +796,16 @@ softdog                16384  1</screen>
 
   <sect1 xml:id="sec-ha-inst-quick-moreinfo">
    <title>For More Information</title>
-   <para>
-    Find more documentation for this product at <link
-     xlink:href="&suse-onlinedoc;&doc-ha;"/>. The
-    documentation also includes a comprehensive <citetitle>&admin;</citetitle> for
-    &productname;. Refer to it for further configuration and administration
-    tasks.
-   </para>
-  </sect1>
+    <para>
+     More documentation for this product is available at
+     <link
+      xlink:href="https://documentation.suse.com/sle-ha/15-GA"/>.
+     For further configuration and administration tasks, see the comprehensive
+     <link
+      xlink:href="https://documentation.suse.com/sle-ha/15-GA/html/SLE-HA-all/book-sleha-guide.html">
+      <citetitle>&admin;</citetitle></link>.
+    </para>
+   </sect1>
  <xi:include href="common_copyright_quick.xml"/>
  <xi:include href="common_legal.xml"/>
 </article>

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -766,7 +766,7 @@ Failed Actions:
   <link xlink:href="https://documentation.suse.com/sle-ha/15-GA"/>.
   For further configuration and administration tasks, see the comprehensive
   <link
-   xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/book-sleha-guide.html">
+   xlink:href="https://documentation.suse.com/sle-ha/15-GA/html/SLE-HA-all/book-sleha-guide.html">
    <citetitle>&admin;</citetitle></link>.
  </para>
  <para>

--- a/xml/art_sle_ha_pmremote.xml
+++ b/xml/art_sle_ha_pmremote.xml
@@ -520,10 +520,9 @@ Full list of resources:
     </step>
     <step>
      <para>Create a KVM guest on <systemitem class="domainname"
-      >&node1;</systemitem>. For details refer to the
-      <citetitle>&virtual;</citetitle> for &sls; &productnumber;,
-      chapter <citetitle>Guest Installation</citetitle>. It is
-      available from <link xlink:href="&suse-onlinedoc;"/>.
+      >&node1;</systemitem>. For details see the <link
+       xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-kvm-inst.html">
+       <citetitle>&virtual;</citetitle> for &sls; &productnumber;</link>.
      </para>
     </step>
     <step>
@@ -763,13 +762,15 @@ Failed Actions:
 <sect1 xml:id="sec-ha-pmremote-more">
 <title>For More Information</title>
  <para>
-  Find more documentation for this product at <link
-  xlink:href="&suse-onlinedoc;&doc-ha;"/>. The
-  documentation also includes a comprehensive <citetitle>&admin;</citetitle> for
-  &productname;. Refer to it for further configuration and administration
-  tasks.
-  </para>
-  <para>Upstream documentation is available from <link
+  More documentation for this product is available at
+  <link xlink:href="https://documentation.suse.com/sle-ha/15-GA"/>.
+  For further configuration and administration tasks, see the comprehensive
+  <link
+   xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/book-sleha-guide.html">
+   <citetitle>&admin;</citetitle></link>.
+ </para>
+ <para>
+  Upstream documentation is available from <link
     xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>. See the document
    <citetitle>Pacemaker Remote&mdash;Scaling High Availability Clusters</citetitle>.
   </para>

--- a/xml/book_sle_ha_geo.xml
+++ b/xml/book_sle_ha_geo.xml
@@ -30,13 +30,7 @@
  <xi:include href="geo_challenges_i.xml"/>
  <xi:include href="geo_concept_i.xml"/>
  <xi:include href="geo_requirements_i.xml"/>
- <!--taroth 2017-07-27: removing, DRBD setup for Geo now covered in:
-     &suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html
- <xi:include href="geo_overview_i.xml"/>-->
  <xi:include href="geo_booth_i.xml"/>
-<!--taroth 2017-07-27: removing, DRBD setup for Geo now covered in:
-    &suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html
- <xi:include href="geo_drbd_i.xml"/>-->
  <xi:include href="geo_sync_i.xml"/>
  <xi:include href="geo_resources_i.xml"/>
  <xi:include href="geo_ip_i.xml"/>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -30,7 +30,7 @@
   <title>Online Documentation and Latest Updates</title>
   <para>
    Documentation for our products is available at
-   <link xlink:href="&suse-onlinedoc;"/>, where you can also
+   <link xlink:href="https://documentation.suse.com/"/>, where you can also
    find the latest updates, and browse or download the documentation in various formats.
    The latest documentation updates can usually be found in the English language version.
   </para>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -159,11 +159,6 @@ called pacemaker_remote, but the daemon pacemaker_remoted. :-(
 <!ENTITY wypublic       "/srv/www/yast/public/">
 <!ENTITY corosync.conf  "<filename xmlns='http://docbook.org/ns/docbook'>/etc/corosync/corosync.conf</filename>">
 <!ENTITY booth.conf     "<filename xmlns='http://docbook.org/ns/docbook'>/etc/booth/booth.conf</filename>">
-<!--do not use http_s_ in the URL below for the sake of Chinese customers-->
-<!ENTITY suse-onlinedoc "http://www.suse.com/documentation/">
-<!ENTITY doc-ha         "sle-ha">
-<!ENTITY doc-geo        "sle-ha-geo">
-<!ENTITY doc-sles       "sles">
 <!ENTITY bsc            "https://bugzilla.suse.com/show_bug.cgi?id=">
 <!ENTITY fate           "Fate #">
 <!ENTITY dc             "doc comment #">

--- a/xml/geo_booth_i.xml
+++ b/xml/geo_booth_i.xml
@@ -239,7 +239,7 @@ ticket = "&ticket2;" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle="se
       For example, the ticket <literal>&ticket3;</literal> specified here can
       be used for failover of NFS and DRBD as explained in
       <link
-       xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>.
+       xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"/>.
      </para>
     </callout>
    <callout arearefs="co-ha-geo-booth-mode">

--- a/xml/geo_docupdates.xml
+++ b/xml/geo_docupdates.xml
@@ -38,7 +38,7 @@
       <para>
       The documentation for &geo; clustering with &productnamereg; has been
       split up into two documents. Both are available from <link
-       xlink:href="https://www.suse.com/documentation"/>.
+       xlink:href="https://documentation.suse.com/"/>.
      </para>
      <formalpara>
       <title><citetitle>&geoquick;</citetitle></title>

--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -36,9 +36,9 @@
     <remark>taroth 2014-11-21: lmb, would you consider the aforementioned link appropriate (WRT to
      our customers and the kind of setup that is needed here)?</remark>
     More information on how to set up DNS, including dynamic update of zone
-    data, can be found in the &sle; <citetitle>&admin;</citetitle>, chapter
-    <citetitle>The Domain Name System</citetitle>. It is available from
-    <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+    data, can be found in the <link
+     xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-dns.html">
+     <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
    </para>
   </listitem>
   <listitem>
@@ -49,11 +49,10 @@
    </para>
 <screen>&prompt.root;<command>dnssec-keygen</command> -a hmac-md5 -b 128 -n USER geo-update</screen>
    <para>
-    For more information, see the <command>dnssec-keygen</command> man page or
-    the  &sle; <citetitle>&admin;</citetitle>, chapter
-    <citetitle>The Domain Name System</citetitle>, section <citetitle>Secure
-     Transactions</citetitle>. It is available from
-    <link xlink:href="&suse-onlinedoc;&doc-sles;"/>.
+    For more information, see the <command>dnssec-keygen</command> man page or the
+    <link
+     xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-dns.html#sec-dns-tsig">
+     <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/geo_more_i.xml
+++ b/xml/geo_more_i.xml
@@ -15,7 +15,7 @@
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="&suse-onlinedoc;&doc-geo;"/>.
+      xlink:href="https://documentation.suse.com/sle-ha/15-GA"/>.
      For example, the <citetitle>&geoquick;</citetitle> guides you through
      the basic setup of a &geo; cluster, using the &geo; bootstrap scripts
      provided by the <systemitem xmlns='http://docbook.org/ns/docbook'
@@ -25,12 +25,11 @@
    </listitem>
    <listitem>
     <para>
-     A document with detailed information how to on data replication via
-     DRBD across &geo; clusters has been published in the <literal>&sbp;</literal>
-     series:
-     <link
-      xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>.
-    </para>
-   </listitem>
+     Find information about data replication across &geo; clusters via DRBD in the following
+      <link
+       xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"><citetitle>&sbp;</citetitle>
+       document</link>.
+     </para>
+    </listitem>
   </itemizedlist>
  </chapter>

--- a/xml/geo_overview_i.xml
+++ b/xml/geo_overview_i.xml
@@ -84,12 +84,6 @@
    </listitem>
   </itemizedlist>
  </example>
-<!--
- <para>This document assumes that you have installed the required software
-  and set up a basic &geo; cluster as described in the &geoquick;, available
-  from <link xlink:href="&suse-onlinedoc;"/>.
-  Completing the setup for the scenario above takes the following basic steps:
- </para>-->
 
  <variablelist>
   <varlistentry>

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -367,9 +367,10 @@
       <para>
        Any resources and constraints of your specific setup that you need on
        all sites of the &geo; cluster (for example, resources for DRBD as
-       described in
+       described in the
        <link
-          xlink:href="&suse-onlinedoc;suse-best-practices/sbp-drbd/data/sbp-drbd.html"/>).
+        xlink:href="https://documentation.suse.com/sbp/all/html/SBP-DRBD/index.html"><citetitle>&sbp;</citetitle>
+       document</link>).
       </para>
      </callout>
      <callout arearefs="co-geo-rsc-booth">

--- a/xml/ha_acl.xml
+++ b/xml/ha_acl.xml
@@ -47,12 +47,14 @@
    how to check this and upgrade the CIB version, see
    <xref linkend="note-ha-cib-upgrade"/>.
   </para>
-  <para>
+  <!--taroth 2020-03-11: commenting the following because we currently only publish 
+    11 SP4 docs (the others are out of maintenance)-->
+   <!--<para>
    If you have upgraded from &productname; 11 SPx and kept your former
    CIB version, refer to the <citetitle>Access Control List</citetitle>
    chapter in the <citetitle>&haguide;</citetitle> for &productname; 11 SP3 or earlier. It is
-   available from <link xlink:href="&suse-onlinedoc;"/>.
-   </para>
+   available from FIXME.
+   </para>-->
  </note>
  <sect1 xml:id="sec-ha-acl-require">
   <title>Requirements and Prerequisites</title>

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -828,9 +828,9 @@ vdc                                   253:32   0   20G  0 disk
        option) and allocated on the same device as the mirror leg?</title>
       <para> (For example, this might be the case if you have created the
        logical volume for a cmirrord setup on &productname; 11 or 12 as
-       described in <link
-        xlink:href="https://www.suse.com/documentation/sle-ha-12/singlehtml/book_sleha/book_sleha.html#sec.ha.clvm.config.cmirrord"
-       />.)</para>
+       described in the <link
+        xlink:href="https://documentation.suse.com/sle-ha/12-SP5/html/SLE-HA-all/cha-ha-clvm.html#sec-ha-clvm-config-cmirrord">
+        <citetitle>&admin;</citetitle> for those versions</link>.)</para>
      </formalpara>
      <para>
       By default, <command>mdadm</command> reserves a certain amount of space

--- a/xml/ha_install.xml
+++ b/xml/ha_install.xml
@@ -61,8 +61,9 @@
 
    <para>
     For detailed instructions on how to use &ay; in various scenarios,
-    see the <citetitle>&sle; &productnumber; &ayguide;</citetitle>, available
-    from <link xlink:href="&suse-onlinedoc;"/>.
+    see the <link
+     xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/book-autoyast.html">
+     <citetitle>&ayguide;</citetitle> for &sls; &productnumber;</link>.
    </para>
 
    <important>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -161,17 +161,12 @@
    <itemizedlist>
     <listitem>
      <para>
-      <link xlink:href="&suse-onlinedoc;&doc-sles;"/>
+      <link xlink:href="https://documentation.suse.com/sles"/>
      </para>
     </listitem>
     <listitem>
      <para>
-      <link xlink:href="&suse-onlinedoc;&doc-ha;"/>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <link xlink:href="&suse-onlinedoc;&doc-geo;"/>
+      <link xlink:href="https://documentation.suse.com/sle-ha"/>
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -484,9 +484,10 @@
   <procedure>
    <step>
     <para>
-     Set up an NFS server with &yast; as described in the &sls;
-     &productnumber; <citetitle>&admin;</citetitle>, chapter <citetitle>Sharing File Systems
-     with NFS</citetitle>. It is available from <link xlink:href="&suse-onlinedoc;"/>.
+     Set up an NFS server with &yast; as described in the
+     <link
+      xlink:href="https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-nfs.html">
+      <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
     </para>
    </step>
    <step>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -416,10 +416,10 @@
    <para>
      Cluster nodes must synchronize to an NTP server outside the cluster.
      Since &productname; 15, chrony is the default implementation of NTP.
-     For more information, see the <citetitle>&admin;</citetitle> for
-     &sls; &productnumber;, chapter <citetitle>Time Synchronization with
-     NTP</citetitle>. It is available from
-     <link xlink:href='http://www.suse.com/documentation/'/>.
+     For more information, see the
+     <link
+     xlink:href='https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-ntp.html'>
+     <citetitle xmlns='http://docbook.org/ns/docbook'>&admin;</citetitle> for &sls; &productnumber;</link>.
     </para>
     <para>
      If nodes are not synchronized, the cluster may not work properly.
@@ -567,10 +567,11 @@
   <listitem>
    <para>
     All cluster nodes on all sites should synchronize to an NTP server outside
-    the cluster. For more information, see the <citetitle>&admin;</citetitle>
-    for &sls; &productnumber;, available at
-    <link xlink:href='http://www.suse.com/documentation/&doc-sles;'/>. Refer to the
-    chapter <citetitle>Time Synchronization with NTP</citetitle>.
+    the cluster. For more information, see the
+    <link
+     xlink:href='https://documentation.suse.com/sles/15-GA/html/SLES-all/cha-ntp.html'>
+     <citetitle xmlns='http://docbook.org/ns/docbook'>&admin;</citetitle>
+     for &sls; &productnumber;</link>.
    </para>
    <para>
     If nodes are not synchronized, log files and cluster reports are very hard


### PR DESCRIPTION
Updating URLs to documentation.suse.com (#125)

Based on the following guidelines:

- avoid entities for URLs (entities for parts of the URL make it harder to
    copy/paste/replace complete URLs, plus they will be resolved during
    translation anyway)
-> this way the URLs are the same in the English versions and translation
    branches and can replaced the same way if needed
- using 15-GA URLs
- use links to html instead of single-html (shorter download times, SEO)
- use descriptive text for links to mention book name
   (in case deeplink is broken, plus better accessibility)

