### PR TITLE
Fix master and slave references in multiple files

### DIFF
--- a/xml/geo_ip_i.xml
+++ b/xml/geo_ip_i.xml
@@ -105,7 +105,7 @@
    <callout arearefs="co-dyn-dns-srv">
     <para>
      IP address of the DNS server to send the updates to. If no server is
-     provided, this defaults to the master server for the correct zone.
+     provided, this defaults to the primary server for the correct zone.
     </para>
    </callout>
    <callout arearefs="co-dyn-dns-srv-port">

--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -112,7 +112,7 @@
     </para>
    </important>
    <para>
-    Your cluster can contain up to 32 Linux servers. Using 
+    Your cluster can contain up to 32 Linux servers. Using
     &pmrm;, the cluster can be extended to include
     additional Linux servers beyond this limit.
     Any server in the cluster can restart resources (applications, services, IP
@@ -222,7 +222,7 @@
     services the cluster provides. Network latency, limited bandwidth and
     access to storage are the main challenges for long-distance clusters.
    </para>
-   
+
   </sect2>
 
   <sect2 xml:id="sec-ha-features-ra">
@@ -716,8 +716,8 @@
     monitors all other related daemons. The daemon that coordinates all actions,
     <systemitem class="daemon">pacemaker-controld</systemitem>, has an instance on
     each cluster node. Pacemaker centralizes all cluster decision-making by
-    electing one of those instances as a master. Should the elected <systemitem
-    class="daemon">pacemaker-controld</systemitem> daemon fail, a new one is
+    electing one of those instances as a primary. Should the elected <systemitem
+    class="daemon">pacemaker-controld</systemitem> daemon fail, a new primary is
     established.
    </para>
    <para>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -736,9 +736,9 @@ C = number of cluster nodes</screen>
        <xref linkend="sec-ha-config-basics-resources-advanced-clones"/>.
       </para>
       <para>
-       Promotable clones (formerly known master/slave or multi-state resources) are a
+       Promotable clones (also known as multi-state resources) are a
        special type of clone resources that can be promoted.
-       <!--<xref linkend="sec-ha-config-basics-resources-advanced-masters"/>--></para>
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>
@@ -947,7 +947,7 @@ C = number of cluster nodes</screen>
         ygao 2018-03-12: The text is still a correct description.-->
         Active instances of these resources are divided into two states,
         active and passive. These are also sometimes called primary and
-        secondary, or master and slave. Promotable clones can be either
+        secondary. Promotable clones can be either
         anonymous or globally unique. See also
         <xref linkend="sec-ha-config-basics-resources-advanced-masters"/>.
        </para>
@@ -985,9 +985,8 @@ C = number of cluster nodes</screen>
     <para>
      Promotable clones (formerly known as multi-state resources) are a
      specialization of clones. They allow the
-     instances to be in one of two operating modes (called
-     <literal>master</literal> or <literal>slave</literal>, but can mean
-     whatever you want them to mean). Promotable clones must contain
+     instances to be in one of two operating modes (primary or
+     secondary). Promotable clones must contain
      exactly one group or one regular resource.
     </para>
     <para>
@@ -1297,19 +1296,19 @@ C = number of cluster nodes</screen>
    <title>Instance attributes (parameters)</title>
 <!--info by dejan (SLEHA 11)-->
 <!--The crm now supports a set of ra commands:
-    
+
     [0]s390vm13:~ > crm ra help
-    
+
     Resource Agents (RA) lists and documentation.
-    
-    
+
+
     Available commands:
-    
+
             classes          list classes and providers
             list             list RA for a class (and provider)
             meta             show meta data for a RA
             providers        show providers for a RA
-    
+
     Perhaps you could use that instead of invoking agents by hand.-->
    <para>
     The scripts of all resource classes can be given parameters which
@@ -1343,66 +1342,66 @@ C = number of cluster nodes</screen>
     returns the following output:
    </para>
 <screen>Manages virtual IPv4 addresses (portable version) (ocf:heartbeat:IPaddr)
-    
+
 This script manages IP alias IP addresses
-It can add an IP alias, or remove one.   
-    
+It can add an IP alias, or remove one.
+
 Parameters (* denotes required, [] the default):
-    
+
 ip* (string): IPv4 address
 The IPv4 address to be configured in dotted quad notation, for example
-"192.168.1.1".                                                        
-    
+"192.168.1.1".
+
 nic (string, [eth0]): Network interface
 The base network interface on which the IP address will be brought
-online.                                                           
-    
-If left empty, the script will try and determine this from the    
-routing table.                                                    
-    
+online.
+
+If left empty, the script will try and determine this from the
+routing table.
+
 Do NOT specify an alias interface in the form eth0:1 or anything here;
-rather, specify the base interface only.                              
-    
+rather, specify the base interface only.
+
 cidr_netmask (string): Netmask
 The netmask for the interface in CIDR format. (ie, 24), or in
-dotted quad notation  255.255.255.0).                        
-    
+dotted quad notation  255.255.255.0).
+
 If unspecified, the script will also try to determine this from the
