### PR TITLE
Clarify conflicting kernel modules

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -481,11 +481,24 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
      <screen>&prompt.root;<command>lsmod</command> | <command>grep</command> dog</screen>
     </step>
     <step>
-     <para>Verify if the watchdog device is available:</para>
-     <screen>&prompt.root;<command>ls -l</command> /dev/watchdog</screen>
+     <para>Verify if the watchdog device is available and works:</para>
+     <screen>&prompt.root;<command>ls -l</command> /dev/watchdog*
+&prompt.root;<command>sbd</command> query-watchdog</screen>
+     <para> If your watchdog device is not available, stop here and check the
+      module name and options. Maybe use another driver. </para>
+    </step>
+    <step>
      <para>
-      If your watchdog device is not available, check the module name and options.
-      Maybe use another driver.
+      Verify if the watchdog device works:
+     </para>
+     <screen>&prompt.root;<command>sbd</command> -d <replaceable>WATCHDOC_DEVICE</replaceable> test-watchdog</screen>
+    </step>
+    <step>
+     <para>
+      Reboot your machine to make sure there are no conflicting kernel modules. For example,
+      if you find the message <literal>cannot register ...</literal> in your log, this would indicate
+      such conflicting modules. To ignore such modules, refer to <link
+       xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-mod.html#sec-mod-modprobe-blacklist"/>.
      </para>
     </step>
    </procedure>


### PR DESCRIPTION
### Description

Addition for bsc#1179194

Clarifiy conflicting kernel modules.


### Checklist

- [ ] To maintenance/SLEHA12SP4
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15SP2
