### PR TITLE
Simplify `ocf:heartbeat:X` calls

### DIFF
--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -180,7 +180,7 @@
      <para>
       Configure a <systemitem>lvmlockd</systemitem> resource as follows:
      </para>
-     <screen>&prompt.root;crm configure primitive lvmlockd ocf:heartbeat:lvmlockd \
+     <screen>&prompt.root;crm configure primitive lvmlockd lvmlockd \
   op start timeout="90" \
   op stop timeout="100" \
   op monitor interval="30" timeout="90"</screen>
@@ -251,7 +251,7 @@
      <itemizedlist>
       <listitem>
        <para>Use exclusive activation mode for local file system usage:</para>
-<screen>&prompt.root;crm configure primitive vg1 ocf:heartbeat:LVM-activate \
+<screen>&prompt.root;crm configure primitive vg1 LVM-activate \
   params vgname=vg1 vg_access_mode=lvmlockd \
   op start timeout=90s interval=0 \
   op stop timeout=90s interval=0 \
@@ -262,7 +262,7 @@
         Use shared activation mode for &ocfs; and add it to the cloned
         <literal>g-storage</literal> group:
        </para>
-<screen>&prompt.root;crm configure primitive vg1 ocf:heartbeat:LVM-activate \
+<screen>&prompt.root;crm configure primitive vg1 LVM-activate \
   params vgname=vg1 vg_access_mode=lvmlockd activation_mode=shared \
   op start timeout=90s interval=0 \
   op stop timeout=90s interval=0 \

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -1780,7 +1780,7 @@ monitor_0     interval=5s timeout=20s</screen>
       are running. However, to detect concurrency violations, also configure
       monitoring for resources which are stopped. For example:
      </para>
-<screen>primitive dummy1 ocf:heartbeat:Dummy \
+<screen>primitive dummy1 Dummy \
     op monitor interval="300s" role="Stopped" timeout="10s" \
     op monitor interval="30s" timeout="10s"</screen>
      <para>
@@ -1932,8 +1932,8 @@ monitor_0     interval=5s timeout=20s</screen>
        two virtual IPs (<varname>vip1</varname> and <varname>vip2</varname>)
        on the same node, <varname>&node1;</varname>:
       </para>
-<screen>&prompt.crm.conf;<command>primitive</command> vip1 ocf:heartbeat:IPaddr2 params ip=&subnetI;.5
-&prompt.crm.conf;<command>primitive</command> vip2 ocf:heartbeat:IPaddr2 params ip=&subnetI;.6
+<screen>&prompt.crm.conf;<command>primitive</command> vip1 IPaddr2 params ip=&subnetI;.5
+&prompt.crm.conf;<command>primitive</command> vip2 IPaddr2 params ip=&subnetI;.6
 &prompt.crm.conf;<command>location</command> loc-&node1; { vip1 vip2 } inf: &node1; </screen>
      </example>
      <para>
@@ -2450,16 +2450,16 @@ monitor_0     interval=5s timeout=20s</screen>
 <screen>node &node1; utilization memory="4000"
 node &node2; utilization memory="4000"
 node  &node3; utilization memory="4000"
-primitive xenA ocf:heartbeat:Xen utilization hv_memory="3500" \
+primitive xenA Xen utilization hv_memory="3500" \
      params xmfile="/etc/xen/shared-vm/vm1"
      meta priority="10" 
-primitive xenB ocf:heartbeat:Xen utilization hv_memory="2000" \
+primitive xenB Xen utilization hv_memory="2000" \
      params xmfile="/etc/xen/shared-vm/vm2"
      meta priority="1"
-primitive xenC ocf:heartbeat:Xen utilization hv_memory="2000" \
+primitive xenC Xen utilization hv_memory="2000" \
      params xmfile="/etc/xen/shared-vm/vm3"
      meta priority="1"
-primitive xenD ocf:heartbeat:Xen utilization hv_memory="1000" \
+primitive xenD Xen utilization hv_memory="1000" \
      params xmfile="/etc/xen/shared-vm/vm4"
      meta priority="5"
 property placement-strategy="minimal"</screen>
@@ -2586,7 +2586,7 @@ property placement-strategy="minimal"</screen>
    </para>
    <example xml:id="ex-ha-nagios-config">
     <title>Configuring resources for monitoring plug-ins</title>
-<screen>primitive vm1 ocf:heartbeat:VirtualDomain \
+<screen>primitive vm1 VirtualDomain \
     params hypervisor="qemu:///system" config="/etc/libvirt/qemu/vm1.xml" \
     op start interval="0" timeout="90" \
     op stop interval="0" timeout="90" \

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -194,9 +194,9 @@
         You can leave out the <literal>params</literal> section if it is the first and only section.
         For example, this line:
       </para>
-      <screen>&prompt.root;<command>crm</command> primitive ipaddr ocf:heartbeat:IPaddr2 params ip=192.168.0.55</screen>
+      <screen>&prompt.root;<command>crm</command> primitive ipaddr IPaddr2 params ip=192.168.0.55</screen>
       <para>is equivalent to this line:</para>
