### PR TITLE
Install missing corosync-qdevice

### DIFF
--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -260,8 +260,15 @@
          (&node1; and &node2;) and the &qnet; server (&node3;).
       </para>
       <procedure>
-         <remark>toms 2020-05-11: Is step 1 and step 2 really needed? Can I just
+         <remark>toms 2020-05-11: Is step 2 and step 3 really needed? Can I just
          jump to step 3?</remark>
+         <step>
+            <para>
+               On all nodes, make sure you have installed the package
+               <package>corosync-qdevice</package>:
+            </para>
+            <screen>&prompt.root;<command>zypper</command> install corosync-qdevice</screen>
+         </step>
          <step>
             <para>
                On &node1;, initialize your cluster:


### PR DESCRIPTION
### Description
Clients need to install the `corosync-qdevice` package first.

Jira: DOCTEAM-63
Bugzilla: bsc#1183954



### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] ~To maintenance/SLEHA12SP5~
- [ ] ~To maintenance/SLEHA12SP4~
