### PR TITLE
Fix bsc#1173007: Clarify vgdisplay

### DIFF
--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -558,8 +558,6 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
       Metadata Sequence No  1
       VG Access             read/write
       VG Status             resizable
-      Clustered             yes
-      Shared                no
       MAX LV                0
       Cur LV                0
       Open LV               0
@@ -572,6 +570,20 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
       Alloc PE / Size       0 / 0
       Free  PE / Size       254 / 1016,00 MB
       VG UUID               UCyWw8-2jqV-enuT-KH4d-NXQI-JhH3-J24anD</screen>
+    </step>
+    <step>
+     <para>
+      Check the shared state of the volume group with the command <command>vgs</command>:
+     </para>
+     <screen>&prompt.root;<command>vgs</command>
+  VG       #PV #LV #SN Attr   VSize     VFree  
+  vgshared   1   1   0 wz--ns 1016.00m  1016.00m</screen>
+     <para>
+      The <literal>Attr</literal> column shows the volume attributes. In this example,
+      the volume group is writable (<literal>w</literal>),
+      resizeable (<literal>z</literal>), the allocation policy is normal (<literal>n</literal>),
+      and it is a shared resource (<literal>s</literal>).
+      See the man page of <command>vgs</command> for details.</para>
     </step>
    </procedure>
    <para>


### PR DESCRIPTION
### Description

In SLE15, we don't use Cluster VG anymore, but instead of Shared VG.

The `vgdisplay` doesn't print this information, but it can be retrieved by the `vgs` command.

bsc#1173007

### Backports

- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