-      <screen>&prompt.root;<command>crm</command> primitive ipaddr ocf:heartbeat:IPaddr2 ip=192.168.0.55</screen>
+      <screen>&prompt.root;<command>crm</command> primitive ipaddr IPaddr2 ip=192.168.0.55</screen>
     </listitem>
     <listitem>
      <formalpara>
@@ -539,7 +539,7 @@ whenever  a takeover occurs.
 
 2. Configure cluster resources
 
-        primitive sysadmin ocf:heartbeat:MailTo
+        primitive sysadmin MailTo
                 email="tux@example.org"
                 op start timeout="10"
                 op stop timeout="10"
@@ -686,7 +686,7 @@ ERROR: 65: required parameter configfile not set</screen>
 <screen>&prompt.crm.conf.templ;<command>show</command>
 primitive virtual-ip ocf:heartbeat:IPaddr \
     params ip=<emphasis role="strong">"192.168.1.101"</emphasis>
-primitive apache ocf:heartbeat:apache \
+primitive apache apache \
     params configfile=<emphasis role="strong">"/etc/apache2/httpd.conf"</emphasis>
     monitor apache 120s:60s
 group <emphasis role="strong">g-intranet</emphasis> \
@@ -1047,7 +1047,7 @@ property $id="cib-bootstrap-options" \
      <para>
       Configure a primitive IP address:
      </para>
-<screen>&prompt.crm.conf;<command>primitive</command> myIP ocf:heartbeat:IPaddr \
+<screen>&prompt.crm.conf;<command>primitive</command> myIP IPaddr \
      params ip=127.0.0.99 op monitor interval=60s</screen>
      <para>
       The previous command configures a <quote>primitive</quote> with the
@@ -1130,7 +1130,7 @@ usage: rsc_template &lt;name&gt; [&lt;class&gt;:[&lt;provider&gt;:]]&lt;type&gt;
     resource templates. For example, the equivalent of the above two would
     be:
    </para>
-<screen>&prompt.crm.conf;<command>primitive</command> MyVM1 ocf:heartbeat:Xen \
+<screen>&prompt.crm.conf;<command>primitive</command> MyVM1 Xen \
    params xmfile="/etc/xen/shared-vm/MyVM1" name="MyVM1" \
    params allow_mem_management="true" \
    op monitor timeout=60s interval=15s \
@@ -1298,8 +1298,8 @@ hostname (string): Hostname
      <varname>loc-&node1;</varname>, referencing the virtual IP addresses
      <varname>vip1</varname> and <varname>vip2</varname>:
     </para>
-<screen>&prompt.crm.conf;<command>primitive</command> vip1 ocf:heartbeat:IPaddr2 params ip=&subnetI;.5
-&prompt.crm.conf;<command>primitive</command> vip2 ocf:heartbeat:IPaddr2 params ip=&subnetI;.6
+<screen>&prompt.crm.conf;<command>primitive</command> vip1 IPaddr2 params ip=&subnetI;.5
+&prompt.crm.conf;<command>primitive</command> vip2 IPaddr2 params ip=&subnetI;.6
 &prompt.crm.conf;<command>location</command> loc-&node1; { vip1 vip2 } inf: &node1; </screen>
     <para>
      In some cases it is much more efficient and convenient to use resource
@@ -1553,7 +1553,7 @@ hostname (string): Hostname
      <para>
       To specify the capacity a resource <emphasis>requires</emphasis>, use:
      </para>
-<screen>&prompt.crm.conf;<command>primitive</command> xen1 ocf:heartbeat:Xen ... \
+<screen>&prompt.crm.conf;<command>primitive</command> xen1 Xen ... \
      utilization memory=4096 cpu=4</screen>
      <para>
       This would make the resource consume 4096 of those memory units from
@@ -1585,16 +1585,16 @@ hostname (string): Hostname
 <screen>&prompt.crm.conf;<command>node</command> &node1; utilization memory="4000"
 &prompt.crm.conf;<command>node</command> &node2; utilization memory="4000"
 &prompt.crm.conf;<command>node</command> &node3; utilization memory="4000"
-&prompt.crm.conf;<command>primitive</command> xenA ocf:heartbeat:Xen \
+&prompt.crm.conf;<command>primitive</command> xenA Xen \
     utilization hv_memory="3500" meta priority="10" \
     params xmfile="/etc/xen/shared-vm/vm1"
-&prompt.crm.conf;<command>primitive</command> xenB ocf:heartbeat:Xen \
+&prompt.crm.conf;<command>primitive</command> xenB Xen \
     utilization hv_memory="2000" meta priority="1" \
     params xmfile="/etc/xen/shared-vm/vm2"
-&prompt.crm.conf;<command>primitive</command> xenC ocf:heartbeat:Xen \
+&prompt.crm.conf;<command>primitive</command> xenC Xen \
     utilization hv_memory="2000" meta priority="1" \
     params xmfile="/etc/xen/shared-vm/vm3"
