### PR TITLE
Fix bsc#1193441: remove colon after "fencing"

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -207,7 +207,7 @@
 
    net {
       protocol  C; <co xml:id="co-ha-quick-nfs-drbd-protocol"/>
-      fencing: resource-and-stonith;
+      fencing resource-and-stonith;
    }
 
    handlers { <co xml:id="co-ha-quick-nfs-fencing-handlers"/>


### PR DESCRIPTION
### Description

Remove colon after the `fencing` key in the DRBD configuration


### Backports


- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4