-routing table.                                                     
-    
+routing table.
+
 broadcast (string): Broadcast address
 Broadcast address associated with the IP. If left empty, the script will
-determine this from the netmask.                                        
-    
+determine this from the netmask.
+
 iflabel (string): Interface label
 You can specify an additional label for your IP address here.
-    
+
 lvs_support (boolean, [false]): Enable support for LVS DR
 Enable support for LVS Direct Routing configurations. In case a IP
 address is stopped, only move it to the loopback device to allow the
 local node to continue to service requests, but no longer advertise it
-on the network.                                                       
-    
-local_stop_script (string): 
+on the network.
+
+local_stop_script (string):
 Script called when the IP is released
-    
-local_start_script (string): 
+
+local_start_script (string):
 Script called when the IP is added
-    
+
 ARP_INTERVAL_MS (integer, [500]): milliseconds between gratuitous ARPs
-milliseconds between ARPs                                         
-    
+milliseconds between ARPs
+
 ARP_REPEAT (integer, [10]): repeat count
 How many gratuitous ARPs to send out when bringing up a new address
-    
+
 ARP_BACKGROUND (boolean, [yes]): run in background
 run in background (no longer any reason to do this)
-    
+
 ARP_NETMASK (string, [ffffffffffff]): netmask for ARP
 netmask for ARP - in nonstandard hexadecimal format.
-    
+
 Operations' defaults (advisory minimum):
-    
+
 start         timeout=90
 stop          timeout=100
 monitor_0     interval=5s timeout=20s</screen>
@@ -1890,7 +1889,7 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </varlistentry>
    </variablelist>
-   
+
    <important>
     <title>Restrictions for constraints and certain types of resources</title>
     <itemizedlist>
@@ -1906,8 +1905,8 @@ monitor_0     interval=5s timeout=20s</screen>
      </listitem>
     </itemizedlist>
    </important>
-   
-   
+
+
    <sect3 xml:id="sec-ha-config-basics-constraints-rscset">
     <title>Resource sets</title>
     <para/>
@@ -2452,7 +2451,7 @@ node &node2; utilization memory="4000"
 node  &node3; utilization memory="4000"
 primitive xenA Xen utilization hv_memory="3500" \
      params xmfile="/etc/xen/shared-vm/vm1"
-     meta priority="10" 
+     meta priority="10"
 primitive xenB Xen utilization hv_memory="2000" \
      params xmfile="/etc/xen/shared-vm/vm2"
      meta priority="1"
@@ -2634,8 +2633,8 @@ group g-vm1-and-services vm1 vm1-sshd \
      <literal>hostname</literal> parameter can also be specified for the
      group, instead of adding it to the individual primitives. For example:
     </para>
-<screen>group g-vm1-and-services vm1 vm1-sshd vm1-httpd \ 
-     meta container="vm1" \ 
+<screen>group g-vm1-and-services vm1 vm1-sshd vm1-httpd \
+     meta container="vm1" \
      params hostname="vm1" </screen>
     <para>
      If any of the services monitored by the monitoring plug-ins fail within
@@ -2751,8 +2750,8 @@ group g-vm1-and-services vm1 vm1-sshd \
     <para>
      Configure an <systemitem>ocf:pacemaker:SysInfo</systemitem> resource:
     </para>
