### PR TITLE
SEO: remove editurls from l10n SLEHA15SP2

### DIFF
--- a/l10n/de-de/xml/MAIN.SLEHA.xml
+++ b/l10n/de-de/xml/MAIN.SLEHA.xml
@@ -14,10 +14,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>Dokumentation</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>
-        <dm:translation>Ja</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/es-es/xml/MAIN.SLEHA.xml
+++ b/l10n/es-es/xml/MAIN.SLEHA.xml
@@ -13,10 +13,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>Documentación</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>
-        <dm:translation>sí</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/fr-fr/xml/MAIN.SLEHA.xml
+++ b/l10n/fr-fr/xml/MAIN.SLEHA.xml
@@ -15,8 +15,7 @@
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
           <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>
-        <dm:translation>oui</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/it-it/xml/MAIN.SLEHA.xml
+++ b/l10n/it-it/xml/MAIN.SLEHA.xml
@@ -14,10 +14,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>Documentazione</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>
-        <dm:translation>sì</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/ja-jp/xml/MAIN.SLEHA.xml
+++ b/l10n/ja-jp/xml/MAIN.SLEHA.xml
@@ -14,9 +14,8 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>マニュアル</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>

--- a/l10n/pt-br/xml/MAIN.SLEHA.xml
+++ b/l10n/pt-br/xml/MAIN.SLEHA.xml
@@ -13,10 +13,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>Documentação</dm:component>
+          <dm:component>Documentacion</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>
-        <dm:translation>sim</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 

--- a/l10n/pt-br/xml/MAIN.SLEHA.xml
+++ b/l10n/pt-br/xml/MAIN.SLEHA.xml
@@ -13,7 +13,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>Documentacion</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>

--- a/l10n/zh-cn/xml/MAIN.SLEHA.xml
+++ b/l10n/zh-cn/xml/MAIN.SLEHA.xml
@@ -14,10 +14,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>文档</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sleha/edit/maintenance/SLEHA15SP2/xml/</dm:editurl>
-        <dm:translation>是</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
     </info>
     

--- a/l10n/zh-tw/xml/MAIN.SLEHA.xml
+++ b/l10n/zh-tw/xml/MAIN.SLEHA.xml
@@ -14,10 +14,9 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:product>SUSE Linux Enterprise High Availability Extension 15 SP2</dm:product>
-          <dm:component>文件</dm:component>
+          <dm:component>Documentation</dm:component>
         </dm:bugtracker>
-         <dm:editurl>https://github.com/SUSE/doc-sleha/edit/master/xml/</dm:editurl>
-        <dm:translation>是</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
  </info>
 


### PR DESCRIPTION
### Description

dm:editurls tag removed for all languages of SLE-HA15 SP2.

Will be done for each branch version separately therefore no backports needed
