### PR TITLE
Add 32 cluster node limit

### DIFF
--- a/xml/ha_requirements.xml
+++ b/xml/ha_requirements.xml
@@ -227,6 +227,9 @@
      <para>For clusters with more than two nodes, it is strongly recommended to use
        an odd number of cluster nodes to have quorum. For more information
        about quorum, see <xref linkend="sec-ha-config-basics-global"/>.
+       A regular cluster may contain up to 32 nodes. With the &pmremote;
+       service, &ha; clusters can be extended to include additional nodes
+       beyond this limit. See &pcmkremquick; for more details.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
### Description
Mention the 32 cluster node limit. Add a reference to pacemaker_remote service to avoid this limit.

Fixes DOCTEAM-27 / bsc#1183355


### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] ~To maintenance/SLEHA12SP5~
- [ ] ~To maintenance/SLEHA12SP4~
