### PR TITLE
Fix bsc#995663: Mention locking_type for LVM

### DIFF
--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -111,6 +111,15 @@
    <procedure>
     <step>
      <para>
+      Check if the locking type of LVM2 is cluster-aware. The keyword
+     <literal>locking_type</literal> in
+     <filename>/etc/lvm/lvm.conf</filename> must contain the value
+     <literal>3</literal> (the default is <literal>1</literal>).
+      Copy the configuration to all nodes, if necessary.
+     </para>
+    </step>
+    <step>
+     <para>
       Create an LVM volume group and replace <filename>/dev/sdb<replaceable>X</replaceable></filename>
       with your corresponding device for LVM:</para>
      <screen>&prompt.root;<command>pvcreate</command> /dev/sdb<replaceable>X</replaceable></screen>


### PR DESCRIPTION
### Description

By default, the locking_type set in lvm.conf on SLES 12 SP1 is "1" or file  locking.  SLES 11 SP4 shows "3" as the default; cluster-aware locking.

Add this detail as a first step in "Creating an LVM Device" of the NFS Quick Start Guide.

---

From Garret in [bsc#995663](https://bugzilla.suse.com/show_bug.cgi?id=995663#c2):

> Looks like locking_type was removed from LVM2 in September 2019, I'm thinking this was a major change added right before SP2 was released.
> 
> e.g. The RPM changelog on SLES15 SP2 shows that clvm support was dropped.
>
> sles15sp2:~ # rpm -q --changelog lvm2
> [...]
> * Mon Sep 02 2019 heming.zhao
>    - Update to LVM2.2.03.05
>    - To drop lvm2-clvm and lvm2-cmirrord rpms (jsc#PM-1324)
> [...]
> I checked the packages on the SCC and found that lvm2-clvm is shipped with SLES15 SP0 and SP1, but not with SP2.
>
> On SLES15 SP1, the default locking_type is set to 1 even after installing the lvm2-clvm package.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [ ] ~To maintenance/SLEHA15SP2~ lvm2-clvm is not shipped
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4