-<screen><?dbsuse-fo font-size="0.71em"?>primitive sysinfo ocf:pacemaker:SysInfo \ 
-     params disks="/tmp /var"<co xml:id="co-disks"/> min_disk_free="100M"<co xml:id="co-min-disk-free"/> disk_unit="M"<co xml:id="co-disk-unit"/> \<!--delay="30s"<co id="co-delay"/>\--> 
+<screen><?dbsuse-fo font-size="0.71em"?>primitive sysinfo ocf:pacemaker:SysInfo \
+     params disks="/tmp /var"<co xml:id="co-disks"/> min_disk_free="100M"<co xml:id="co-min-disk-free"/> disk_unit="M"<co xml:id="co-disk-unit"/> \<!--delay="30s"<co id="co-delay"/>\-->
      op monitor interval="15s"</screen>
     <calloutlist>
      <callout arearefs="co-disks">
@@ -2843,7 +2842,7 @@ group g-vm1-and-services vm1 vm1-sshd \
    The node will be returned to service and can run resources again.
   </para>
  </sect1>
- 
+
  <sect1 xml:id="sec-ha-config-basics-more">
   <title>For more information</title>
 

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -18,7 +18,7 @@ TEST SCENARIO:
 50000+0 records out
 51200000 bytes (51 MB) copied, 2.01732 s, 25.4 MB/s
 # losetup /dev/loop0 /loopdev/drbd1.img
-# losetup 
+# losetup
 NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
 /dev/loop0         0      0         0  0 /loopdev/drbd1.img
 
@@ -277,10 +277,9 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
     <note>
      <title>Restricted support for <quote>auto promote</quote> feature</title>
      <para>
-      The DRBD9 feature <quote>auto promote</quote> can use a clone
-      and file system resource instead of a master/slave connection. When using
-      this feature while a file system is being mounted, DRBD will change to
-      primary mode automatically.
+      The DRBD9 feature <quote>auto-promote</quote> can automatically promote a
+      resource to the primary role when one of its devices is mounted or opened
+      for writing.
      </para>
      <para>
       The auto promote feature has currently restricted support.

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -121,11 +121,11 @@
    <para>
     A representation of the whole cluster configuration and status (cluster
     options, nodes, resources, constraints and the relationship to each
-    other). It is written in XML and resides in memory. A master CIB is kept
+    other). It is written in XML and resides in memory. A primary CIB is kept
     and maintained on the
     <xref linkend="glos-dc" xrefstyle="select:nopage"/> and replicated to
     the other nodes. Normal read and write operations on the CIB are
-    serialized through the master CIB.
+    serialized through the primary CIB.
    </para>
   </glossdef>
  </glossentry>
@@ -407,7 +407,7 @@ performance will be met during a contractual measurement period.</para>
    <para>
     The CRM is implemented as daemon, pacemaker-controld. It has an instance on each
     cluster node. All cluster decision-making is centralized by electing one
-    of the pacemaker-controld instances to act as a master. If the elected pacemaker-controld process
+    of the pacemaker-controld instances to act as a primary. If the elected pacemaker-controld process
     fails (or the node it ran on), a new one is established.
    </para>
   </glossdef>

--- a/xml/ha_lb_haproxy.xml
+++ b/xml/ha_lb_haproxy.xml
@@ -63,7 +63,7 @@
   The following section gives an overview of the &haproxy; and how to
   set up on &ha;. The load balancer distributes all requests to its
   back-end servers. It is configured as active/passive, meaning if one
-  master fails, the slave becomes the master. In such a scenario, the user
+  server fails, the passive server becomes active. In such a scenario, the user
   will not notice any interruption.
  </para>
 

--- a/xml/ha_netbonding.xml
+++ b/xml/ha_netbonding.xml
@@ -45,8 +45,8 @@
   The configuration of the bonding device is done by means of bonding module
   options. The behavior is determined through the mode of the bonding
   device. By default, this is <systemitem>mode=active-backup</systemitem>,
-  which means that a different slave device will become active if the active
-  slave fails.
+  which means that a different device will become active if the primary
+  device fails.
  </para>
  <para>
   When using &corosync;, the bonding device is not managed by the cluster
@@ -161,9 +161,6 @@
      </step>
      <step>
       <para>
-       It shows any Ethernet devices that have been configured as bonding
-       slaves in
-       <xref linkend="step-bond-slave" xrefstyle="select:label nopage"/>.
        To select the Ethernet devices that you want to include into the
        bond, activate the check box in front of the respective devices.
       </para>
