### PR TITLE
Fix #1179220: Command "show" -> "show changed"

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -1097,7 +1097,7 @@ Illegal request, Invalid opcode</screen>
 &prompt.crm.conf;<command>colocation</command> col-ext4-with-sg-persist Mandatory: ext4 ms-sg:Master</screen>
     </step>
     <step>
-     <para> Check all your changes with the <command>show</command> command.
+     <para> Check all your changes with the <command>show changed</command> command.
      </para>
     </step>
     <step>


### PR DESCRIPTION
### Description

Configuring an sg_persist Resource" step "6. Check all your changes with the show command."
"show" should be "show changed";  otherwise you'll see the whole configuration.

### Backports

- [x] To maintenance/SLEHA12SP4
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1
