### PR TITLE
delete ocfs2 acl mount option

### DIFF
--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -604,8 +604,7 @@
      the cluster:
     </para>
 <screen>&prompt.crm.conf;<command>primitive</command> ocfs2-1 ocf:heartbeat:Filesystem \
-  params device="/dev/sdb1" directory="/mnt/shared" \
-  fstype="ocfs2" options="acl" \
+  params device="/dev/sdb1" directory="/mnt/shared" fstype="ocfs2" \
   op monitor interval="20" timeout="40" \
   op start timeout="60" op stop timeout="60" \
   meta target-role="Started"</screen>


### PR DESCRIPTION
### Description
https://bugzilla.suse.com/show_bug.cgi?id=1178336, remove acl mount option

### Backports
No backports, 15 SP3 only.