@@ -266,12 +263,12 @@
  </sect1>
 <!--fate#312287 (SP3), fate#311403 (SP3)-->
  <sect1 xml:id="sec-ha-netbond-hotpug-yast">
-  <title>Hotplugging of bonding slaves</title>
+  <title>Hotplugging devices into a bond</title>
 
   <para>
-   Sometimes it is necessary to replace a bonding slave interface with
+   Sometimes it is necessary to replace an interface in a bond with
    another one, for example, if the respective network device constantly
-   fails. The solution is to set up hotplugging bonding slaves. It is also
+   fails. The solution is to set up hotplugging. It is also
    necessary to change the <systemitem>udev</systemitem> rules to match the
    device by bus ID instead of by MAC address. This enables you to replace
    defective hardware (a network card in the same slot but with a different
@@ -279,11 +276,11 @@
   </para>
 
   <procedure>
-   <title>Configuring hotplugging of bonding slaves with &yast;</title>
+   <title>Hotplugging devices into a bond with &yast;</title>
 <!--taroth 2013-04-17: need to use hard-coded link as books are not in the
     same set-->
    <para>
-    If you prefer manual configuration instead, refer to the &sls; &productname;
+    If you prefer manual configuration instead, refer to the &sls;
     &admin;, chapter <citetitle>Basic Networking</citetitle>, section
     <citetitle>Hotplugging of bond ports</citetitle>.
    </para>
@@ -298,7 +295,7 @@
     <para>
      In the <guimenu>Network Settings</guimenu>, switch to the
      <guimenu>Overview</guimenu> tab, which shows the already configured
-     devices. If bonding slaves are already configured, the
+     devices. If devices are already configured in a bond, the
      <guimenu>Note</guimenu> column shows it.
     </para>
    </step>
@@ -353,9 +350,9 @@
   </procedure>
 
   <para>
-   At boot time, the network setup does not wait for the hotplug slaves, but
-   for the bond to become ready, which needs at least one available slave.
-   When one of the slave interfaces is removed from the system (unbind from
+   At boot time, the network setup does not wait for the hotplug devices, but
+   for the bond to become ready, which needs at least one available device.
+   When one of the interfaces is removed from the system (unbind from
    NIC driver, <command>rmmod</command> of the NIC driver or true PCI
    hotplug removal), the Kernel removes it from the bond automatically. When
    a new card is added to the system (replacement of the hardware in the

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -1,6 +1,6 @@
 <!ENTITY abstract-admin
 " This guide is intended for administrators who need to set up, configure,
-  and maintain clusters with &productnamereg;. For quick and efficient 
+  and maintain clusters with &productnamereg;. For quick and efficient
   configuration and administration, the product includes both a graphical user
   interface and a command line interface (CLI). For performing key tasks,
   both approaches are covered in this guide. Thus, you can choose the appropriate
@@ -17,7 +17,7 @@
 <!ENTITY abstract-nfsquick
 " This document describes how to set up highly available NFS storage in a
     two-node cluster, using the following components:
-    DRBD* (Distributed Replicated Block Device), LVM (Logical Volume Manager), 
+    DRBD* (Distributed Replicated Block Device), LVM (Logical Volume Manager),
     and Pacemaker as cluster resource manager.">
 
 <!ENTITY abstract-geoquick
@@ -43,54 +43,54 @@
    do not run the complete cluster stack and thus are not regular members of the
    cluster.">
 
-<!ENTITY def-existing-cluster 
+<!ENTITY def-existing-cluster
 "  The term <quote xmlns='http://docbook.org/ns/docbook'>existing
     cluster</quote> is used to refer to any
     cluster that consists of at least one node. Existing clusters have a basic
     &corosync; configuration that defines the communication channels, but
     they do not necessarily have resource configuration yet.">
-    
+
  <!ENTITY def-multicast
  '  A technology used for a one-to-many communication within a network that
     can be used for cluster communication. &corosync; supports both
     multicast and unicast.'>
-   
+
 <!ENTITY def-unicast
 '  A technology for sending messages to a single network destination.
     &corosync; supports both multicast and unicast. In &corosync;, unicast
     is implemented as UDP-unicast (UDPU).'>
-   
+
 <!ENTITY def-mcastaddr
 '  IP address to be used for multicasting by the &corosync; executive. The IP
-   address can either be IPv4 or IPv6. '>   
-   
+   address can either be IPv4 or IPv6. '>
+
 <!ENTITY def-mcastport
-'  The port to use for cluster communication.'>   
+'  The port to use for cluster communication.'>
 
 <!ENTITY def-bindnetaddr
 'The network address the &corosync; executive should bind to. '>
 
-<!ENTITY def-rrp 
+<!ENTITY def-rrp
 ' Allows the  use of multiple redundant local area networks for resilience
    against partial or total network faults. This way, cluster communication can
    still be kept up as long as a single network is operational.
    &corosync; supports the Totem Redundant Ring Protocol.'>
-   
- <!ENTITY def-csync2 
+
+ <!ENTITY def-csync2
  'A synchronization tool that can be used to replicate configuration files
-    across all nodes in the cluster, and even across &geo; clusters.'>  
-    
+    across all nodes in the cluster, and even across &geo; clusters.'>
+
 <!ENTITY def-conntrack
 "Allow interaction with the in-kernel connection tracking system for
     enabling <emphasis
     xmlns='http://docbook.org/ns/docbook'>stateful</emphasis> packet
     inspection for iptables. Used by the &hasi; to synchronize the connection
-    status between cluster nodes.">    
-    
+    status between cluster nodes.">
+
 <!ENTITY def-ay
 '&ay; is a system for installing one or more &sle; systems automatically
-    and without user intervention. '>    
-    
+    and without user intervention. '>
+
 
 <!ENTITY maint-mode-basics
 " <para xmlns='http://docbook.org/ns/docbook'>
@@ -99,30 +99,30 @@
    cluster configuration, updating software packages for individual nodes, or
    upgrading the cluster to a higher product version.
   </para>">
-   
+
  <!ENTITY booth-port
  'The port to be used for communication between the booth instances at each
  site.'>
-   
+
  <!ENTITY booth-transport
- 'The transport protocol used for communication between the sites. 
+ 'The transport protocol used for communication between the sites.
    Only UDP is supported, but other transport layers will follow in
    the future.'>
- 
+
  <!ENTITY booth-site
  'The IP address used for the &boothd; on a site. '>
- 
+
  <!ENTITY booth-arbitrator
 ' The IP address of the machine to use as arbitrator. '>
 
  <!ENTITY booth-ticket
  'The tickets to be managed by booth or a cluster administrator.'>
- 
+
  <!ENTITY booth-auth
- 'Enables booth authentication for clients and servers on the basis 
+ 'Enables booth authentication for clients and servers on the basis
   of a shared key. This parameter specifies the path to the
   key file.'>
-  
+
  <!ENTITY booth-key-req
  "<itemizedlist xmlns='http://docbook.org/ns/docbook'>
       <title>Key Requirements</title>
@@ -154,7 +154,7 @@
  xmlns='http://docbook.org/ns/docbook'>one</emphasis> machine to serve as
  arbitrator for <emphasis
  xmlns='http://docbook.org/ns/docbook'>different</emphasis> &geo; clusters.">
-   
+
  <!ENTITY ticket-dependency-loss-policy
  "<para xmlns='http://docbook.org/ns/docbook'>
      For &geo; clusters, you can specify which resources depend on a
@@ -183,11 +183,11 @@
      <listitem>
       <para>
        <literal>demote</literal>: Demote relevant resources that are running
-       in <literal>master</literal> mode to <literal>slave</literal> mode.
+       in active mode to passive mode.
       </para>
      </listitem>
     </itemizedlist>">
-    
+
 <!ENTITY boothd-resource-group
 "<para xmlns='http://docbook.org/ns/docbook'>
       Each site needs to run one instance of
@@ -198,9 +198,9 @@
       possible, add resource stickiness to the configuration. As each daemon
       needs a persistent IP address, configure another primitive with a
       virtual IP address. Group both primitives:</para>">
-      
-      
-<!ENTITY booth-order-constraint     
+
+
+<!ENTITY booth-order-constraint
    "<para xmlns='http://docbook.org/ns/docbook'>
       If a ticket has been granted to a site but all nodes of that site
       should fail to host the <systemitem class='daemon'>boothd</systemitem>
@@ -209,9 +209,9 @@
       &boothd; instance would be available to safely manage failover of the
       ticket to another site. To avoid a potential concurrency violation of the
       ticket (the ticket is granted to multiple sites simultaneously), add an
-      ordering constraint: 
-     </para> ">  
-     
+      ordering constraint:
+     </para> ">
+
 <!ENTITY failback-nodes
 "  <para xmlns='http://docbook.org/ns/docbook'>
     A resource might fail back to its original node when that node is back
@@ -221,8 +221,8 @@
     change its resource stickiness value. You can
     either specify resource stickiness when you are creating a resource or
     afterward.
-   </para>">     
-   
+   </para>">
+
 <!ENTITY placement-strategy-values
 " <variablelist xmlns='http://docbook.org/ns/docbook'>
     <varlistentry>
@@ -254,7 +254,7 @@
       <para>
        Utilization values are considered when deciding if a node has enough
        free capacity to satisfy a resource&apos;s requirements. An attempt is
-       made to concentrate the resources on as few nodes as possible 
+       made to concentrate the resources on as few nodes as possible
        (to achieve power savings on the remaining nodes).
       </para>
      </listitem>
@@ -280,8 +280,8 @@
      results. Ensure that resource priorities are properly set so that
      your most important resources are scheduled first.
     </para>
-   </note>">   
-   
+   </note>">
+
    <!ENTITY drbd-resource
    " <para xmlns='http://docbook.org/ns/docbook'>
       A resource name that allows some association to the
@@ -289,23 +289,23 @@
       the complete DRBD configuration can be synchronized across
       the sites without causing name conflicts.
      </para>" >
-      
+
  <!ENTITY drbd-disk
    "  <para xmlns='http://docbook.org/ns/docbook'>
        The device that is replicated between the nodes. In our example, LVM
        is used as a storage layer below DRBD, and the volume group name is
        <literal>volgroup</literal>.
-      </para>" >   
-      
-      
+      </para>" >
+
+
  <!ENTITY drbd-device
    "  <para xmlns='http://docbook.org/ns/docbook'>
        The device name for DRBD and its minor number. To differentiate
        between the lower layer DRBD for the local replication and the upper
        layer DRBD for replication between the &geo; cluster sites, the device
        minor numbers <literal>0</literal> and <literal>10</literal> are used.
-   </para>" >    
-      
+   </para>" >
+
 <!ENTITY drbd-protocol-c
    "  <para xmlns='http://docbook.org/ns/docbook'>
        DRBD is running in protocol <literal>C</literal>, a synchronous
@@ -315,20 +315,20 @@
        to lead to any data loss. Data loss is, of course, inevitable even with
        this replication protocol if both nodes (or their storage subsystems) are
        irreversibly destroyed at the same time.
-     </para>" >    
-      
+     </para>" >
+
 <!ENTITY drbd-shared-secret
    "  <para xmlns='http://docbook.org/ns/docbook'>
        A shared-secret is used to validate connection pairs. You need a
        different shared-secret for each connection pair. You can get unique
        values with the <command>uuidgen</command> program.
-      </para>" >     
-      
+      </para>" >
+
 <!ENTITY drbd-on
    "  <para xmlns='http://docbook.org/ns/docbook'>
        The <literal>on</literal> section states which host this
        configuration statement applies to.
-      </para>" >   
+      </para>" >
 
 <!ENTITY drbd-address
    " <para xmlns='http://docbook.org/ns/docbook'>
@@ -615,7 +615,7 @@
    <para>
      Mixed architectures within one cluster are not supported. However, for
      &geo; clusters, each member of the &geo; cluster can have a different
-     architecture&mdash;be it a cluster site or an arbitrator. For example, 
+     architecture&mdash;be it a cluster site or an arbitrator. For example,
      you can run a &geo; cluster with three members (two cluster sites and an
      arbitrator), where one cluster site runs on &zseries;, the other
      cluster site runs on &x86;, and the arbitrator runs on &power;.


### PR DESCRIPTION
### Description
 
General fixes that can be backported. Language in ha-netbonding.xml is more vague than Tomas' SP4 changes in doc-sle, since the GUI hasn't changed in older versions.

Did not change any IDs, even though at least one could use changing (sec-ha-config-basics-resources-advanced-masters).

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

jsc#SLE-22017
