### PR TITLE
Add resourc-level fencing for DRBD

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -207,6 +207,13 @@
 
    net {
       protocol  C; <co xml:id="co-ha-quick-nfs-drbd-protocol"/>
+      fencing: resource-and-stonith;
+   }
+
+   handlers { <co xml:id="co-ha-quick-nfs-fencing-handlers"/>
+      fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
+      after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
+      # ...
    }
 
    connection-mesh { <co xml:id="co-ha-quick-nfs-connectionmesh"/>
@@ -242,6 +249,15 @@
         <para>The specified protocol to be used for this connection. For protocol
          <literal>C</literal>, a write is considered to be complete when
          it has reached all disks, be they local or remote.
+        </para>
+       </callout>
+       <callout arearefs="co-ha-quick-nfs-fencing-handlers">
+        <para>
+         Enables resource-level fencing. If the DRBD replication link
+         becomes disconnected, &pace; tries to promote the DRBD resource
+         to another node. During this process, the scripts were called.
+         See <xref linkend="sec-ha-drbd-fencing"/> for more
+         information.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-connectionmesh">


### PR DESCRIPTION
### Description
Mention resource-level fencing in DRBD configuration

From [bsc#1163480](https://bugzilla.suse.com/show_bug.cgi?id=1163480) and [DOCTEAM-146](https://jira.suse.com/browse/DOCTEAM-146)

### Backports


- [x] To maintenance/SLEHA15SP3: e153e086
- [x] To maintenance/SLEHA15SP2: 86f14f48
- [x] To maintenance/SLEHA15SP1: 57d5a0a7
- [x] To maintenance/SLEHA15: 9edb8b4b
- [x] To maintenance/SLEHA12SP5: 7e4c87c7
- [x] To maintenance/SLEHA12SP4: d4194200
