### PR TITLE
Fix SLE-222541: nocluster mount option for OCFS2

### DIFF
--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -556,26 +556,34 @@
    </step>
    <step>
     <para>
-     Check if the cluster is online with the command <command>crm
-     status</command>.
+     Decide if you need the whole cluster stack.
     </para>
-   </step>
-   <step>
-    <para>
-     Mount the volume from the command line, using the
-     <command>mount</command> command.
-    </para>
+    <stepalternatives>
+     <step>
+      <formalpara>
+       <title>Cluster is not needed</title>
+       <para>
+        There are use cases when you do not need a full functional cluster stack.
+        <!--For example, when restoring the services from backups or a third disaster
+        recover site.-->
+        In such cases, mount the volume from the command line, using the
+       <command>mount</command> command and add the <literal>-o nocluster</literal> option.
+       </para>
+      </formalpara>
+     </step>
+     <step>
+      <formalpara>
+       <title>Cluster is needed</title>
+       <para>
+        Check if the cluster is online with the command <command>crm
+         status</command>. Mount the volume from the command line, using the
+        <command>mount</command> command
+       </para>
+      </formalpara>
+     </step>
+    </stepalternatives>
    </step>
   </procedure>
-
-  <warning>
-   <title>Manually mounted &ocfs; devices</title>
-   <para>
-    If you mount the &ocfs; file system manually for testing purposes,
-    make sure to unmount it again before starting to use it by means of
-    cluster resources.
-   </para>
-  </warning>
 
   <procedure xml:id="pro-ocfs2-mount-cluster">
    <title>Mounting an &ocfs; volume with the cluster resource manager</title>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -439,7 +439,7 @@
         the block size when you create the volume. For the available options
         and recommendations, refer to the <command>mkfs.ocfs2</command> man
         page.
-<!-- Brendo, 17.11.2010: to detect the blocksize of the device, use: 
+<!-- Brendo, 17.11.2010: to detect the blocksize of the device, use:
              blockdev -\-getbsz &lt;block-device&gt;. -->
        </para>
       </entry>
@@ -526,10 +526,10 @@
 <!-- Brendo, 17.11.2010: maybe add -b 4k in the example (this is common
         for software raids) -->
 <!--taroth 2014-08-14: additional info from bnc#853631:
-       The complete command is:    
+       The complete command is:
        mkfs.ocfs2 -/-cluster-stack=pcmk -/-cluster-name=mycluster -N 32 /dev/sdb1
        Note, cluster-name should be same as defined in corosync.conf
-   
+
        Alternatively, you can load the ocfs2 module, set the cluster_stack to pcmk and
        issue mkfs.ocfs2:
        # modprobe ocfs2_stack_user
@@ -556,34 +556,32 @@
    </step>
    <step>
     <para>
-     Decide if you need the whole cluster stack.
+     Check if the cluster is online with the command <command>crm
+     status</command>.
     </para>
-    <stepalternatives>
-     <step>
-      <formalpara>
-       <title>Cluster is not needed</title>
-       <para>
-        There are use cases when you do not need a full functional cluster stack.
-        <!--For example, when restoring the services from backups or a third disaster
-        recover site.-->
-        In such cases, mount the volume from the command line, using the
-       <command>mount</command> command and add the <literal>-o nocluster</literal> option.
-       </para>
-      </formalpara>
-     </step>
-     <step>
-      <formalpara>
-       <title>Cluster is needed</title>
-       <para>
-        Check if the cluster is online with the command <command>crm
-         status</command>. Mount the volume from the command line, using the
-        <command>mount</command> command
-       </para>
-      </formalpara>
-     </step>
-    </stepalternatives>
+   </step>
+   <step>
+    <para>
+     Mount the volume from the command line, using the
+     <command>mount</command> command.
+    </para>
    </step>
   </procedure>
+   <tip>
+    <title>Mounting an existing &ocfs; volume on a single node</title>
+    <para>
+     You can mount an &ocfs; volume on a single node without a fully functional
+     cluster stack; for example, to quickly access the data from a backup.
+     To do so, use the <command>mount</command> command with the
+     <literal>-o nocluster</literal> option.
+    </para>
+    <warning role="compact">
+     <para>
+      This mount method lacks cluster-wide protection. To avoid damaging the file
+      system, you must ensure that it is only mounted on one node.
+     </para>
+    </warning>
+   </tip>
 
   <procedure xml:id="pro-ocfs2-mount-cluster">
    <title>Mounting an &ocfs; volume with the cluster resource manager</title>


### PR DESCRIPTION
### Description
Kernel 5.8 supports the "nocluster" mount option to enable a use case, when no full functional cluster stack is needed.

### Backports

- [x] To maintenance/SLEHA15SP4
- [ ] To maintenance/SLEHA15SP3
- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

[SLE-22507](https://jira.suse.com/browse/SLE-22507)