### PR TITLE
Fix bsc#1155609 Explain System Level Concept

### DIFF
--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -37,6 +37,50 @@
  </info>
  <sect1 xml:id="sec-ha-maint-shutdown-node">
   <title>Implications of Taking Down a Cluster Node</title>
+  <para>
+   In &sls; &hasi; 15 SP2, the way how cluster services were started and
+   stopped has been changed. &suse; recommends using the &crmshell;. The
+   old commands with <command>systemctl</command> are still available, but
+   are recommended for experienced users only.
+   For details, refer to the &suse; blog article <link
+    xlink:href="https://www.suse.com/c/suse-high-availability-cluster-services-how-to-stop-start-or-view-the-status/"
+   />.
+  </para>
+  <para>
+   The recommended way of starting, stopping, or viewing the status is:
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term><command>crm cluster start</command></term>
+    <listitem>
+     <para>Starting cluster services on one node</para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>crm cluster stop</command></term>
+    <listitem>
+     <para>Stopping cluster services on one node</para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>crm cluster restart</command></term>
+    <listitem>
+     <para>Restarting cluster services on one node</para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>crm cluster status</command></term>
+    <listitem>
+     <para>Viewing status of the cluster stack on one node</para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <para>
+   Execute the above commands as user &rootuser; or as a user who
+   has the required privileges.
+  </para>
 
   <para>
    When you shut down or reboot a cluster node (or stop the &pace; service on a
@@ -77,7 +121,7 @@
 <screen>&prompt.root;crm -w node standby</screen>
     <para>
      That way, services can migrate off the node without being limited by the
-     shutdown timeout of &pace;.
+     shutdown timeout of &pace; cluster services.
     </para>
    </step>
    <step>
@@ -94,7 +138,7 @@ Node <replaceable>&node2;</replaceable>: standby
    </step>
    <step>
     <para>
-     Stop the &pace; service on that node:
+     Stop the cluster services on that node:
     </para>
 <screen>&prompt.root;crm cluster stop</screen>
    </step>
@@ -117,7 +161,7 @@ Node <replaceable>&node2;</replaceable>: standby
    </step>
    <step>
     <para>
-     Check if the &pace; service has started:
+     Check if the cluster services has started:
     </para>
 <screen>&prompt.root;crm cluster status</screen>
    </step>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -38,8 +38,8 @@
  <sect1 xml:id="sec-ha-maint-shutdown-node">
   <title>Implications of Taking Down a Cluster Node</title>
   <para>
-   In &sls; &hasi; 15 SP2, the way how cluster services were started and
-   stopped has been changed. &suse; recommends using the &crmshell;. The
+   In &sls; &hasi; 15 SP2, the way cluster services were started and
+   stopped has changed. &suse; recommends using the &crmshell;. The
    old commands with <command>systemctl</command> are still available, but
    are recommended for experienced users only.
    For details, refer to the &suse; blog article <link
@@ -47,32 +47,32 @@
    />.
   </para>
   <para>
-   The recommended way of starting, stopping, or viewing the status is:
+   The recommended way to start, stop, or view the status is:
   </para>
 
   <variablelist>
    <varlistentry>
     <term><command>crm cluster start</command></term>
     <listitem>
-     <para>Starting cluster services on one node</para>
+     <para>Start cluster services on one node</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><command>crm cluster stop</command></term>
     <listitem>
-     <para>Stopping cluster services on one node</para>
+     <para>Stop cluster services on one node</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><command>crm cluster restart</command></term>
     <listitem>
-     <para>Restarting cluster services on one node</para>
+     <para>Restart cluster services on one node</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><command>crm cluster status</command></term>
     <listitem>
-     <para>Viewing status of the cluster stack on one node</para>
+     <para>View status of the cluster stack on one node</para>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/xml/ha_yast_cluster.xml
+++ b/xml/ha_yast_cluster.xml
@@ -1027,14 +1027,14 @@ Finished with 1 errors.</screen>
   </sect1>
 
   <sect1 xml:id="sec-ha-installation-start">
-   <title>Bringing the Cluster Online</title>
+   <title>Bringing the Cluster Online Node by Node</title>
    <para>
-    After the initial cluster configuration is done, start the &pace;
-    service on <emphasis>each</emphasis> cluster node to bring the stack
+    After the initial cluster configuration is done, start the cluster
+    services on <emphasis>each</emphasis> cluster node to bring the stack
     online:
    </para>
    <procedure>
-    <title>Starting &pace; and Checking the Status</title>
+    <title>Starting Cluster Services and Checking the Status</title>
     <step>
      <para>
       Log in to an existing node.
@@ -1046,7 +1046,7 @@ Finished with 1 errors.</screen>
      </para>
 <screen>&prompt.root;<command>crm</command> cluster status</screen>
      <para>
-      If not, start &pace; now:
+      If not, start the cluster services now:
      </para>
 <screen>&prompt.root;<command>crm</command> cluster start</screen>
     </step>
@@ -1062,13 +1062,17 @@ Finished with 1 errors.</screen>
       online, the output should be similar to the following:
      </para>
 <screen>&prompt.root;crm status
-Last updated: Thu Jul  3 11:07:10 2014
-Last change: Thu Jul  3 10:58:43 2014
-Current DC: alice (175704363) - partition with quorum
-2 Nodes configured
-0 Resources configured
+Cluster Summary:
+  * Stack: corosync
+  * Current DC: &node1; (version ...) - partition with quorum
+  * Last updated: ...
+  * Last change:  ... by hacluster via crmd on &node2;
+  * 2 nodes configured
+  * 1 resource instance configured
 
-Online: [ alice bob ]</screen>
+Node List:
+  * Online: [ &node1; &node2; ]
+...</screen>
      <para>
       This output indicates that the cluster resource manager is started and
       is ready to manage resources.


### PR DESCRIPTION
### Description

This PR fixes bsc#1155609 and contains the following changes:

* In `ha_maintenance.xml`:
  - Explain the recommended way (crm cluster start|stop|restart|status)
  - Refer to SUSE blog for details

* In ha_yast_cluster.xml`:
  - Amend title ("... at the Node Level")
  - Use "cluster service" instead of mentioning Pacemaker (recommended by Yan)
  - Update output of "crm status"


### Checklist

We are on hold to backport this to SLE15SP0/SP1 untill further feedback from customers.

- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA15SP1


----

@zzhou1 This is a first draft of the above Bugzilla entry. Would you like to review it? I can also create a PDF in case you need it.