### PR TITLE
SEO: edit urls removed l10n SLE-HA 15 SP3

### DIFF
--- a/l10n/sleha/de-de/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/de-de/xml/MAIN.SLEHA.xml
@@ -12,11 +12,11 @@
       <productnumber><phrase role="productnumber"><phrase os="sles">15 SP3</phrase></phrase></productnumber>
        <dm:docmanager>
         <dm:bugtracker>
-          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+         <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
-          <dm:component>Dokumentation</dm:component>
+         <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-        <dm:translation>Ja</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/sleha/de-de/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/de-de/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
           <dm:component>Dokumentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>Ja</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/sleha/es-es/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/es-es/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
           <dm:component>Documentación</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>sí</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/sleha/es-es/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/es-es/xml/MAIN.SLEHA.xml
@@ -12,11 +12,11 @@
       <productnumber><phrase role="productnumber"><phrase os="sles">15 SP3</phrase></phrase></productnumber>
        <dm:docmanager>
         <dm:bugtracker>
-          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+         <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
-          <dm:component>Documentación</dm:component>
+         <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-        <dm:translation>sí</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/sleha/fr-fr/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/fr-fr/xml/MAIN.SLEHA.xml
@@ -12,11 +12,11 @@
       <productnumber><phrase role="productnumber"><phrase os="sles">15 SP3</phrase></phrase></productnumber>
        <dm:docmanager>
         <dm:bugtracker>
-          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+         <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP3</dm:product>
-          <dm:component>Documentation</dm:component>
+         <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-        <dm:translation>oui</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/sleha/fr-fr/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/fr-fr/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP3</dm:product>
           <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>oui</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/sleha/it-it/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/it-it/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
           <dm:component>Documentazione</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>sì</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/sleha/it-it/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/it-it/xml/MAIN.SLEHA.xml
@@ -12,11 +12,11 @@
       <productnumber><phrase role="productnumber"><phrase os="sles">15 SP3</phrase></phrase></productnumber>
        <dm:docmanager>
         <dm:bugtracker>
-          <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
+         <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
-          <dm:component>Documentazione</dm:component>
+         <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-        <dm:translation>sì</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/sleha/ja-jp/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/ja-jp/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
           <dm:component>マニュアル</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/sleha/ja-jp/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/ja-jp/xml/MAIN.SLEHA.xml
@@ -14,7 +14,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
-          <dm:component>マニュアル</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/l10n/sleha/pt-br/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/pt-br/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
           <dm:component>Documentação</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>sim</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/sleha/pt-br/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/pt-br/xml/MAIN.SLEHA.xml
@@ -14,9 +14,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
-          <dm:component>Documentação</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-        <dm:translation>sim</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/sleha/zh-cn/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/zh-cn/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
           <dm:component>文档</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/sleha/zh-cn/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/zh-cn/xml/MAIN.SLEHA.xml
@@ -14,7 +14,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
-          <dm:component>文档</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/l10n/sleha/zh-tw/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/zh-tw/xml/MAIN.SLEHA.xml
@@ -14,7 +14,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
-          <dm:component>文件</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/l10n/sleha/zh-tw/xml/MAIN.SLEHA.xml
+++ b/l10n/sleha/zh-tw/xml/MAIN.SLEHA.xml
@@ -16,7 +16,6 @@
          <dm:product>SUSE Linux Enterprise High Availability 15 SP3</dm:product>
           <dm:component>文件</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/main/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>


### PR DESCRIPTION
### Description

dm:editurls tag removed for all languages of SLE 15 SP3.

### Backports

Will be done for each branch version separately therefore no backports needed.

- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4
