### PR TITLE
Rework ACL chapter (bsc#1176035)

### DIFF
--- a/xml/ha_acl.xml
+++ b/xml/ha_acl.xml
@@ -120,13 +120,60 @@
    </itemizedlist>
   </important>
 
-  <para>
-   To use ACLs you need some knowledge about XPath. XPath is a language for
-   selecting nodes in an XML document. Refer to
-   <link xlink:href="http://en.wikipedia.org/wiki/XPath"/> or look into the
-   specification at <link xlink:href="http://www.w3.org/TR/xpath/"/>.
-  </para>
  </sect1>
+
+ <sect1 xml:id="sec-ha-acl-basics">
+  <title>Conceptual Overview</title>
+
+  <para>
+   Access control lists consist of an ordered set of access rules. Each rule
+   allows read or write access or denies access to a part of the cluster
+   configuration. Rules are typically combined to produce a specific role,
+   then users may be assigned to a role that matches their tasks. An ACL
+   role is a set of rules which describe access rights to CIB. A rule
+   consists of the following:
+  </para>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     an access right like <literal>read</literal>, <literal>write</literal>,
+     or <literal>deny</literal>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     a specification where to apply the rule. This specification can be a
+     type, an ID reference, or an XPath expression.
+     XPath is a language for selecting nodes in an XML document. Refer to
+     <link xlink:href="http://en.wikipedia.org/wiki/XPath"/><!-- or look into the
+     specification at <link xlink:href="http://www.w3.org/TR/xpath/"/>-->.
+    </para>
+   </listitem>
+  </itemizedlist>
+
+  <para>
+   Usually, it is convenient to bundle ACLs into roles and assign a specific
+   role to system users (ACL targets). There are these methods to create ACL
+   roles:
+  </para>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     <xref linkend="sec-ha-acl-config-xpath"/>. You need to know the
+     structure of the underlying XML to create ACL rules.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref linkend="sec-ha-acl-config-tag"/>. Create a shorthand syntax and
+     ACL rules to apply to the matched objects.
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect1>
+
  <sect1 xml:id="sec-ha-acl-enable">
   <title>Enabling Use of ACLs in Your Cluster</title>
 
@@ -136,8 +183,8 @@
    command in the &crmsh;:
   </para>
 
-<screen>&prompt.root;<command>crm</command> configure property enable-acl=true</screen>
-    <para>
+  <screen>&prompt.root;<command>crm</command> configure property enable-acl=true</screen>
+  <para>
    Alternatively, use &hawk2; as described in
    <xref linkend="pro-ha-acl-enable-hawk2"/>.
   </para>
@@ -169,476 +216,526 @@
     </para>
    </step>
   </procedure>
-  
+
  </sect1>
- <sect1 xml:id="sec-ha-acl-basics">
-  <title>The Basics of ACLs</title>
 
+ <sect1 xml:id="sec-ha-acl-create-ro-monitor-role">
+  <title>Creating a Read-Only Monitor Role</title>
   <para>
-   Access control lists consist of an ordered set of access rules. Each rule
-   allows read or write access or denies access to a part of the cluster
-   configuration. Rules are typically combined to produce a specific role,
-   then users may be assigned to a role that matches their tasks. An ACL
-   role is a set of rules which describe access rights to CIB. A rule
-   consists of the following:
+   The following subsections describe how to configure read-only access
+   by defining a <systemitem>monitor</systemitem> role either in &hawk2;
+   or &crmshell;.
   </para>
 
-  <itemizedlist>
-   <listitem>
-    <para>
-     an access right like <literal>read</literal>, <literal>write</literal>,
-     or <literal>deny</literal>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     a specification where to apply the rule. This specification can be a
-     type, an ID reference, or an XPath expression.
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <para>
-   Usually, it is convenient to bundle ACLs into roles and assign a specific
-   role to system users (ACL targets). There are two methods to create ACL
-   rules:
-  </para>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-     <xref linkend="sec-ha-acl-config-xpath"/>. You need to know the
-     structure of the underlying XML to create ACL rules.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <xref linkend="sec-ha-acl-config-tag"/>. Create a shorthand syntax and
-     ACL rules to apply to the matched objects.
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <sect2 xml:id="sec-ha-acl-config-xpath">
-   <title>Setting ACL Rules via XPath Expressions</title>
+  <sect2 xml:id="sec-ha-acl-config-hawk2">
+   <title>Creating a Read-Only Monitor Role with &hawk2;</title>
    <para>
-    To manage ACL rules via XPath, you need to know the structure of the
-    underlying XML. Retrieve the structure with the following command that
-    shows your cluster configuration in XML (see
-    <xref linkend="ex-ha-acl-excerpt" xrefstyle="select:label nopage"/>):
+    The following procedures show how to configure read-only access to the
+    cluster configuration by defining a <systemitem>monitor</systemitem> role and
+    assigning it to a user. Alternatively, you can use &crmsh; to do so,
+    as described in <xref linkend="pro-ha-acl-crm"/>.
    </para>
-<screen>&prompt.root;<command>crm</command> configure show xml</screen>
-   <remark>taroth 2014-08-13: filed https://bugzilla.novell.com/show_bug.cgi?id=891695 for a future "Show CIB"
-    option in Hawk</remark>
-   <example xml:id="ex-ha-acl-excerpt">
-    <title>Excerpt of a Cluster Configuration in XML</title>
-<screen>&lt;num_updates="59" 
-      dc-uuid="175704363"
-      crm_feature_set="3.0.9"
-      validate-with="pacemaker-2.0"
-      epoch="96"
-      admin_epoch="0"
-      cib-last-written="Fri Aug  8 13:47:28 2014"
-      have-quorum="1"&gt;
-  &lt;configuration&gt;
-    &lt;crm_config&gt;
-       &lt;cluster_property_set id="cib-bootstrap-options"&gt;
-        &lt;nvpair name="stonith-enabled" value="true" id="cib-bootstrap-options-stonith-enabled"/&gt;
-       [...]
-      &lt;/cluster_property_set&gt;
-    &lt;/crm_config&gt;
-    &lt;nodes&gt;
-      &lt;node id="175704363" uname="alice"/&gt;
-      &lt;node id="175704619" uname="bob"/&gt;
-    &lt;/nodes&gt;
-    &lt;resources&gt; [...]  &lt;/resources&gt;
-    &lt;constraints/&gt;
-    &lt;rsc_defaults&gt; [...] &lt;/rsc_defaults&gt;
-    &lt;op_defaults&gt; [...] &lt;/op_defaults&gt;
-  &lt;configuration&gt;
-&lt;/cib&gt;</screen>
-   </example>
-   <para>
-    With the XPath language you can locate nodes in this XML document. For
-    example, to select the root node (<literal>cib</literal>) use the XPath
-    expression <literal>/cib</literal>. To locate the global cluster
-    configurations, use the XPath expression
-    <literal>/cib/configuration/crm_config</literal>.
-   </para>
-   <para>
-    As an example, <xref linkend="tab-ha-acl-operator"/> shows the
-    parameters (access type and XPath expression) to create an
-    <quote>operator</quote> role. Users with this role can only execute the
-    tasks mentioned in the second column&mdash;they cannot reconfigure
-    any resources (for example, change parameters or operations), nor change
-    the configuration of colocation or ordering constraints.
-   </para>
-   <table xml:id="tab-ha-acl-operator">
-    <title>Operator Role&mdash;Access Types and XPath Expressions</title>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Type
-        </para>
-       </entry>
-       <entry>
-        <para>
-         XPath/Explanation
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         Write
-        </para>
-       </entry>
-       <entry>
-<screen>//crm_config//nvpair[@name='maintenance-mode']</screen>
-        <para>
-         Turn cluster maintenance mode on or off.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         Write
-        </para>
-       </entry>
-       <entry>
-<screen>//op_defaults//nvpair[@name='record-pending']</screen>
-        <para>
-         Choose whether pending operations are recorded.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         Write
-        </para>
-       </entry>
-       <entry>
-<screen>//nodes/node//nvpair[@name='standby']</screen>
-        <para>
-         Set node in online or standby mode.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         Write
-        </para>
-       </entry>
-       <entry>
-<screen>//resources//nvpair[@name='target-role']</screen>
-        <para>
-         Start, stop, promote or demote any resource.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         Write
-        </para>
-       </entry>
-       <entry>
-<screen>//resources//nvpair[@name='maintenance']</screen>
-        <para>
-         Select if a resource should be put to maintenance mode or not.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         Write
-        </para>
-       </entry>
-       <entry>
-<screen>//constraints/rsc_location</screen>
-        <para>
-         Migrate/move resources from one node to another.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         Read
-        </para>
-       </entry>
-       <entry>
-<screen>/cib</screen>
-        <para>
-         View the status of the cluster.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-acl-config-tag">
-   <title>Setting ACL Rules via Abbreviations</title>
-   <para>
-    For users who do not want to deal with the XML structure there is an
-    easier method.
-<!--It is a combination of a tag specifier and/or a
-    reference.-->
-   </para>
-   <para>
-    For example, consider the following XPath:
-   </para>
-<screen>//*[@id="rsc1"]</screen>
-   <para>
-    which locates all the XML nodes with the ID <literal>rsc1</literal>.
-   </para>
-   <para>
-    The abbreviated syntax is written like this:
-   </para>
-<screen>ref:"rsc1"</screen>
-   <para>
-    This also works for constraints. Here is the verbose XPath:
-   </para>
-<screen>//constraints/rsc_location</screen>
-   <para>
-    The abbreviated syntax is written like this:
-   </para>
-<screen>type:"rsc_location"</screen>
-   <para>
-    The abbreviated syntax can be used in &crmsh; and &hawk2;. The CIB
-    daemon knows how to apply the ACL rules to the matching objects.
-   </para>
-  </sect2>
- </sect1>
- 
-  <sect1 xml:id="sec-ha-acl-config-hawk2">
-  <title>Configuring ACLs with &hawk2;</title>
-  <para>
-   The following procedures show how to configure read-only access to the
-   cluster configuration by defining a <literal>monitor</literal> role and
-   assigning it to a user. Alternatively, you can use &crmsh; to do so,
-   as described in <xref linkend="pro-ha-acl-crm"/>.
-  </para>
-
-  <procedure xml:id="pro-ha-acl-hawk2-role">
-   <title>Adding a Monitor Role with &hawk2;</title>
-   <step>
-    <para>
-     Log in to &hawk2;: </para>
-    <screen>https://<replaceable>HAWKSERVER</replaceable>:7630/</screen>
-   </step>
-   <step>
-    <para>
-     In the left navigation bar, select <guimenu>Roles</guimenu>. 
-    </para>
-   </step>
-   <step>
-    <para>
-      Click <guimenu>Create</guimenu>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Enter a unique <guimenu>Role ID</guimenu>, for example,
-     <literal>monitor</literal>.
-    </para>
-   </step>
-   <step>
-    <para>
-      As access <guimenu>Right</guimenu>, select <literal>Read</literal>.
-    </para>
-   </step>
-   <step>
-    <para>
-     As <guimenu>Xpath</guimenu>, enter the XPath expression
-     <literal>/cib</literal>.
-    </para>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="hawk2-acl-role.png" width="100%" format="PNG"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="hawk2-acl-role.png" width="100%" format="PNG"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-   </step>
-   <step>
-    <para>
-      Click <guimenu>Create</guimenu>.
-    </para>
-    <para>
-     This creates a new role with the name <literal>monitor</literal>, sets
-     the <literal>read</literal> rights and applies this to all elements in
-     the CIB by using the XPath expression<literal>/cib</literal>.
-    </para>
-   </step>
-   <step>
-    <para>
-     If necessary, add more rules by clicking the plus icon and specifying
-     the respective parameters.
-    </para>
-   </step>
-   <step>
-    <para>
-     Sort the individual rules by using the arrow up or down buttons.
-    </para>
-   </step>
-  </procedure>
-
-  <procedure xml:id="pro-ha-acl-hawk2-target">
-    <title>Assigning a Role to a Target with &hawk2;</title>
-   <para>
-    To assign the role we created in <xref linkend="pro-ha-acl-hawk2-role"
-    xrefstyle="select:label"/> to a system user (target), proceed as follows:
-   </para>
-   <step>
-    <para>
-     Log in to &hawk2;: </para>
-    <screen>https://<replaceable>HAWKSERVER</replaceable>:7630/</screen>
-   </step>
-   <step>
-    <para>
-     In the left navigation bar, select <guimenu>Targets</guimenu>. 
-    </para>
-   </step>
-   <step>
-    <para>
-     To create a system user (ACL Target), click <guimenu>Create</guimenu> and
-     enter a unique <guimenu>Target ID</guimenu>, for example, <literal>tux</literal>.
-     Make sure this user belongs to the <systemitem
-      class="groupname">haclient</systemitem> group.
-    </para>
-   </step>
-   <step>
-    <para>
-     To assign a role to the target, select one or multiple <guimenu>Roles</guimenu>.
-    </para>
-    <para>
-     In our example, select the <literal>monitor</literal> role you created
-     in <xref linkend="pro-ha-acl-hawk2-role" xrefstyle="select:label"/>.
+   <procedure xml:id="pro-ha-acl-hawk2-role">
+    <title>Adding a Monitor Role with &hawk2;</title>
+    <step>
+     <para>
+      Log in to &hawk2;: </para>
+     <screen>https://<replaceable>HAWKSERVER</replaceable>:7630/</screen>
+    </step>
+    <step>
+     <para>
+      In the left navigation bar, select <guimenu>Roles</guimenu>.
      </para>
-    <informalfigure>
-       <mediaobject>
-        <imageobject role="fo">
-         <imagedata fileref="hawk2-acl-user-assign.png" width="100%" format="PNG"/>
-        </imageobject>
-        <imageobject role="html">
-         <imagedata fileref="hawk2-acl-user-assign.png" width="80%" format="PNG"/>
-        </imageobject>
-       </mediaobject>
-      </informalfigure>
-     </step>
-     <step>
-      <para>
-       Confirm your choice.
-      </para>
-     </step>
+    </step>
+    <step>
+     <para>
+      Click <guimenu>Create</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Enter a unique <guimenu>Role ID</guimenu>, for example,
+      <literal>monitor</literal>.
+     </para>
+    </step>
+    <step>
+     <para>
+      As access <guimenu>Right</guimenu>, select <literal>Read</literal>.
+     </para>
+    </step>
+    <step>
+     <para>
+      As <guimenu>Xpath</guimenu>, enter the XPath expression
+      <literal>/cib</literal>.
+     </para>
+     <informalfigure>
+      <mediaobject>
+       <imageobject role="fo">
+        <imagedata fileref="hawk2-acl-role.png" width="100%" format="PNG"/>
+       </imageobject>
+       <imageobject role="html">
+        <imagedata fileref="hawk2-acl-role.png" width="100%" format="PNG"/>
+       </imageobject>
+      </mediaobject>
+     </informalfigure>
+    </step>
+    <step>
+     <para>
+      Click <guimenu>Create</guimenu>.
+     </para>
+     <para>
+      This creates a new role with the name <literal>monitor</literal>, sets
+      the <literal>read</literal> rights and applies this to all elements in
+      the CIB by using the XPath expression<literal>/cib</literal>.
+     </para>
+    </step>
+    <step>
+     <para>
+      If necessary, add more rules by clicking the plus icon and specifying
+      the respective parameters.
+     </para>
+    </step>
+    <step>
+     <para>
+      Sort the individual rules by using the arrow up or down buttons.
+     </para>
+    </step>
    </procedure>
 
-  <para>
-   To configure access rights for resources or constraints, you can also use
-   the abbreviated syntax as explained in
-   <xref linkend="sec-ha-acl-config-tag"/>.
-  </para>
- </sect1>
-
- <sect1 xml:id="sec-ha-acl-config-crm">
-  <title>Configuring ACLs with &crmsh;</title>
-
-  <para>
-   The following procedure shows how to configure a read-only access to the
-   cluster configuration by defining a <literal>monitor</literal> role and
-   assigning it to a user.
-  </para>
-
-  <procedure xml:id="pro-ha-acl-crm">
-   <title>Adding a Monitor Role and Assigning a User with &crmsh;</title>
-   <step>
+   <procedure xml:id="pro-ha-acl-hawk2-target">
+    <title>Assigning a Role to a Target with &hawk2;</title>
     <para>
-     Log in as &rootuser;.
+     To assign the role we created in <xref linkend="pro-ha-acl-hawk2-role"
+      xrefstyle="select:label"/> to a system user (target), proceed as follows:
     </para>
-   </step>
-   <step>
-    <para>
-     Start the interactive mode of &crmsh;:
-    </para>
-<screen>&prompt.root;<command>crm</command> configure
+    <step>
+     <para>
+      Log in to &hawk2;: </para>
+     <screen>https://<replaceable>HAWKSERVER</replaceable>:7630/</screen>
+    </step>
+    <step>
+     <para>
+      In the left navigation bar, select <guimenu>Targets</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      To create a system user (ACL Target), click <guimenu>Create</guimenu> and
+      enter a unique <guimenu>Target ID</guimenu>, for example, <literal>tux</literal>.
+      Make sure this user belongs to the <systemitem
+       class="groupname">haclient</systemitem> group.
+     </para>
+    </step>
+    <step>
+     <para>
+      To assign a role to the target, select one or multiple <guimenu>Roles</guimenu>.
+     </para>
+     <para>
+      In our example, select the <literal>monitor</literal> role you created
+      in <xref linkend="pro-ha-acl-hawk2-role" xrefstyle="select:label"/>.
+     </para>
+     <informalfigure>
+      <mediaobject>
+       <imageobject role="fo">
+        <imagedata fileref="hawk2-acl-user-assign.png" width="100%" format="PNG"/>
+       </imageobject>
+       <imageobject role="html">
+        <imagedata fileref="hawk2-acl-user-assign.png" width="80%" format="PNG"/>
+       </imageobject>
+      </mediaobject>
+     </informalfigure>
+    </step>
+    <step>
+     <para>
+      Confirm your choice.
+     </para>
+    </step>
+   </procedure>
+   <para>
+    To configure access rights for resources or constraints, you can also use
+    the abbreviated syntax as explained in
+    <xref linkend="sec-ha-acl-config-tag"/>.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-ha-acl-config-crm">
+   <title>Creating a Read-Only Monitor Role with &crmsh;</title>
+   <para>
+    The following procedure shows how to configure a read-only access to the
+    cluster configuration by defining a <literal>monitor</literal> role and
+    assigning it to a user.
+   </para>
+
+   <procedure xml:id="pro-ha-acl-crm">
+    <title>Adding a Monitor Role and Assigning a User with &crmsh;</title>
+    <step>
+     <para>
+      Log in as &rootuser;.
+     </para>
+    </step>
+    <step>
+     <para>
+      Start the interactive mode of &crmsh;:
+     </para>
+     <screen>&prompt.root;<command>crm</command> configure
 &prompt.crm.conf;</screen>
-   </step>
-   <step>
-    <para>
-     Define your ACL role(s):
-    </para>
-    <substeps performance="required">
-     <step>
-      <para>
-       Use the <command>role</command> command to define a new role:
-      </para>
-<screen>&prompt.crm.conf;<command>role</command> monitor read xpath:"/cib"</screen>
-      <para>
-       The previous command creates a new role with the name
-       <literal>monitor</literal>, sets the <literal>read</literal> rights
-       and applies it to all elements in the CIB by using the XPath
-       expression <literal>/cib</literal>. If necessary, you can add more
-       access rights and XPath arguments.
-      </para>
-     </step>
-     <step>
-      <para>
-       Add additional roles as needed.
-      </para>
-     </step>
-    </substeps>
-   </step>
-   <step>
-    <para>
-     Assign your roles to one or multiple ACL targets, which are the
-     corresponding system users. Make sure they belong to the
-     <systemitem class="groupname">haclient</systemitem> group.
-    </para>
-<screen>&prompt.crm.conf;<command>acl_target</command> &exampleuser_plain; monitor</screen>
-   </step>
-   <step>
-    <para>
-     Check your changes:
-    </para>
-<screen>&prompt.crm.conf;<command>show</command></screen>
-   </step>
-   <step>
-    <para>
-     Commit your changes:
-    </para>
-<screen>&prompt.crm.conf;<command>commit</command></screen>
-   </step>
-  </procedure>
+    </step>
+    <step>
+     <para>
+      Define your ACL role(s):
+     </para>
+     <substeps performance="required">
+      <step>
+       <para>
+        Use the <command>role</command> command to define a new role:
+       </para>
+       <screen>&prompt.crm.conf;<command>role</command> monitor read xpath:"/cib"</screen>
+       <para>
+        The previous command creates a new role with the name
+        <literal>monitor</literal>, sets the <literal>read</literal> rights
+        and applies it to all elements in the CIB by using the XPath
+        expression <literal>/cib</literal>. If necessary, you can add more
+        access rights and XPath arguments.
+       </para>
+      </step>
+      <step>
+       <para>
+        Add additional roles as needed.
+       </para>
+      </step>
+     </substeps>
+    </step>
+    <step>
+     <para>
+      Assign your roles to one or multiple ACL targets, which are the
+      corresponding system users. Make sure they belong to the
+      <systemitem class="groupname">haclient</systemitem> group.
+     </para>
+     <screen>&prompt.crm.conf;<command>acl_target</command> &exampleuser_plain; monitor</screen>
+    </step>
+    <step>
+     <para>
+      Check your changes:
+     </para>
+     <screen>&prompt.crm.conf;<command>show</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit your changes:
+     </para>
+     <screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+   </procedure>
 
-  <para>
-   To configure access rights for resources or constraints, you can also use
-   the abbreviated syntax as explained in
-   <xref linkend="sec-ha-acl-config-tag"/>.
-  </para>
- </sect1>
-<!-- taroth 2015-04-29: commenting for now (as agreed with ygao) 
+   <para>
+    To configure access rights for resources or constraints, you can also use
+    the abbreviated syntax as explained in
+    <xref linkend="sec-ha-acl-config-tag"/>.
+   </para>
+   <!-- taroth 2015-04-29: commenting for now (as agreed with ygao)
   as the upstream document is outdated
   (does not reflect the changes mentioned in bsc#921056)
-  
+
   <sect1 id="sec-ha-acl-moreinfo">
   <title>For More Information</title>
 
   <para>
    See <ulink url="http://www.clusterlabs.org/pacemaker/doc/acls.html"/>.
   </para>
- </sect1>-->
+   </sect1>
+-->
+  </sect2>
+ </sect1>
+
+  <sect1 xml:id="sec-ha-acl-rm-user">
+   <title>Removing a User</title>
+   <para>
+    The following subsections describe how to remove an existing user from
+    ACL either in &hawk2; or &crmsh;.
+   </para>
+   <sect2 xml:id="sec-ha-acl-rm-user-hawk2">
+    <title>Removing a User with &hawk2;</title>
+    <para>To remove a user from ACL, proceed as follows:</para>
+    <procedure>
+     <step>
+      <para>
+       Log in to &hawk2;: </para>
+      <screen>https://<replaceable>HAWKSERVER</replaceable>:7630/</screen>
+     </step>
+     <step>
+      <para>
+       In the left navigation bar, select <guimenu>Targets</guimenu>.
+      </para>
+     </step>
+     <step>
+      <para>
+       To remove a system user (ACL target), click the garbage bin icon under
+       the <guimenu>Operations</guimenu> column.
+      </para>
+     </step>
+     <step>
+      <para>
+       Confirm the dialog box.
+      </para>
+     </step>
+    </procedure>
+   </sect2>
+   <sect2 xml:id="sec-ha-acl-rm-user-crmsh">
+     <title>Removing a User with &crmsh;</title>
+     <para> To remove a user from ACL, replace the placeholder
+     <replaceable>USER</replaceable> with the name of the user: </para>
+    <screen>&prompt.root;<command>crm</command> configure delete <replaceable>USERNAME</replaceable></screen>
+    <para>
+     As an alternative, you can use the <command>edit</command> subcommand:
+    </para>
+    <screen>&prompt.root;<command>crm</command> configure edit <replaceable>USERNAME</replaceable></screen>
+   </sect2>
+  </sect1>
+
+  <sect1 xml:id="sec-ha-acl-rm-role">
+   <title>Removing an Existing Role</title>
+   <para>
+    The following subsections describe how to remove an existing role in either &hawk2; or &crmsh;.
+   </para>
+   <note>
+    <title>Deleting Roles with Referenced Users</title>
+    <para>
+     Keep in mind, no user should belong to this role. If there is still a reference to a user in the
+     role, the role cannot be deleted.
+     Delete the references to the users first before you delete the role.
+    </para>
+   </note>
+
+   <sect2 xml:id="sec-ha-acl-rm-role-hawk2">
+    <title>Removing an Existing Role with &hawk2;</title>
+    <para>To remove a role, proceed as follows:</para>
+    <procedure>
+     <step>
+      <para>
+       Log in to &hawk2;: </para>
+      <screen>https://<replaceable>HAWKSERVER</replaceable>:7630/</screen>
+     </step>
+     <step>
+      <para>
+       In the left navigation bar, select <guimenu>Roles</guimenu>.
+      </para>
+     </step>
+     <step>
+      <para>
+       To remove a role, click the garbage bin icon under
+       the <guimenu>Operations</guimenu> column.
+      </para>
+     </step>
+     <step>
+      <para>
+       Confirm the dialog box. If an error message appears, make sure your
+       role is <quote>empty</quote> and does not reference users.
+      </para>
+     </step>
+    </procedure>
+   </sect2>
+   <sect2 xml:id="sec-ha-acl-rm-role-crmsh">
+    <title>Removing an Existing Role with &crmsh;</title>
+    <para>
+    To remove an existing role, replace the placeholder <replaceable>ROLE</replaceable> with the name
+    of the role:
+   </para>
+   <screen>&prompt.root;<command>crm</command> configure delete <replaceable>ROLE</replaceable></screen>
+   </sect2>
+  </sect1>
+
+ <sect1 xml:id="sec-ha-acl-config-xpath">
+  <title>Setting ACL Rules via XPath Expressions</title>
+  <para>
+   To manage ACL rules via XPath, you need to know the structure of the
+   underlying XML. Retrieve the structure with the following command that
+   shows your cluster configuration in XML (see
+   <xref linkend="ex-ha-acl-excerpt" xrefstyle="select:label nopage"/>):
+  </para>
+  <screen>&prompt.root;<command>crm</command> configure show xml</screen>
+  <remark>taroth 2014-08-13: filed https://bugzilla.novell.com/show_bug.cgi?id=891695 for a future "Show CIB"
+   option in Hawk</remark>
+  <example xml:id="ex-ha-acl-excerpt">
+   <title>Excerpt of a Cluster Configuration in XML</title>
+   <screen>&lt;cib>
+  &lt;!-- ... -->
+  &lt;configuration>
+    &lt;crm_config>
+       &lt;cluster_property_set id="cib-bootstrap-options">
+        &lt;nvpair name="stonith-enabled" value="true" id="cib-bootstrap-options-stonith-enabled"/>
+       [...]
+      &lt;/cluster_property_set>
+    &lt;/crm_config>
+    &lt;nodes>
+      &lt;node id="175704363" uname="alice"/>
+      &lt;node id="175704619" uname="bob"/>
+    &lt;/nodes>
+    &lt;resources> [...]  &lt;/resources>
+    &lt;constraints/>
+    &lt;rsc_defaults> [...] &lt;/rsc_defaults>
+    &lt;op_defaults> [...] &lt;/op_defaults>
+  &lt;configuration>
+&lt;/cib></screen>
+  </example>
+  <para>
+   With the XPath language you can locate nodes in this XML document. For
+   example, to select the root node (<literal>cib</literal>) use the XPath
+   expression <literal>/cib</literal>. To locate the global cluster
+   configurations, use the XPath expression
+   <literal>/cib/configuration/crm_config</literal>.
+  </para>
+  <para>
+   As an example, <xref linkend="tab-ha-acl-operator"/> shows the
+   parameters (access type and XPath expression) to create an
+   <quote>operator</quote> role. Users with this role can only execute the
+   tasks mentioned in the second column&mdash;they cannot reconfigure
+   any resources (for example, change parameters or operations), nor change
+   the configuration of colocation or ordering constraints.
+  </para>
+  <table xml:id="tab-ha-acl-operator">
+   <title>Operator Role&mdash;Access Types and XPath Expressions</title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>
+       <para>
+        Type
+       </para>
+      </entry>
+      <entry>
+       <para>
+        XPath/Explanation
+       </para>
+      </entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>
+       <para>
+        Write
+       </para>
+      </entry>
+      <entry>
+       <screen>//crm_config//nvpair[@name='maintenance-mode']</screen>
+       <para>
+        Turn cluster maintenance mode on or off.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Write
+       </para>
+      </entry>
+      <entry>
+       <screen>//op_defaults//nvpair[@name='record-pending']</screen>
+       <para>
+        Choose whether pending operations are recorded.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Write
+       </para>
+      </entry>
+      <entry>
+       <screen>//nodes/node//nvpair[@name='standby']</screen>
+       <para>
+        Set node in online or standby mode.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Write
+       </para>
+      </entry>
+      <entry>
+       <screen>//resources//nvpair[@name='target-role']</screen>
+       <para>
+        Start, stop, promote or demote any resource.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Write
+       </para>
+      </entry>
+      <entry>
+       <screen>//resources//nvpair[@name='maintenance']</screen>
+       <para>
+        Select if a resource should be put to maintenance mode or not.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Write
+       </para>
+      </entry>
+      <entry>
+       <screen>//constraints/rsc_location</screen>
+       <para>
+        Migrate/move resources from one node to another.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Read
+       </para>
+      </entry>
+      <entry>
+       <screen>/cib</screen>
+       <para>
+        View the status of the cluster.
+       </para>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+ </sect1>
+
+ <sect1 xml:id="sec-ha-acl-config-tag">
+  <title>Setting ACL Rules via Abbreviations</title>
+  <para>
+   For users who do not want to deal with the XML structure there is an
+   easier method.
+   <!--It is a combination of a tag specifier and/or a
+    reference.-->
+  </para>
+  <para>
+   For example, consider the following XPath:
+  </para>
+  <screen>//*[@id="rsc1"]</screen>
+  <para>
+   which locates all the XML nodes with the ID <literal>rsc1</literal>.
+  </para>
+  <para>
+   The abbreviated syntax is written like this:
+  </para>
+  <screen>ref:"rsc1"</screen>
+  <para>
+   This also works for constraints. Here is the verbose XPath:
+  </para>
+  <screen>//constraints/rsc_location</screen>
+  <para>
+   The abbreviated syntax is written like this:
+  </para>
+  <screen>type:"rsc_location"</screen>
+  <para>
+   The abbreviated syntax can be used in &crmsh; and &hawk2;. The CIB
+   daemon knows how to apply the ACL rules to the matching objects.
+  </para>
+ </sect1>
 </chapter>


### PR DESCRIPTION
### Description

This PR fixes bsc#1176035 and contains:

* Move section ID=sec-ha-acl-enable after Conceptual Overview
* Rename titles:
  - ID=`sec-ha-acl-basics`:
    The Basics of ACLs -> Conceptual Overview
  - ID=`sec-ha-acl-config-hawk2`:
    Configuring ACLs with &hawk2; -> Creating a Read-Only Monitor Role with &hawk2;
  - ID=`sec-ha-acl-config-crm`:
    Configuring ACLs with &crmsh; -> Creating a Read-Only Monitor Role with &crmsh;
* Move sect2 (ID=`sec-ha-acl-config-xpath`) to the end and create a sect1
* Move sect2 (ID=`sec-ha-acl-config-tag`) to the end and create a sect1
* Add two new sections:
  - `sec-ha-acl-rm-user`: Removing a User
  - `sec-ha-acl-rm-role`: Removing an Existing Role


### Backports?

- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15SP2
