### PR TITLE
Fix bsc#1184502: use -w for watchdog device

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -491,7 +491,7 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
      <para>
       Verify if the watchdog device works:
      </para>
-     <screen>&prompt.root;<command>sbd</command> -d <replaceable>WATCHDOC_DEVICE</replaceable> test-watchdog</screen>
+     <screen>&prompt.root;<command>sbd</command> -w <replaceable>WATCHDOG_DEVICE</replaceable> test-watchdog</screen>
     </step>
     <step>
      <para>


### PR DESCRIPTION
### Description

* Use `-w` option instead of `-d`
* Fix typo in replaceable, should be `WATCHDOG_DEVICE` instead of `WATCHDOC_DEVICE`

### Backports

- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4
