### PR TITLE
Merge two procedures into one

### DIFF
--- a/xml/ha_yast_cluster.xml
+++ b/xml/ha_yast_cluster.xml
@@ -876,32 +876,14 @@ Finished with 1 errors.</screen>
     configure and use the conntrack tools. This requires the following basic
     steps:
    </para>
-   <procedure>
-    <step>
-     <para>
-      <xref linkend="pro-ha-installation-setup-conntrackd" xrefstyle="select:title"/>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Configuring a resource for
-      <systemitem class="daemon">conntrackd</systemitem> (class:
-      <literal>ocf</literal>, provider: <literal>heartbeat</literal>). If
-      you use &hawk2; to add the resource, use the default values proposed
-      by &hawk2;.
-     </para>
-    </step>
-   </procedure>
-   <para>
-    After having configured the conntrack tools, you can use them for &lvs;,
-    see <xref linkend="cha-ha-lb" xrefstyle="select:title"/>.
-   </para>
+
 <!--from fate#311872: It supports the only FTFW syncing mode now.-->
    <procedure xml:id="pro-ha-installation-setup-conntrackd">
     <title>Configuring the <systemitem class="resource">conntrackd</systemitem> with &yast;</title>
     <para>
      Use the &yast; cluster module to configure the user space
-     <systemitem class="daemon">conntrackd</systemitem>. It needs a
+     <systemitem class="daemon">conntrackd</systemitem> (see <xref
+      linkend="fig-ha-installation-setup-conntrackd"/>).  It needs a
      dedicated network interface that is not used for other communication
      channels. The daemon can be started via a resource agent afterward.
     </para>
@@ -909,16 +891,6 @@ Finished with 1 errors.</screen>
      <para>
       Start the &yast; cluster module and switch to the <guimenu>Configure
       conntrackd</guimenu> category.
-     </para>
-    </step>
-    <step>
-     <para>
-      Select a <guimenu>Dedicated Interface</guimenu> for synchronizing the
-      connection status. The IPv4 address of the selected interface is
-      automatically detected and shown in &yast;. It must already be
-      configured and it must support multicast.
-<!--taroth 2011-11-09: for the records, this has nothing to do with the
-       corosync conf-->
      </para>
     </step>
     <step>
@@ -954,8 +926,18 @@ Finished with 1 errors.</screen>
       proceed with <xref linkend="sec-ha-installation-setup-services"/>.
      </para>
     </step>
+    <step>
+     <para>
+      Select a <guimenu>Dedicated Interface</guimenu> for synchronizing the
+      connection status. The IPv4 address of the selected interface is
+      automatically detected and shown in &yast;. It must already be
+      configured and it must support multicast.
+      <!--taroth 2011-11-09: for the records, this has nothing to do with the
+       corosync conf-->
+     </para>
+    </step>
    </procedure>
-   <figure>
+   <figure xml:id="fig-ha-installation-setup-conntrackd">
     <title>&yast; Cluster&mdash;<systemitem class="resource">conntrackd</systemitem></title>
     <mediaobject>
      <imageobject role="fo">
@@ -966,6 +948,10 @@ Finished with 1 errors.</screen>
      </imageobject>
     </mediaobject>
    </figure>
+   <para>
+    After having configured the conntrack tools, you can use them for &lvs;,
+    see <xref linkend="cha-ha-lb" xrefstyle="select:title"/>.
+   </para>
   </sect1>
 
   <sect1 xml:id="sec-ha-installation-setup-services">


### PR DESCRIPTION
### Description

In section "Synchronizing Connection Status Between Cluster Nodes" (ID=sec-ha-installation-setup-conntrackd) we have two procedures. However, that doesn't work much as it just confuses readers. 

To clarify that, we should merge these two procedures into one.

Related to bsc#1179006


### Checklist


- [ ] To maintenance/SLEHA12SP4 (if possible)
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15SP2
