### PR TITLE
Bugfix: Skipping Service Packs (bsc#1158534)

### DIFF
--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -575,7 +575,7 @@
     <title>Skipping Service Packs</title>
     <para>
      The easiest upgrade path is consecutively installing all service packs.
-     For the &sle; 15 product line (GA and the following service packs) it is
+     For the &sle; 15 product line (GA and the subsequent service packs) it is
      also supported to skip one service pack when upgrading. For example, upgrading from
      SLE&nbsp;HA&nbsp;15&nbsp;GA to 15&nbsp;SP2 or from SLE&nbsp;HA&nbsp;15&nbsp;SP1
      to 15&nbsp;SP3 is supported.

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -136,8 +136,8 @@
   <para>
    The &hasi; has the same supported upgrade paths as the underlying base system. For a complete
    overview, see the section <link
-   xlink:href=" https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-paths.html#sec-upgrade-paths-supported">
-    <citetitle>Supported Upgrade Paths to &sls; &productnumber;</citetitle></link> in the
+   xlink:href=" https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-paths.html#sec-upgrade-paths-supported"
+   ><citetitle>Supported Upgrade Paths to &sls; &productnumber;</citetitle></link> in the
    <citetitle>&sls; &upguide;</citetitle>.
   </para>
 
@@ -148,8 +148,7 @@
    <listitem>
     <para>
      <emphasis>Cluster rolling upgrades</emphasis> are only supported within the same major
-     release (from the GA of a product version to the next service pack, and from one service pack
-     to the next).
+     release (from one service pack to the next, or from the GA version of a product to SP1).
     </para>
    </listitem>
    <listitem>
@@ -572,11 +571,11 @@
    <note>
     <title>Skipping Service Packs</title>
     <para>
-     Consecutively installing all Service Packs is the easiest upgrade path.
-     For the &sle; 15 product line (GA and the following Service Packs) it is
-     also supported to skip one service pack when upgrading. For example, it is
-     supported to upgrade from SLE&nbsp;HA&nbsp;15&nbsp;GA to 15&nbsp;SP2 or from
-     SLE&nbsp;HA&nbsp;15&nbsp;SP1 to 15&nbsp;SP3.
+     The easiest upgrade path is consecutively installing all service packs.
+     For the &sle; 15 product line (GA and the following service packs) it is
+     also supported to skip one service pack when upgrading. For example, upgrading from
+     SLE&nbsp;HA&nbsp;15&nbsp;GA to 15&nbsp;SP2 or from SLE&nbsp;HA&nbsp;15&nbsp;SP1
+     to 15&nbsp;SP3 is supported.
     </para>
    </note>
   </sect2>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -133,17 +133,28 @@
    migrate to.
   </para>
 
+  <para>
+   The &hasi; has the same supported upgrade paths as the underlying base system. For a complete
+   overview, see the section <link
+   xlink:href=" https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-paths.html#sec-upgrade-paths-supported">
+    <citetitle>Supported Upgrade Paths to &sls; &productnumber;</citetitle></link> in the
+   <citetitle>&sls; &upguide;</citetitle>.
+  </para>
+
+  <para>
+   In addition, the following rules apply, as the &ha; cluster stack offers two methods for
+   upgrading the cluster:</para>
   <itemizedlist>
    <listitem>
     <para>
-     Cluster rolling upgrades are only supported within the same major release (from the
-     GA of a product version to the next service pack, and from one service pack
+     <emphasis>Cluster rolling upgrades</emphasis> are only supported within the same major
+     release (from the GA of a product version to the next service pack, and from one service pack
      to the next).
     </para>
    </listitem>
    <listitem>
     <para>
-     Cluster offline upgrades are required to upgrade from one major release to
+     <emphasis>Cluster offline upgrades</emphasis> are required to upgrade from one major release to
      the next (for example, from SLE&nbsp;HA&nbsp;12 to
      SLE&nbsp;HA&nbsp;15) or from a service pack within one major
      release to the next major release (for example, from
@@ -154,9 +165,9 @@
 
   <para>
    <xref linkend="sec-ha-migration-upgrade-oview" xrefstyle="select:label"/>
-   gives an overview of the supported upgrade paths for
-   SLE&nbsp;HA&nbsp;(Geo). The column <citetitle>For Details</citetitle> lists
-   the specific upgrade documentation you should refer (including also the base
+   list the supported upgrade paths and methods for SLE&nbsp;HA&nbsp;(Geo),
+   moving from one version to the next. The column <citetitle>For Details</citetitle> lists
+   the specific upgrade documentation you should refer to (including also the base
    system and &hageo;). This documentation is available from:</para>
    <itemizedlist>
     <listitem>
@@ -554,6 +565,20 @@
      </tbody>
     </tgroup>
    </informaltable>
+
+   <!--taroth 2020-04-27: the following note is copied from
+    https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP1/xml/sle_update_upgrading.xml,
+    ll. 57-70 and adjusted to the HA product-->
+   <note>
+    <title>Skipping Service Packs</title>
+    <para>
+     Consecutively installing all Service Packs is the easiest upgrade path.
+     For the &sle; 15 product line (GA and the following Service Packs) it is
+     also supported to skip one service pack when upgrading. For example, it is
+     supported to upgrade from SLE&nbsp;HA&nbsp;15&nbsp;GA to 15&nbsp;SP2 or from
+     SLE&nbsp;HA&nbsp;15&nbsp;SP1 to 15&nbsp;SP3.
+    </para>
+   </note>
   </sect2>
 
   <sect2 xml:id="sec-ha-migration-upgrade-require">

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -128,9 +128,9 @@
   <title>Upgrading your Cluster to the Latest Product Version</title>
 
   <para>
-   Which upgrade path is supported, and how to perform the upgrade depends
-   on the current product version and on the target version you want to
-   migrate to.
+   Which upgrade path is supported, and how to perform the upgrade, depends
+   on the current product version as well as on the target version you want
+   to migrate to.
   </para>
 
   <para>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -146,19 +146,22 @@
    upgrading the cluster:</para>
   <itemizedlist>
    <listitem>
-    <para>
-     <emphasis>Cluster rolling upgrades</emphasis> are only supported within the same major
-     release (from one service pack to the next, or from the GA version of a product to SP1).
-    </para>
+    <formalpara>
+     <title><xref linkend="vle-upgrade-rolling"/></title>
+     <para>A cluster rolling upgrade is only supported within the same major release
+      (from one service pack to the next, or from the GA version of a product to SP1).</para>
+    </formalpara>
    </listitem>
    <listitem>
-    <para>
-     <emphasis>Cluster offline upgrades</emphasis> are required to upgrade from one major release to
-     the next (for example, from SLE&nbsp;HA&nbsp;12 to
-     SLE&nbsp;HA&nbsp;15) or from a service pack within one major
-     release to the next major release (for example, from
-     SLE&nbsp;HA&nbsp;12&nbsp;SP3 to SLE&nbsp;HA&nbsp;15).
-    </para>
+    <formalpara>
+     <title><xref linkend="vle-upgrade-offline" xrefstyle="select:label"/></title>
+      <para>A cluster offline upgrade is required to upgrade from one major release to
+      the next (for example, from SLE&nbsp;HA&nbsp;12 to
+      SLE&nbsp;HA&nbsp;15) or from a service pack within one major
+      release to the next major release (for example, from
+      SLE&nbsp;HA&nbsp;12&nbsp;SP3 to SLE&nbsp;HA&nbsp;15).
+     </para>
+    </formalpara>
    </listitem>
   </itemizedlist>
 


### PR DESCRIPTION
### Description

Fix for https://bugzilla.suse.com/show_bug.cgi?id=1158534:  [doc] 5.2.1 Supported Upgrade Paths for SLE HA and SLE HA Geo - skip a service pack - supported? 

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLEHA12SP4
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