-&prompt.crm.conf;<command>primitive</command> xenD ocf:heartbeat:Xen \
+&prompt.crm.conf;<command>primitive</command> xenD Xen \
     utilization hv_memory="1000" meta priority="5" \
     params xmfile="/etc/xen/shared-vm/vm4"
 &prompt.crm.conf;<command>property</command> placement-strategy="minimal"</screen>
@@ -1728,7 +1728,7 @@ hostname (string): Hostname
       <para>
        Configure the primitive, for example:
       </para>
-<screen>&prompt.crm.conf;<command>primitive</command> Apache ocf:heartbeat:apache</screen>
+<screen>&prompt.crm.conf;<command>primitive</command> Apache apache</screen>
      </step>
      <step>
       <para>
@@ -2103,7 +2103,7 @@ Resource Group: dlm-clvm:1
   </para>
 
 <screen>&prompt.root;<command>crm</command> configure show
-primitive mydb ocf:heartbeat:mysql \
+primitive mydb mysql \
    params replication_user=admin ...</screen>
 
   <para>

--- a/xml/ha_config_example.xml
+++ b/xml/ha_config_example.xml
@@ -44,7 +44,7 @@ primitive ocfs2-1 ocf:heartbeat:Filesystem \
      op monitor interval="20" timeout="40"
 primitive sbd_stonith stonith:external/sbd \
      params pcmk_delay_max=30 meta target-role="Started"
-primitive vg1 ocf:heartbeat:LVM \
+primitive vg1 LVM \
      params volgrpname="cluster-vg" \
      op monitor interval="60" timeout="60"
 group g-storage dlm<!-- o2cb--> clvm vg1 ocfs2-1

--- a/xml/ha_example_cli_i.xml
+++ b/xml/ha_example_cli_i.xml
@@ -55,7 +55,7 @@
    <para>
     Create an IP address resource:
    </para>
-<screen>&prompt.crm.conf;<command>resource</command><command>primitive</command> myIP ocf:heartbeat:IPaddr params ip=10.10.0.1<!--
+<screen>&prompt.crm.conf;<command>resource</command><command>primitive</command> myIP IPaddr params ip=10.10.0.1<!--
   --></screen>
   </step>
  </procedure>

--- a/xml/ha_samba.xml
+++ b/xml/ha_samba.xml
@@ -288,7 +288,7 @@
     </para>
 <!--taroth 2012-02-07: fixed bnc#745334, default timeout for start/stop-->
 <screen>&prompt.root;<command>crm</command> configure
-&prompt.crm.conf;<command>primitive</command> ctdb ocf:heartbeat:CTDB params \
+&prompt.crm.conf;<command>primitive</command> ctdb CTDB params \
     ctdb_manages_winbind="false" \ 
     ctdb_manages_samba="false" \
     ctdb_recovery_lock="/srv/clusterfs/samba/ctdb.lock" \
@@ -314,7 +314,7 @@
     <para>
      Add a clustered IP address:
     </para>
-<screen>&prompt.crm.conf;<command>primitive</command> ip ocf:heartbeat:IPaddr2<!-- 
+<screen>&prompt.crm.conf;<command>primitive</command> ip IPaddr2<!-- 
     --> params ip=&subnetII;.222 \
     unique_clone_address="true" \
     op monitor interval="60" \

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -1157,7 +1157,7 @@ Illegal request, Invalid opcode</screen>
     </step>
     <step>
      <para> Add a file system primitive for Ext4: </para>
-     <screen>&prompt.crm.conf;<command>primitive</command> ext4 ocf:heartbeat:Filesystem \
+     <screen>&prompt.crm.conf;<command>primitive</command> ext4 Filesystem \
     params device="/dev/sdc1" directory="/mnt/ext4" fstype=ext4</screen>
     </step>
     <step>


### PR DESCRIPTION
### Description

Replace

    primitive aaa ocf:heartbeat:XXX

with

    primitive aaa XXX

Used the following two sed calls:

```
$ sed -r -i 's#primitive ([a-zA-Z0-9]+)\s+ocf:heartbeat:([a-zA-Z0-9_]+)#primitive \1 \2#g' xml/*.xml

$ sed -r -i 's#<command>primitive</command> ([a-zA-Z0-9]+)\s+ocf:heartbeat:([a-zA-Z0-9_]+)#<command>primitive</command> \1 \2#g' xml/*.xml
```

See [DOCTEAM#101](https://jira.suse.com/browse/DOCTEAM-101)


### Backports

- [x] To maintenance/SLEHA15SP3: bb61b7226
- [x] To maintenance/SLEHA15SP2: d341f8704
- [x] To maintenance/SLEHA15SP1: 3cd0dd527
- [x] To maintenance/SLEHA15: 3ce05c86b
- [x] To maintenance/SLEHA12SP5: ad8d4be31
- [x] To maintenance/SLEHA12SP4: 88803bda6
- [x] To maintenance/SLEHA12SP3: 9eb72871d