### PR TITLE
Fix bsc#1174245: Rejoin after cluster rolling upgrade

### DIFF
--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -925,6 +925,11 @@
      supported for a short time frame during the cluster rolling upgrade. Complete
      the cluster rolling upgrade within one week.
     </para>
+    <para>
+     Once all the online nodes are running the upgraded version, it is not
+     possible for any other nodes with the old version to (re-)join without
+     having been upgraded.
+    </para>
    </important>
    <procedure xml:id="pro-ha-migration-rolling-upgrade">
     <title>Performing a Cluster Rolling Upgrade</title>


### PR DESCRIPTION
### Description

Extend important note to clarify what happens when nodes with older versions try to (re)join

See [bsc#1174245](https://bugzilla.suse.com/show_bug.cgi?id=1174245)


### Checklist

- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15SP2
