### PR TITLE
Fix DOCTEAM-207: Use Mandatoryi/inf consistently

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -520,7 +520,7 @@ include /etc/drbd.d/*.res;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>order</command> o-drbd_before_nfs Mandatory: \
   ms-drbd_nfs:promote g-nfs:start
-&prompt.crm.conf;<command>colocation</command> col-nfs_on_drbd Mandatory: \
+&prompt.crm.conf;<command>colocation</command> col-nfs_on_drbd inf: \
   g-nfs ms-drbd_nfs:Master</screen>
     </listitem>
     <listitem>
@@ -584,7 +584,7 @@ include /etc/drbd.d/*.res;</screen>
       </para>
 <screen>&prompt.crm.conf;<command>order</command> o-root_before_nfs Mandatory: \
   cl-exportfs_root g-nfs:start
-&prompt.crm.conf;<command>colocation</command> c-nfs_on_root Mandatory: \
+&prompt.crm.conf;<command>colocation</command> c-nfs_on_root inf: \
   g-nfs cl-exportfs_root
 &prompt.crm.conf;<command>commit</command></screen>
       <para>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -1934,7 +1934,7 @@ monitor_0     interval=5s timeout=20s</screen>
       </para>
 <screen>&prompt.crm.conf;<command>primitive</command> vip1 ocf:heartbeat:IPaddr2 params ip=&subnetI;.5
 &prompt.crm.conf;<command>primitive</command> vip2 ocf:heartbeat:IPaddr2 params ip=&subnetI;.6
-&prompt.crm.conf;<command>location</command> loc-&node1; { vip1 vip2 } Mandatory: &node1; </screen>
+&prompt.crm.conf;<command>location</command> loc-&node1; { vip1 vip2 } inf: &node1; </screen>
      </example>
      <para>
       If you want to use resource sets to replace a configuration of

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -1300,14 +1300,14 @@ hostname (string): Hostname
     </para>
 <screen>&prompt.crm.conf;<command>primitive</command> vip1 ocf:heartbeat:IPaddr2 params ip=&subnetI;.5
 &prompt.crm.conf;<command>primitive</command> vip2 ocf:heartbeat:IPaddr2 params ip=&subnetI;.6
-&prompt.crm.conf;<command>location</command> loc-&node1; { vip1 vip2 } Mandatory: &node1; </screen>
+&prompt.crm.conf;<command>location</command> loc-&node1; { vip1 vip2 } inf: &node1; </screen>
     <para>
      In some cases it is much more efficient and convenient to use resource
      patterns for your <command>location</command> command. A resource
      pattern is a regular expression between two slashes. For example, the
      above virtual IP addresses can be all matched with the following:
     </para>
-<screen>&prompt.crm.conf;<command>location</command>  loc-&node1; /vip.*/ Mandatory: &node1;</screen>
+<screen>&prompt.crm.conf;<command>location</command>  loc-&node1; /vip.*/ inf: &node1;</screen>
    </sect3>
    <sect3 xml:id="sec-ha-manual-config-constraints-collocational">
     <title>Colocational constraints</title>
@@ -1331,9 +1331,9 @@ hostname (string): Hostname
 <!-- 
      colocation ID SCORE: RSC[:ROLE] RSC[:ROLE]
      
-     Example: colocation dummy_and_apache -Mandatory: apache dummy
+     Example: colocation dummy_and_apache -inf: apache dummy
     -->
-<screen>&prompt.crm.conf;<command>colocation</command> nfs_on_filesystem Mandatory: nfs_group filesystem_resource</screen>
+<screen>&prompt.crm.conf;<command>colocation</command> nfs_on_filesystem inf: nfs_group filesystem_resource</screen>
     <para>
      For a master slave configuration, it is necessary to know if the
      current node is a master in addition to running the resource locally.
@@ -1376,13 +1376,14 @@ hostname (string): Hostname
      Use the following command in the <command>crm</command> shell to
      configure an ordering constraint:
     </para>
-<!-- order ID score-type: FIRST-RSC[:ACTION] THEN-RSC[:ACTION] 
-     
+<!-- 
+     order <id> [kind:] first then [symmetrical=<bool>]
+     kind :: Mandatory | Optional | Serialize
      score-type :: advisory | mandatory | <score>
-     
+
      Example: order c_apache_1 mandatory: apache:start ip_1
     -->
-<screen>&prompt.crm.conf;<command>order</command> nfs_after_filesystem mandatory: filesystem_resource nfs_group</screen>
+<screen>&prompt.crm.conf;<command>order</command> nfs_after_filesystem Mandatory: filesystem_resource nfs_group</screen>
    </sect3>
    <sect3 xml:id="sec-ha-manual-config-constraints-example">
     <title>Constraints for the example configuration</title>
@@ -1400,7 +1401,7 @@ hostname (string): Hostname
        The file system must always be on the same node as the master of the
        DRBD resource.
       </para>
-<screen>&prompt.crm.conf;<command>colocation</command> filesystem_on_master Mandatory: \
+<screen>&prompt.crm.conf;<command>colocation</command> filesystem_on_master inf: \
     filesystem_resource drbd_resource:Master</screen>
      </listitem>
      <listitem>
