### PR TITLE
Fix bsc#1189235: Use move instead of migrate

### DIFF
--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -2015,13 +2015,13 @@ Resource Group: dlm-clvm:1
     using either &hawk2; or the command line.
    </para>
    <para>
-    Use the <command>migrate</command> command for this task. For example,
+    Use the <command>move</command> command for this task. For example,
     to migrate the resource <literal>ipaddress1</literal> to a cluster node
     named <systemitem class="domainname">&node2;</systemitem>, use these
     commands:
    </para>
 <screen>&prompt.root;<command>crm</command> resource
-&prompt.crm.res;<command>migrate</command> ipaddress1 &node2;</screen>
+&prompt.crm.res;<command>move</command> ipaddress1 &node2;</screen>
   </sect2>
 
   <sect2 xml:id="sec-ha-manual-config-tag">

--- a/xml/ha_example_cli_i.xml
+++ b/xml/ha_example_cli_i.xml
@@ -90,7 +90,7 @@
     Migrate your resource <literal>myip</literal> to node
     <systemitem>&wsIII;</systemitem>:
    </para>
-<screen><command>crm</command> resource <command>migrate</command> myIP &wsIII;</screen>
+<screen><command>crm</command> resource <command>move</command> myIP &wsIII;</screen>
   </step>
  </procedure>
 </sect1>

--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -289,7 +289,7 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
       happened in the past and which was not <quote>cleaned</quote>. Or it
       may be because of an earlier administrative action, that is a location
       constraint with a negative score. Such a location constraint is
-      inserted by the <command>crm resource migrate</command> command,
+      inserted by the <command>crm resource move</command> command,
       for example.
      </para>
     </listitem>


### PR DESCRIPTION
### Description
The command `crm resource migrate` has been marked as deprecated and is replaced by `crm resource move`.


### Backports
<!--
 Are backports required? Check all items that apply.
-->


- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4

### References

[bsc#1189235](https://bugzilla.suse.com/show_bug.cgi?id=1189235)