### PR TITLE
Fix bsc#1183651: Replace pingd RA -> ping

### DIFF
--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -1275,14 +1275,17 @@ hostname (string): Hostname
     -->
 <screen>&prompt.crm.conf;<command>location</command> loc-fs1 fs1 100: &node1;</screen>
     <para>
-     Another example is a location with pingd:
+     Another example is a location with ping:
     </para>
-<screen>&prompt.crm.conf;<command>primitive</command> pingd pingd \
-    params name=pingd dampen=5s multiplier=100 host_list="r1 r2"
+<screen>&prompt.crm.conf;<command>primitive</command> ping ping \
+    params name=ping dampen=5s multiplier=100 host_list="r1 r2"
+&prompt.crm.conf;<command>clone</command> cl-ping ping meta interleave=true
 &prompt.crm.conf;<command>location</command> loc-node_pref internal_www \
     rule 50: #uname eq &node1; \
-    rule pingd: defined pingd</screen>
+    rule ping: defined ping</screen>
     <para>
+     The parameter <parameter>host_list</parameter> is a space-separated list
+     of hosts to ping and count.
      Another use case for location constraints are grouping primitives as a
      <emphasis>resource set</emphasis>. This can be useful if several
      resources depend on, for example, a ping attribute for network


### PR DESCRIPTION
### Description

Deprecate "pingd" resource agent in favor of "ping"

@gao-yan Yan, this is a naive implementation (just replaced `pingd` -> `ping`). Probably this isn't enough. The glossary item is disabled and won't be shown in the output.

Would you mind to have a quick look? :slightly_smiling_face: 

### Backports

- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4
