### PR TITLE
bsc#1193176: mention architectures

### DIFF
--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -105,6 +105,14 @@
      </para>
     </listitem>
    </itemizedlist>
+   <important>
+    <title>No support for mixed architectures</title>
+    <para>
+     All nodes belonging to a cluster should have the same processor platform:
+     &x86;, &zseries;, or &power;. Clusters of mixed architectures are
+     <emphasis>not</emphasis> supported.
+    </para>
+   </important>
    <para>
     Your cluster can contain up to 32 Linux servers. Using 
     &pmrm;, the cluster can be extended to include


### PR DESCRIPTION
### Description
Mention that mixed clusters of different processor platforms are not supported.

### Backports

- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References
[bsc#1193176](https://bugzilla.suse.com/show_bug.cgi?id=1193176) - hybrid clusters across HA architecure? 
