### PR TITLE
Fix bsc#1158562: avoid phrase (reg. default value)

### DIFF
--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -2264,7 +2264,7 @@ monitor_0     interval=5s timeout=20s</screen>
      <term>Value is <literal>0</literal>:</term>
      <listitem>
       <para>
-       This is the default. The resource will be placed optimally in the
+       The resource will be placed optimally in the
        system. This may mean that it is moved when a <quote>better</quote>
        or less loaded node becomes available. This option is almost
        equivalent to automatic failback, except that the resource may be


### PR DESCRIPTION
### Description

Related to bsc#1158562

Avoid "This is the default value" for failback nodes and resource stickiness.


### Checklist

*Are backports required?*

- [ ] To maintenance/SLEHA12SP4
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
