### PR TITLE
Clarify DRBD with STONITH

### DIFF
--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -929,19 +929,27 @@ resource r0-U {
  </sect1>
 
  <sect1 xml:id="sec-ha-drbd-fencing">
-  <title>Using resource-level fencing</title>
+  <title>Using resource-level fencing with &stonith;</title>
   <para>
    When a DRBD replication link becomes interrupted, &pace; tries to promote
    the DRBD resource to another node. To prevent &pace; from starting a service
    with outdated data, enable resource-level fencing in the DRBD configuration
-   file as shown in <xref linkend="ex-ha-drbd-fencing"/>.
+   file.
   </para>
+   <para>
+    The fencing policy can have different values (see man page <command>drbdsetup</command> and the
+     <option>--fencing</option> option).
+    As a &productname; cluster is normally used with a &stonith; device, the value
+    <constant>resource-and-stonith</constant> is used in
+    <xref linkend="ex-ha-drbd-fencing"/>.
+  </para>
+
   <example xml:id="ex-ha-drbd-fencing">
    <title>Configuration of DRBD with resource-level fencing using the Cluster
     Information Base (CIB)</title>
    <screen>resource <replaceable>RESOURCE</replaceable> {
   net {
-    fencing resource-only;
+    fencing resource-and-stonith;
     # ...
   }
   handlers {


### PR DESCRIPTION
### Description
Clarify configuration of DRBD with resource-level fencing

See [bsc#1191870](https://bugzilla.suse.com/show_bug.cgi?id=1191870)

### Backports

- [x] To maintenance/SLEHA15SP3: 5de12db0
- [x] To maintenance/SLEHA15SP2: b328def0
- [x] To maintenance/SLEHA15SP1: 3e0da2a4
- [x] To maintenance/SLEHA15: 0e9e8bf1
- [x] To maintenance/SLEHA12SP5: 666b38a1
- [ ] To maintenance/SLEHA12SP4: --
