### PR TITLE
Fix bsc#1174929: Mention NR for corosync-quorumtool

### DIFF
--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -443,6 +443,14 @@ Membership information
                         </para>
                      </listitem>
                   </varlistentry>
+                  <varlistentry>
+                     <term><literal>NR</literal> (not registered)</term>
+                     <listitem>
+                        <para>
+                           Shows that the cluster is not using a quorum device.
+                        </para>
+                     </listitem>
+                  </varlistentry>
                </variablelist>
             </callout>
          </calloutlist>


### PR DESCRIPTION
### Description

Related to bsc#1174929, reported by Dario.

### Backports

- [ ] ~To maintenance/SLEHA12SP4~
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
