### PR TITLE
Add log file path for crmsh

### DIFF
--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -6,7 +6,7 @@
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
 <!--
- 
+
  Future TODOs:
  * Correct IDs
  * FATE 304867 Multilevel administration rights for CIB
@@ -86,8 +86,12 @@
    convention described in
    <xref linkend="app-naming" xrefstyle="select:label"/>.
   </para>
+  <para>
+   Events are logged to <filename>/var/log/crmsh/crmsh.log</filename>.
+  </para>
 
-<!-- toms 2014-02-27: 
+
+<!-- toms 2014-02-27:
       Should we add that to the section "Typographical Conventions"?
     -->
 
@@ -161,7 +165,7 @@
     <para>
      The &crmsh; supports full tab completion in Bash directly, not only
      for the interactive shell. For example, typing <literal>crm help
-     config</literal><keycap function="tab"/> will complete the word 
+     config</literal><keycap function="tab"/> will complete the word
      like in the interactive shell.
     </para>
    </tip>
@@ -338,9 +342,9 @@ drbdconf (string, [/etc/drbd.conf]): Path to drbd.conf
 Operations' defaults (advisory minimum):
 
     start         timeout=240
-    promote       timeout=90 
-    demote        timeout=90 
-    notify        timeout=90 
+    promote       timeout=90
+    demote        timeout=90
+    notify        timeout=90
     stop          timeout=100
     monitor_Slave_0 interval=20 timeout=20 start-delay=1m
     monitor_Master_0 interval=10 timeout=20 start-delay=1m</screen>
@@ -796,7 +800,7 @@ INFO: myNewConfig shadow CIB created</screen>
     following example is a transcript, adding a monitor operation:
    </para>
 <screen>&prompt.root;<command>crm</command> configure
-&prompt.crm.conf;<command>show</command> fence-&node2; 
+&prompt.crm.conf;<command>show</command> fence-&node2;
 primitive fence-&node2; stonith:apcsmart \
         params hostlist="&node2;"
 &prompt.crm.conf;<command>monitor</command> fence-&node2; 120m:60s
@@ -863,8 +867,8 @@ Votequorum information
 Expected votes:   2
 Highest expected: 2
 Total votes:      2
-Quorum:           2  
-Flags:            Quorate 
+Quorum:           2
+Flags:            Quorate
 
 Membership information
 ----------------------
@@ -1082,7 +1086,7 @@ property $id="cib-bootstrap-options" \
     <ulink
     url="http://www.linux-foundation.org/spec/refspecs/LSB_1.3.0/gLSB/gLSB/iniscrptact.html"/>.
     </para>
-    
+
     </sect2>-->
   </sect2>
 
@@ -1249,16 +1253,16 @@ hostname (string): Hostname
      <systemitem class="server">&node1;</systemitem> to 100 would be the
      following:
     </para>
-<!-- 
+<!--
      location ID RSC {node_pref|rules}
-     
+
      Grammar:
      node_pref :: <score>: <node>
-     
+
      rules ::
      rule [id_spec] [$role=<role>] <score>: <expression>
      [rule [id_spec] [$role=<role>] <score>: <expression> ...]
-     
+
      id_spec :: $id=<id> | $id-ref=<id>
      score :: <number> | <attribute> | [-]inf
      expression :: <single_exp> [bool_op <simple_exp> ...]
@@ -1269,8 +1273,8 @@ hostname (string): Hostname
      type :: string | version | number
      binary_op :: lt | gt | lte | gte | eq | ne
      unary_op :: defined | not_defined
-     
-     date_expr :: date_op <start> [<end>]  (TBD) 
+
+     date_expr :: date_op <start> [<end>]  (TBD)
     -->
 <screen>&prompt.crm.conf;<command>location</command> loc-fs1 fs1 100: &node1;</screen>
     <para>
@@ -1327,9 +1331,9 @@ hostname (string): Hostname
      <literal>filesystem_resource</literal> and <literal>nfs_group</literal>
      always on the same host, use the following constraint:
     </para>
-<!-- 
+<!--
      colocation ID SCORE: RSC[:ROLE] RSC[:ROLE]
-     
+
      Example: colocation dummy_and_apache -inf: apache dummy
     -->
 <screen>&prompt.crm.conf;<command>colocation</command> nfs_on_filesystem inf: nfs_group filesystem_resource</screen>
@@ -1375,7 +1379,7 @@ hostname (string): Hostname
      Use the following command in the <command>crm</command> shell to
      configure an ordering constraint:
     </para>
-<!-- 
+<!--
      order <id> [kind:] first then [symmetrical=<bool>]
      kind :: Mandatory | Optional | Serialize
      score-type :: advisory | mandatory | <score>
@@ -1477,9 +1481,9 @@ hostname (string): Hostname
     To take this into account, the &hasi; allows you to specify the
     following parameters:
    </para>
-   <remark>dejan 2011-11-24: It is not clear whether location 
-      constraints have any influence on resource placement in case 
-      placement-strategy is set to something other than default. 
+   <remark>dejan 2011-11-24: It is not clear whether location
+      constraints have any influence on resource placement in case
+      placement-strategy is set to something other than default.
       Or is it explained elsewhere?</remark>
    <orderedlist spacing="normal">
     <listitem>
@@ -1737,7 +1741,7 @@ hostname (string): Hostname
      </step>
     </procedure>
    </sect3>
-<!-- 
+<!--
     <sect2 id="sec-ha-manual-config-clone-globally" os="notdefinied">
     <title>Creating globally unique clone resources</title>
     <remark>Haven't found an example. Any idea?</remark>
@@ -2190,7 +2194,7 @@ linux</screen>
    </varlistentry>
   </variablelist>
 
-<!-- On SLE 11 HA SP2: 
+<!-- On SLE 11 HA SP2:
     # rpm -q python-dateutil
 python-dateutil-1.4.1-1.20
   -->
@@ -2209,7 +2213,7 @@ python-dateutil-1.4.1-1.20
 Source: live
 Period: 2012-01-12 14:10:56 - end
 Nodes: &node1;
-Groups: 
+Groups:
 Resources:</screen>
 
   <para>


### PR DESCRIPTION
### Description

For SLE-22500. All references to hb_report had already been replaced, but I added a reference to the log file for crmsh per Tanja's comment in SLE-21746. Let me know if there's anything I've missed that still needs to be done for this issue.

(Looks like my text editor also deleted some white spaces). 

### Backports

- [x] To maintenance/SLEHA15SP4
- [ ] To maintenance/SLEHA15SP3
- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

SLE-22500
