### PR TITLE
Describe priority fencing delays

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -809,17 +809,51 @@ Timeout (msgwait)  : 10
      </callout>
    </calloutlist>
   </step>
-  <step>
-   <para>For a two-node cluster, decide if you want predictable or random delays. For
-   other cluster setups you do not need to set this parameter.</para>
+  <step xml:id="st-ha-storage-protect-fencing-static-random">
+   <para>
+    For a two-node cluster, in case of split-brain, there will be fencing issued from
+    each node to the other as expected. To prevent both nodes from being reset at practically
+    the same time, it is recommended to apply the following fencing
+    delays to help one of the nodes, or even the preferred node, win the fencing match.
+    For clusters with more than two nodes, you do not need to apply these delays.
+   </para>
    <variablelist>
+    <varlistentry>
+     <term>Priority fencing delay</term>
+     <listitem>
+       <para>
+        The <literal>priority-fencing-delay</literal> cluster property is disabled by
+        default. By configuring a delay value, if the other node is lost and it has
+        the higher total resource priority, the fencing targeting it will be delayed
+        for the specified amount of time. This means that in case of split-brain,
+        the more important node wins the fencing match .
+      </para>
+      <para>
+        Resources that matter can be configured with priority meta attribute. On
+        calculation, the priority values of the resources or instances that are running
+        on each node are summed up to be accounted. A promoted resource instance takes the
+        configured base priority plus one, so that it receives a higher value than any
+        unpromoted instance.
+      </para>
+      <screen>&prompt.root;<command>crm</command> configure property priority-fencing-delay=30</screen>
+       <para>
+        Even if <literal>priority-fencing-delay</literal> is used, we still
+        recommend also using <literal>pcmk_delay_base</literal> or
+        <literal>pcmk_delay_max</literal> as described below to address any
+        situations where the nodes happen to have equal priority.
+        The value of <literal>priority-fencing-delay</literal> should be significantly
+        greater than the maximum of <literal>pcmk_delay_base</literal> / <literal>pcmk_delay_max</literal>, 
+        and preferably twice the maximum.
+       </para>
+     </listitem>
+    </varlistentry>
     <varlistentry>
      <term>Predictable static delays</term>
      <listitem>
       <para>This parameter enables a static delay before executing &stonith; actions.
       It ensures that the nodes do not fence each other if separate fencing resources
       and different delay values are being used. The targeted node will
-      loose in a <quote>fencing race</quote>.
+      loose in a fencing match.
       The parameter can be used to <quote>mark</quote> a specific node to survive
       in case of a split brain scenario in a two-node cluster.
       To make this succeed, it is essential to create two primitive &stonith;


### PR DESCRIPTION
### Description

With 12 SP4/5 and 15 SP1/2 we got a great improvement "priority fencing". It goes beyond "static fencing delay"

The priority fencing delay is applied in case:

 * A node is lost and should be fenced
 * The node has the highest node priority
 * We don’t have the majority of the nodes in our cluster partition


Fixes DOCTEAM-81 / bsc#1180922

It will appear in [Procedure 11.7: _Configuring the cluster to use SBD_](https://susedoc.github.io/doc-sleha/main/single-html/SLE-HA-guide/#pro-ha-storage-protect-fencing)

### Backports

- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4

---

![priority-fencing-delays](https://user-images.githubusercontent.com/1312925/117328717-3014e280-ae94-11eb-8b29-e3ca70c4f605.png)