@@ -1408,7 +1409,7 @@ hostname (string): Hostname
        The NFS server and the IP address must be on the same node as the
        file system.
       </para>
-<screen>&prompt.crm.conf;<command>colocation</command> nfs_with_fs Mandatory: \
+<screen>&prompt.crm.conf;<command>colocation</command> nfs_with_fs inf: \
    nfs_group filesystem_resource</screen>
      </listitem>
      <listitem>
@@ -1416,7 +1417,7 @@ hostname (string): Hostname
        The NFS server and the IP address start after the file system is
        mounted:
       </para>
-<screen>&prompt.crm.conf;<command>order</command> nfs_second mandatory: \
+<screen>&prompt.crm.conf;<command>order</command> nfs_second Mandatory: \
    filesystem_resource:start nfs_group</screen>
      </listitem>
      <listitem>

--- a/xml/ha_fencing.xml
+++ b/xml/ha_fencing.xml
@@ -318,8 +318,8 @@ username=USERNAME password=PASSW0RD
 primitive st-ibmrsa-2 stonith:external/ibmrsa-telnet \
 params nodename=&node2; ip_address=192.168.0.102 \
 username=USERNAME password=PASSW0RD
-location l-st-&node1; st-ibmrsa-1 -Mandatory: &node1;
-location l-st-&node2; st-ibmrsa-2 -Mandatory: &node2;
+location l-st-&node1; st-ibmrsa-1 -inf: &node1;
+location l-st-&node2; st-ibmrsa-2 -inf: &node2;
 commit</screen>
     <para>
      In this example, location constraints are used for the following

--- a/xml/ha_samba.xml
+++ b/xml/ha_samba.xml
@@ -306,7 +306,7 @@
     op monitor interval="60" timeout="60"
 &prompt.crm.conf;<command>group</command> g-ctdb ctdb nmb smb
 &prompt.crm.conf;<command>clone</command> cl-ctdb g-ctdb meta interleave="true"
-&prompt.crm.conf;<command>colocation</command> col-ctdb-with-clusterfs Mandatory: cl-ctdb cl-clusterfs
+&prompt.crm.conf;<command>colocation</command> col-ctdb-with-clusterfs inf: cl-ctdb cl-clusterfs
 &prompt.crm.conf;<command>order</command> o-clusterfs-then-ctdb Mandatory: cl-clusterfs cl-ctdb
 &prompt.crm.conf;<command>commit</command></screen>
    </step>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -1153,7 +1153,7 @@ Illegal request, Invalid opcode</screen>
      <para> Add the following order relationship plus a collocation between the
       <literal>sg_persist</literal> master and the file system resource: </para>
      <screen>&prompt.crm.conf;<command>order</command> o-ms-sg-before-ext4 Mandatory: ms-sg:promote ext4:start
-&prompt.crm.conf;<command>colocation</command> col-ext4-with-sg-persist Mandatory: ext4 ms-sg:Master</screen>
+&prompt.crm.conf;<command>colocation</command> col-ext4-with-sg-persist inf: ext4 ms-sg:Master</screen>
     </step>
     <step>
      <para> Check all your changes with the <command>show changed</command> command.
@@ -1280,7 +1280,7 @@ Illegal request, Invalid opcode</screen>
        <literal>filesystem1</literal>:
       </para>
       <screen>&prompt.crm.conf;<command>order</command> order-sfex-1 Mandatory: sfex_1 filesystem1
-&prompt.crm.conf;<command>colocation</command> col-sfex-1 Mandatory: filesystem1 sfex_1</screen>
+&prompt.crm.conf;<command>colocation</command> col-sfex-1 inf: filesystem1 sfex_1</screen>
      </step>
      <step>
       <para>

--- a/xml/nfs_quick_clusterscript.xml
+++ b/xml/nfs_quick_clusterscript.xml
@@ -519,7 +519,7 @@ add_drivers+=drbd</screen>
               this clone has been properly started, add the following
               constraints to the configuration:</para>
             <screen>&prompt.root;<command>crm</command> order o-root_before_nfs Mandatory: cl-exportfs-root g-nfs:start
-&prompt.root;<command>crm</command> colocation c-nfs_on_root Mandatory: g-nfs cl-exportfs-root</screen>
+&prompt.root;<command>crm</command> colocation c-nfs_on_root inf: g-nfs cl-exportfs-root</screen>
           </step>
           <step>
             <para>Check the output of the <command>exportfs -v</command>


### PR DESCRIPTION
### Description
Internally, "Mandatory" is only used by order constraints. To be consistent with other (upstream) documentation,
use "inf" for location and colocation constraints.

* [bsc#1158626](https://bugzilla.suse.com/show_bug.cgi?id=1158626)
* [DOCTEAM-207](https://jira.suse.com/browse/DOCTEAM-207)

Originates from https://github.com/SUSE/doc-sleha/commit/b71f4c584271fe80c8fc1eed57ddabe7ac60a41d#commitcomment-52178525

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP3
- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4

----

@gao-yan This is from your comment. I tried to make it consistent with upstream documentation. If possible, could you have a quick look? Many thanks!
