### PR TITLE
Fix #1179194: Add missing path & verify step

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -402,9 +402,11 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
   <para>
    <xref linkend="tab-ha-storage-protect-watchdog-drivers" xrefstyle="select:label"/>
    lists the most commonly used watchdog drivers. If your hardware is not listed there,
-   the directory
+   the directories
    <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/watchdog</filename>
-   gives you a list of choices, too. Alternatively, ask your hardware or
+   or
+   <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/ipmi</filename>
+   give you a list of choices, too. Alternatively, ask your hardware or
    system vendor for details on system specific watchdog configuration.
    </para>
 
@@ -477,6 +479,14 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
     <step>
      <para>Test whether the watchdog module is loaded correctly:</para>
      <screen>&prompt.root;<command>lsmod</command> | <command>grep</command> dog</screen>
+    </step>
+    <step>
+     <para>Verify if the watchdog device is available:</para>
+     <screen>&prompt.root;<command>ls -l</command> /dev/watchdog</screen>
+     <para>
+      If your watchdog device is not available, check the module name and options.
+      Maybe use another driver.
+     </para>
     </step>
    </procedure>
   </sect2>


### PR DESCRIPTION
### Description

It seems, watchdog drivers can also be found in a different directory `/lib/modules/<version>/kernel/drivers/char/ipmi/`).
=> Add dir into the floating text

Add verifying step.

See bsc#1179194

### Backports

- [x] To maintenance/SLEHA12SP4
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
