### PR TITLE
add missing default values for SBD

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -664,7 +664,18 @@ Timeout (msgwait)  : 10
    <procedure xml:id="pro-ha-storage-protect-sbd-config">
    <title>Editing the SBD configuration file</title>
     <step>
-     <para>Open the file <filename>/etc/sysconfig/sbd</filename>.</para>
+     <para>Open the file <filename>/etc/sysconfig/sbd</filename> and use
+      the following entries:</para>
+     <screen>SBD_PACEMAKER=yes
+SBD_STARTMODE=always
+SBD_DELAY_START=no
+SBD_WATCHDOG_DEV=/dev/watchdog
+SBD_WATCHDOG_TIMEOUT=5</screen>
+      <para>
+       The <varname>SBD_DEVICE</varname> entry is not needed as no shared
+       disk is used. When this parameter is missing, the <systemitem>sbd</systemitem>
+       service does not start any watcher process for SBD devices.
+      </para>
     </step>
     <step>
      <para>Search for the following parameter: <parameter>SBD_DEVICE</parameter>.


### PR DESCRIPTION
### Description

This PR contains the same same step content like in procedure with
ID=pro-ha-storage-protect-confdiskless

Fixes [DOCTEAM#11](https://jira.suse.com/browse/DOCTEAM-11)


### Backports
According to the issue, the following backports are needed:

- [x] To maintenance/SLEHA15SP3: c25c8cb31
- [x] To maintenance/SLEHA15SP2: bcb0008f6
- [x] To maintenance/SLEHA15SP1: 4915dd4b4
- [x] To maintenance/SLEHA15: cf09e6f5d
- [x] To maintenance/SLEHA12SP5: c8e9c52ea
- [x] To maintenance/SLEHA12SP4: ef3f72323
- [ ] To maintenance/SLEHA12SP3: 3748387c1 (not requested, but added anyway as it was simple)
