### PR TITLE
crm live shell: exit -> quit (bsc#1195098)

### DIFF
--- a/xml/article_pacemaker_remote.xml
+++ b/xml/article_pacemaker_remote.xml
@@ -418,7 +418,7 @@ ssh: connect to host &node3; port 3121: Connection refused</screen>
      params server=&node3; reconnect_interval=15m \
      op monitor interval=30s
 &prompt.crm.conf;<command>commit</command>
-&prompt.crm.conf;<command>exit</command></screen>
+&prompt.crm.conf;<command>quit</command></screen>
     </step>
     <step>
      <para>Check the status of the cluster with the command

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -149,7 +149,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
     <para>
      The configuration is saved to the CIB.
@@ -207,7 +207,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
     <para>
      The configuration is saved to the CIB.
@@ -260,7 +260,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
     <para>
      The configuration is saved to the CIB.
@@ -392,7 +392,7 @@
     <para>
      If the configuration is according to your wishes, submit your changes with
      <command>submit</command> and leave the crm live shell with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
    </step>
    <step xml:id="st-ha-geo-rsc-sync-cib-export-start">
@@ -504,7 +504,7 @@
      <para>
       Review your changes with <command>show</command>, submit your changes
       with <command>submit</command>, and leave the crm live shell with
-      <command>exit</command>.
+      <command>quit</command>.
      </para>
     </listitem>
     <listitem>

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -238,8 +238,7 @@
       For example, if you type <command>resource</command> you enter the
       resource management level. Your prompt changes to
       <literal>&crm.live;resource#</literal>. To leave the
-      internal shell, use the commands <command>quit</command>,
-      <command>bye</command>, or <command>exit</command>. If you need to go
+      internal shell, use the command <command>quit</command>. If you need to go
       one level back, use <command>back</command>, <command>up</command>,
       <command>end</command>, or <command>cd</command>.
      </para>
@@ -960,10 +959,10 @@ property $id="cib-bootstrap-options" \
    </step>
    <step>
     <para>
-     Commit your changes and exit:
+     Commit your changes and quit:
     </para>
 <screen>&prompt.crm.conf;<command>commit</command>
-&prompt.crm.conf;<command>exit</command></screen>
+&prompt.crm.conf;<command>quit</command></screen>
    </step>
   </procedure>
  </sect1>-->

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -188,7 +188,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
    </step>
   </procedure>
@@ -440,7 +440,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
    </step>
   </procedure>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -302,7 +302,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
    </step>
   </procedure>
@@ -634,7 +634,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
    </step>
   </procedure>

--- a/xml/ha_storage_basics.xml
+++ b/xml/ha_storage_basics.xml
@@ -130,7 +130,7 @@
     <para>
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
-     <command>exit</command>.
+     <command>quit</command>.
     </para>
    </step>
   </procedure>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -900,7 +900,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
    <step>
     <para>
      Submit your changes with <command>commit</command> and leave the crm live
-     configuration with <command>exit</command>.
+     configuration with <command>quit</command>.
     </para>
    </step>
   </procedure>
@@ -1003,7 +1003,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
    <step>
     <para>
      Submit your changes with <command>commit</command> and leave the crm live
-     configuration with <command>exit</command>.
+     configuration with <command>quit</command>.
     </para>
    </step>
   </procedure>


### PR DESCRIPTION
### Description
In the crm live shell, 'exit' and 'bye' are still accepted, but the shell gives this hint: "This command is deprecated, please use 'quit'"
### Backports

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
