### PR TITLE
Fix bsc#1158207 add missing service into new step

### DIFF
--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -464,6 +464,12 @@ Report saved in '/root/&exampleuser_plain;-test.tar.bz2'</screen>
        <para>Replace <filename>/etc/hawk/hawk.pem</filename> with the
         certificate that &hawk2; should present.</para>
       </step>
+      <step>
+       <para>
+        Restart the &hawk2; services to reload the new certificate:
+       </para>
+       <screen>&prompt.root;<command>systemctl</command> restart hawk-backend hawk</screen>
+      </step>
      </procedure>
      <para>
       Change ownership of the files to <literal>root:haclient</literal>


### PR DESCRIPTION
### Description

Hawk needs to be restarted with "systemctl restart hawk" to reload the new certificate.

See [bsc#1158207](https://bugzilla.suse.com/show_bug.cgi?id=1158207) for details.


### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLEHA12SP4
- [ ] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1

@gao-yan: could you have a quick look? I guess this would apply to SLEHA12 SP4/SP5 as well, right?