### PR TITLE
Fix URLs

### DIFF
--- a/xml/article_pacemaker_remote.xml
+++ b/xml/article_pacemaker_remote.xml
@@ -521,7 +521,7 @@ Full list of resources:
     <step>
      <para>Create a KVM guest on <systemitem class="domainname"
       >&node1;</systemitem>. For details, see the <link
-       xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-kvm-inst.html">
+       xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-kvm-inst.html">
        <citetitle>&virtual;</citetitle> for &sls; &productnumber;</link>.
      </para>
     </step>
@@ -763,10 +763,10 @@ Failed Actions:
 <title>For more information</title>
  <para>
   More documentation for this product is available at
-  <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
+  <link xlink:href="https://documentation.suse.com/sle-ha/"/>.
   For further configuration and administration tasks, see the comprehensive
   <link
-   xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/book-sleha-guide.html">
+   xlink:href="https://documentation.suse.com/sle-ha/html/SLE-HA-all/book-sleha-guide.html">
    <citetitle>&admin;</citetitle></link>.
  </para>
  <para>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -21,13 +21,13 @@
  <para>
   Find the support statement for &productname; and general information about
   technology previews below. For details about the product lifecycle, see the
-  <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-background.html">
+  <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-upgrade-background.html">
   <citetitle>&upguide;</citetitle> for &sls; &productnumber;</link>.
  </para>
  <para>
   If you are entitled to support, find details how to collect information
   for a support ticket in the <link
-   xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-adm-support.html">
+   xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-adm-support.html">
    <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
  </para>
 

--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -37,7 +37,7 @@
      our customers and the kind of setup that is needed here)?</remark>
     More information on how to set up DNS, including dynamic update of zone
     data, can be found in the <link
-     xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-dns.html">
+     xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-dns.html">
      <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
    </para>
   </listitem>
@@ -51,7 +51,7 @@
    <para>
     For more information, see the <command>dnssec-keygen</command> man page or the
     <link
-     xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-dns.html#sec-dns-tsig">
+     xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-dns.html#sec-dns-tsig">
      <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
    </para>
   </listitem>

--- a/xml/geo_more_i.xml
+++ b/xml/geo_more_i.xml
@@ -15,7 +15,7 @@
     <para>
      More documentation for this product is available at
      <link
-      xlink:href="https://documentation.suse.com/sle-ha/15-SP2"/>.
+      xlink:href="https://documentation.suse.com/sle-ha/"/>.
      For example, the <citetitle>&geoquick;</citetitle> guides you through
      the basic setup of a &geo; cluster, using the &geo; bootstrap scripts
      provided by the <systemitem xmlns='http://docbook.org/ns/docbook'

--- a/xml/ha_install.xml
+++ b/xml/ha_install.xml
@@ -62,7 +62,7 @@
    <para>
     For detailed instructions on how to use &ay; in various scenarios,
     see the <link
-     xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/book-autoyast.html">
+     xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-autoyast.html">
      <citetitle>&ayguide;</citetitle> for &sls; &productnumber;</link>.
    </para>
 

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -136,7 +136,7 @@
   <para>
    The &hasi; has the same supported upgrade paths as the underlying base system. For a complete
    overview, see the section <link
-   xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-upgrade-paths.html#sec-upgrade-paths-supported"
+   xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-upgrade-paths.html#sec-upgrade-paths-supported"
    ><citetitle>Supported Upgrade Paths to &sls; &productnumber;</citetitle></link> in the
    <citetitle>&sls; &upguide;</citetitle>.
   </para>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -486,7 +486,7 @@
     <para>
      Set up an NFS server with &yast; as described in the
      <link
-      xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-nfs.html">
+      xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-nfs.html">
       <citetitle>&admin;</citetitle> for &sls; &productnumber;</link>.
     </para>
    </step>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -418,7 +418,7 @@
      Since &productname; 15, chrony is the default implementation of NTP.
      For more information, see the
      <link
-     xlink:href='https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-ntp.html'>
+     xlink:href='https://documentation.suse.com/sles/html/SLES-all/cha-ntp.html'>
      <citetitle xmlns='http://docbook.org/ns/docbook'>&admin;</citetitle> for &sls; &productnumber;</link>.
     </para>
     <para>
@@ -569,7 +569,7 @@
     All cluster nodes on all sites should synchronize to an NTP server outside
     the cluster. For more information, see the
     <link
-     xlink:href='https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-ntp.html'>
+     xlink:href='https://documentation.suse.com/sles/html/SLES-all/cha-ntp.html'>
      <citetitle xmlns='http://docbook.org/ns/docbook'>&admin;</citetitle>
      for &sls; &productnumber;</link>.
    </para>


### PR DESCRIPTION
### Description

Remove SP-specific info from links to documentation.suse.com.

### Backports

No backports required.