### PR TITLE
Fix bsc#1121875: when bindnetaddr is not required

### DIFF
--- a/xml/ha_yast_cluster.xml
+++ b/xml/ha_yast_cluster.xml
@@ -65,6 +65,10 @@
       <systemitem>bindnetaddr</systemitem> to
       <literal>192.168.5.64</literal>.
      </para>
+     <para> If <systemitem>nodelist</systemitem> with
+       <systemitem>ringX_addr</systemitem> is explicitly configured in
+       <filename>/etc/corosync/corosync.conf</filename>,
+       <systemitem>bindnetaddr</systemitem> is not strictly required. </para>
      <note>
       <title>Network address for all nodes</title>
       <para>


### PR DESCRIPTION
### Description

Mention when the parameter `bindnetaddr` is not strictly required.

### Checklist

- [ ] To maintenance/SLEHA12SP4
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA15SP1

@gao-yan
I've added your small sentence into the "Bind network address" at http://docserv.suse.de/documents/SLE-HA_15_SP3/SLE-HA-guide/html/cha-ha-ycluster.html#sec-ha-installation-terms
I've considered other location, but haven't found a better one.

Would that be appropriate location?
