### PR TITLE
ha-cluster-bootstrap: update deprecated commands 

### DIFF
--- a/xml/article_geo_clustering.xml
+++ b/xml/article_geo_clustering.xml
@@ -222,7 +222,7 @@
 
   <para>
    All bootstrap scripts log to
-   <filename>/var/log/crmsh.crmsh.log</filename>. Check the log file
+   <filename>/var/log/crmsh/crmsh.log</filename>. Check the log file
    for any details of the bootstrap process. Any options set during the
    bootstrap process can be modified later (by modifying booth settings,
    modifying resources etc.). For details, see the <xref linkend="book-administration"/>.

--- a/xml/article_geo_clustering.xml
+++ b/xml/article_geo_clustering.xml
@@ -222,7 +222,7 @@
 
   <para>
    All bootstrap scripts log to
-   <filename>/var/log/ha-cluster-bootstrap.log</filename>. Check the log file
+   <filename>/var/log/crmsh.crmsh.log</filename>. Check the log file
    for any details of the bootstrap process. Any options set during the
    bootstrap process can be modified later (by modifying booth settings,
    modifying resources etc.). For details, see the <xref linkend="book-administration"/>.

--- a/xml/article_geo_clustering.xml
+++ b/xml/article_geo_clustering.xml
@@ -183,7 +183,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     With <command>ha-cluster-geo-init</command>, turn a cluster into the first
+     With <command>crm cluster geo_init</command>, turn a cluster into the first
      site of a &geo; cluster. The script takes some parameters like the names of
      the clusters, the arbitrator, and one or multiple tickets and creates
      &booth.conf; from them. It copies the booth configuration to all nodes on the
@@ -191,31 +191,31 @@
      booth on the current cluster site.
     </para>
     <para>
-     For details, see <xref linkend="sec-ha-geo-quick-ha-cluster-geo-init"/>.
+     For details, see <xref linkend="sec-ha-geo-quick-crm-cluster-geo-init"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     With <command>ha-cluster-geo-join</command>, add the current cluster to an
+     With <command>crm cluster geo_join</command>, add the current cluster to an
      existing &geo; cluster. The script copies the booth configuration from an
      existing cluster site and writes it to &booth.conf; on all nodes on the
      current cluster site. It also configures the cluster resources needed for
      booth on the current cluster site.
     </para>
     <para>
-     For details, see <xref linkend="sec-ha-geo-quick-ha-cluster-geo-join"/>.
+     For details, see <xref linkend="sec-ha-geo-quick-crm-cluster-geo-join"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     With <command>ha-cluster-geo-init-arbitrator</command>, turn the current
+     With <command>crm cluster geo_init_arbitrator</command>, turn the current
      machine into an arbitrator for the &geo; cluster. The script copies the
      booth configuration from an existing cluster site and writes it to
      &booth.conf;.
     </para>
     <para>
      For details, see
-     <xref linkend="sec-ha-geo-quick-ha-cluster-geo-init-arbitrator"/>.
+     <xref linkend="sec-ha-geo-quick-crm-cluster-geo-init-arbitrator"/>.
     </para>
    </listitem>
   </itemizedlist>
@@ -295,16 +295,16 @@
    </itemizedlist>
   </important>
  </sect1>
- <sect1 xml:id="sec-ha-geo-quick-ha-cluster-geo-init">
+ <sect1 xml:id="sec-ha-geo-quick-crm-cluster-geo-init">
   <title>Setting up the first site of a &geo; cluster</title>
 
   <para>
-   Use the <command>ha-cluster-geo-init</command> script to turn an existing
+   Use the <command>crm cluster geo_init</command> command to turn an existing
    cluster into the first site of a &geo; cluster.
   </para>
 
-  <procedure xml:id="pro-ha-geo-quick-ha-cluster-geo-init">
-   <title>Setting up the first site (<systemitem>&cluster1;</systemitem>) with <command>ha-cluster-geo-init</command></title>
+  <procedure xml:id="pro-ha-geo-quick-crm-cluster-geo-init">
+   <title>Setting up the first site (<systemitem>&cluster1;</systemitem>) with <command>crm cluster geo_init</command></title>
    <step>
     <para>
      Define a virtual IP per cluster site that can be used to access the site.
@@ -332,14 +332,14 @@
      <literal>&node1;</literal> of the cluster <literal>&cluster1;</literal>).
     </para>
    </step>
-   <step xml:id="st-ha-cluster-geo-init">
+   <step xml:id="st-crm-cluster-geo-init">
     <para>
-     Run <command>ha-cluster-geo-init</command>. For example, use the following
+     Run <command>crm cluster geo_init</command>. For example, use the following
      options:
      <remark>taroth 2017-12-29: FATE#322100 - remove the --arbitrator option?
      (see c#6)</remark>
     </para>
-<screen>&prompt.root;<command>ha-cluster-geo-init</command> \
+<screen>&prompt.root;<command>crm cluster geo_init</command> \
   --clusters<co xml:id="co-geo-init-clusters"/> "&cluster1;=&geo-vip-site1; &cluster2;=&geo-vip-site2;" \
   --tickets<co xml:id="co-geo-init-ticket"/> &ticket3; \
   --arbitrator<co xml:id="co-geo-init-arbitrator"/> &geo-ip-arbi;</screen>
@@ -364,14 +364,14 @@
   <para>
    The bootstrap script creates the booth configuration file and synchronizes
    it across the cluster sites. It also creates the basic cluster resources
-   needed for booth. <xref linkend="st-ha-cluster-geo-init" xrefstyle="seletc:label"/> of
-   <xref linkend="pro-ha-geo-quick-ha-cluster-geo-init" xrefstyle="select:label"/>
+   needed for booth. <xref linkend="st-crm-cluster-geo-init" xrefstyle="seletc:label"/> of
+   <xref linkend="pro-ha-geo-quick-crm-cluster-geo-init" xrefstyle="select:label"/>
    would result in the following booth configuration and cluster resources:
    <remark>taroth 2017-12-29: FATE#322100 - remove the arbitrator entry? (c#6)</remark>
   </para>
 
   <example xml:id="ex-geo-init-booth-conf">
-   <title>Booth configuration created by <command>ha-cluster-geo-init</command></title>
+   <title>Booth configuration created by <command>crm cluster geo_init</command></title>
 <screen># The booth configuration file is "/etc/booth/booth.conf". You need to
 # prepare the same booth configuration file on each arbitrator and
 # each node in the cluster sites where the booth daemon can be launched.
@@ -390,7 +390,7 @@ expire="600"</screen>
   </example>
 
   <example xml:id="ex-geo-init-rsc-conf">
-   <title>Cluster resources created by <command>ha-cluster-geo-init</command></title>
+   <title>Cluster resources created by <command>crm cluster geo_init</command></title>
 <screen>primitive<co xml:id="co-geo-quick-rsc-booth-ip"/> booth-ip IPaddr2 \
   params rule #cluster-name eq &cluster1; ip=&geo-vip-site1; \
   params rule #cluster-name eq &cluster2; ip=&geo-vip-site2; \
@@ -433,31 +433,31 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
    </calloutlist>
   </example>
  </sect1>
- <sect1 xml:id="sec-ha-geo-quick-ha-cluster-geo-join">
+ <sect1 xml:id="sec-ha-geo-quick-crm-cluster-geo-join">
   <title>Adding another site to a &geo; cluster</title>
 
   <para>
    After you have initialized the first site of your &geo; cluster, add the
-   second cluster with <literal>ha-cluster-geo-join</literal>, as described in
-   <xref linkend="pro-ha-geo-quick-ha-cluster-geo-join"
+   second cluster with <literal>crm cluster geo_join</literal>, as described in
+   <xref linkend="pro-ha-geo-quick-crm-cluster-geo-join"
    xrefstyle="select:label"/>.
    The script needs SSH access to an already configured cluster site and will
    add the current cluster to the &geo; cluster.
   </para>
 
-  <procedure xml:id="pro-ha-geo-quick-ha-cluster-geo-join">
-   <title>Adding the second site (<literal>&cluster2;</literal>) with <command>ha-cluster-geo-join</command></title>
+  <procedure xml:id="pro-ha-geo-quick-crm-cluster-geo-join">
+   <title>Adding the second site (<literal>&cluster2;</literal>) with <command>crm cluster geo_join</command></title>
    <step>
     <para>
      Log in to a node of the cluster site you want to add (for example, on node
      <literal>&node3;</literal> of the cluster <literal>&cluster2;</literal>).
     </para>
    </step>
-   <step xml:id="st-ha-cluster-geo-join">
+   <step xml:id="st-crm-cluster-geo-join">
     <para>
-     Run the <command>ha-cluster-geo-join</command> command. For example:
+     Run the <command>crm cluster geo_join</command> command. For example:
     </para>
-<screen>&prompt.root;<command>ha-cluster-geo-join</command> \
+<screen>&prompt.root;<command>crm cluster geo_join</command> \
   --cluster-node<co xml:id="co-geo-join-cluster-node"/> &geo-vip-site1;\
   --clusters<co xml:id="co-geo-join-clusters"/> "&cluster1;=&geo-vip-site1; &cluster2;=&geo-vip-site2;"
      </screen>
@@ -479,7 +479,7 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
   </procedure>
 
   <para>
-   The <command>ha-cluster-geo-join</command> script copies the booth
+   The <command>crm cluster geo_join</command> command copies the booth
    configuration from
    <xref linkend="co-geo-join-cluster-node" xrefstyle="select:label"/>, see
    <xref linkend="ex-geo-init-booth-conf" xrefstyle="select:label"/>. In
@@ -488,19 +488,19 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
    xrefstyle="select:label"/>).
   </para>
  </sect1>
- <sect1 xml:id="sec-ha-geo-quick-ha-cluster-geo-init-arbitrator">
+ <sect1 xml:id="sec-ha-geo-quick-crm-cluster-geo-init-arbitrator">
   <title>Adding the arbitrator</title>
 
   <para>
    <remark>taroth 2017-12-29: FATE#322100 - move this section to Geo Guide? (c#6)</remark>
    After you have set up all sites of your &geo; cluster with
-   <command>ha-cluster-geo-init</command> and
-   <command>ha-cluster-geo-join</command>, set up the arbitrator with
-   <command>ha-cluster-geo-init-arbitrator</command>.
+   <command>crm cluster geo_init</command> and
+   <command>crm cluster geo_join</command>, set up the arbitrator with
+   <command>crm cluster geo_init_arbitrator</command>.
   </para>
 
-  <procedure xml:id="pro-ha-geo-quick-ha-cluster-geo-init-arbitrator">
-   <title>Setting up the arbitrator with <command>ha-cluster-geo-init-arbitrator</command></title>
+  <procedure xml:id="pro-ha-geo-quick-crm-cluster-geo-init-arbitrator">
+   <title>Setting up the arbitrator with <command>crm cluster geo_init_arbitrator</command></title>
    <step>
     <para>
      Log in to the machine you want to use as arbitrator.
@@ -510,7 +510,7 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
     <para>
      Run the following command. For example:
     </para>
-<screen>&prompt.root;<command>ha-cluster-geo-init-arbitrator</command> --cluster-node<co
+<screen>&prompt.root;<command>crm cluster geo_init_arbitrator</command> --cluster-node<co
    xml:id="co-geo-init-arbitrator-cluster-node"/> &geo-vip-site1;</screen>
     <calloutlist>
      <callout arearefs="co-geo-init-arbitrator-cluster-node">
@@ -526,7 +526,7 @@ meta target-role=Stopped<co xml:id="co-geo-quick-rsc-stopped"/></screen>
   </procedure>
 
   <para>
-   The <command>ha-cluster-geo-init-arbitrator</command> script copies the
+   The <command>crm cluster geo_init_arbitrator</command> script copies the
    booth configuration from
    <xref linkend="co-geo-init-arbitrator-cluster-node"/>, see
    <xref linkend="ex-geo-init-booth-conf" xrefstyle="select:label"/>. It also

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -155,8 +155,7 @@
  <sect1 xml:id="sec-ha-inst-quick-bootstrap">
   <title>Overview of the bootstrap scripts</title>
   <para>
-   All commands from the <package>ha-cluster-bootstrap</package> package
-   execute bootstrap scripts that require only a minimum of time and manual
+   The following commands execute bootstrap scripts that require only a minimum of time and manual
    intervention.
   </para>
   <itemizedlist>
@@ -178,14 +177,11 @@
    </listitem>
   </itemizedlist>
   <para>
-   All bootstrap scripts log to <filename>/var/log/ha-cluster-bootstrap.log</filename>.
+   All bootstrap scripts log to <filename>/var/log/crmsh.crmsh.log</filename>.
    Check this file for any details of the bootstrap process. Any options set
    during the bootstrap process can be modified later with the
    &yast; cluster module. See <xref linkend="cha-ha-ycluster"/>
    for details.
-  </para>
-  <para>Each script comes with a man page covering the range of functions, the
-   script's options, and an overview of the files the script can create and modify.
   </para>
   <para>
    The bootstrap script <command>crm cluster init</command> checks and

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -177,7 +177,7 @@
    </listitem>
   </itemizedlist>
   <para>
-   All bootstrap scripts log to <filename>/var/log/crmsh.crmsh.log</filename>.
+   All bootstrap scripts log to <filename>/var/log/crmsh/crmsh.log</filename>.
    Check this file for any details of the bootstrap process. Any options set
    during the bootstrap process can be modified later with the
    &yast; cluster module. See <xref linkend="cha-ha-ycluster"/>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -323,9 +323,7 @@
    * https://trello.com/c/rclDZHPR
    * http://www.linux-ha.org/wiki/SBD_Fencing
   -->
-   <!--taroth 2016-07-21: the following is copied from
-    /usr/sbin/ha-cluster-init: If you have shared storage, for example a SAN or
-    iSCSI target, you can use it to avoid split brain scenarios-->
+
    <para>
     If you have shared storage, for example, a SAN (Storage Area Network),
     you can use it to avoid split brain scenarios. To do so, configure SBD

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -635,7 +635,7 @@ softdog                16384  1</screen>
   <para>
     If you have a one-node cluster up and running, add the second cluster
     node with the <command>crm cluster join</command> bootstrap
-    script, as described in <xref linkend="pro-ha-inst-quick-setup-ha-cluster-join"
+    script, as described in <xref linkend="pro-ha-inst-quick-setup-crm-cluster-join"
     xrefstyle="select:label nopage"/>.
     The script only needs access to an existing cluster node and
     will complete the basic setup on the current machine automatically.
@@ -645,7 +645,7 @@ softdog                16384  1</screen>
    The bootstrap scripts take care of changing the configuration specific to
    a two-node cluster, for example, SBD, &corosync;.
   </para>
-  <procedure xml:id="pro-ha-inst-quick-setup-ha-cluster-join">
+  <procedure xml:id="pro-ha-inst-quick-setup-crm-cluster-join">
    <title>Adding the second node (<systemitem class="server">&node2;</systemitem>) with
     <command>crm cluster join</command></title>
    <step>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -96,7 +96,7 @@
   <para>
    Before you proceed, install and set up a basic two-node cluster. This task is
    described in <citetitle>&instquick;</citetitle>. The &instquick; describes
-   how to use the <package>ha-cluster-bootstrap</package> package to set up a
+   how to use the &crmshell; to set up a
    cluster with minimal effort.
   </para>
  </sect1>

--- a/xml/geo_booth_i.xml
+++ b/xml/geo_booth_i.xml
@@ -137,10 +137,7 @@
 
   <para>
    If you have set up your basic &geo; cluster with the
-   <systemitem
-    xmlns='http://docbook.org/ns/docbook'
-    class='resource'>ha-cluster-bootstrap</systemitem>
-   scripts as described in the &geoquick;, the scripts have created a default
+   bootstrap scripts as described in the &geoquick;, the scripts have created a default
    booth configuration on all sites with a minimal set of parameters. To extend
    or fine-tune the minimal booth configuration, have a look at
    <xref linkend="ex-ha-booth-conf-default"
@@ -219,9 +216,7 @@ ticket = "&ticket2;" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle="se
      </para>
      <para>
       If you have set up booth with the
-      <systemitem xmlns='http://docbook.org/ns/docbook'
-       class='resource'>ha-cluster-bootstrap</systemitem>
-      scripts, the virtual IPs you have specified during setup have been
+      bootstrap scripts, the virtual IPs you have specified during setup have been
       written to the booth configuration already (and have been added to the
       cluster configuration, too). To set up the cluster resources manually,
       see <xref linkend="sec-ha-geo-rsc-boothd"/>.

--- a/xml/geo_booth_i.xml
+++ b/xml/geo_booth_i.xml
@@ -257,8 +257,7 @@ ticket = "&ticket2;" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle="se
       another site. If no expiry time is specified, the ticket will expire
       after <literal>600</literal> seconds by default. The parameter should not
       be set to a value less than 120 seconds. The default value set by the
-      <systemitem>crm cluster init</systemitem> scripts is
-      <literal>600</literal>.
+      bootstrap scripts is <literal>600</literal>.
      </para>
     </callout>
     <callout arearefs="co-ha-geo-booth-config-timeout">
@@ -827,7 +826,7 @@ ticket = "tkt-sap-prod" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle=
      <para>
       The booth service for each cluster site is managed by the booth resource
       group (that has either been configured automatically if you used the
-      <systemitem>crm cluster init</systemitem> scripts for &geo; cluster setup,
+      bootstrap scripts for &geo; cluster setup,
       or manually as described in <xref linkend="sec-ha-geo-rsc-boothd"/>). To
       start one instance of the booth service per site, start the respective
       booth resource group on each cluster site.

--- a/xml/geo_more_i.xml
+++ b/xml/geo_more_i.xml
@@ -18,9 +18,7 @@
       xlink:href="https://documentation.suse.com/sle-ha-15/"/>.
      For example, the <citetitle>&geoquick;</citetitle> guides you through
      the basic setup of a &geo; cluster, using the &geo; bootstrap scripts
-     provided by the <systemitem xmlns='http://docbook.org/ns/docbook'
-      class='resource'>ha-cluster-bootstrap</systemitem>
-     package.
+     provided by the &crmshell;.
     </para>
    </listitem>
    <listitem>

--- a/xml/geo_resources_i.xml
+++ b/xml/geo_resources_i.xml
@@ -161,8 +161,7 @@
   <title>Configuring a resource group for <systemitem class="daemon">boothd</systemitem></title>
 
   <para>
-   If you have set up your &geo; cluster with the
-   <systemitem>crm cluster init</systemitem> bootstrap scripts, you can skip the
+   If you have set up your &geo; cluster with the bootstrap scripts, you can skip the
    following procedure as the resources and the resource group for boothd have
    already been configured in this case.
   </para>

--- a/xml/geo_scripts_i.xml
+++ b/xml/geo_scripts_i.xml
@@ -30,7 +30,7 @@
  <itemizedlist>
   <listitem>
    <para>
-    With <command>ha-cluster-geo-init</command>, turn a cluster into the first
+    With <command>crm cluster geo_init</command>, turn a cluster into the first
     member of a &geo; cluster. The script creates &booth.conf; (by taking
     several parameters like the names of the clusters, an arbitrator, and one or
     more tickets). It also configures the following cluster resources needed
@@ -56,13 +56,13 @@
   </listitem>
   <listitem>
    <para>
-    With <command>ha-cluster-geo-join</command>, add the current cluster to an
+    With <command>crm cluster geo_join</command>, add the current cluster to an
     existing &geo; cluster.
    </para>
   </listitem>
   <listitem>
    <para>
-    With <command>ha-cluster-geo-init-arbitrator</command>, make the current node an
+    With <command>crm cluster geo_init_arbitrator</command>, make the current node an
     arbitrator for the &geo; cluster.
    </para>
   </listitem>

--- a/xml/geo_scripts_i.xml
+++ b/xml/geo_scripts_i.xml
@@ -24,8 +24,7 @@
       </dm:docmanager>
     </info>
  <para>
-  All commands from the <package>ha-cluster-bootstrap</package> package
-  execute bootstrap scripts that require only a minimum of time and manual
+  The following commands execute bootstrap scripts that require only a minimum of time and manual
   intervention.
  </para>
  <itemizedlist>
@@ -69,11 +68,8 @@
   </listitem>
  </itemizedlist>
  <para>
-  All bootstrap scripts log to <filename>/var/log/ha-cluster-bootstrap.log</filename>.
+  All bootstrap scripts log to <filename>/var/log/crmsh.crmsh.log</filename>.
   Check this file for any details of the bootstrap process. Any options set
   during the bootstrap process can be modified later.
- </para>
- <para>Each script comes with a man page covering the range of functions, the
-  script's options, and an overview of the files the script can create and modify.
  </para>
 </sect1>

--- a/xml/geo_scripts_i.xml
+++ b/xml/geo_scripts_i.xml
@@ -68,7 +68,7 @@
   </listitem>
  </itemizedlist>
  <para>
-  All bootstrap scripts log to <filename>/var/log/crmsh.crmsh.log</filename>.
+  All bootstrap scripts log to <filename>/var/log/crmsh/crmsh.log</filename>.
   Check this file for any details of the bootstrap process. Any options set
   during the bootstrap process can be modified later.
  </para>

--- a/xml/ha_config_hawk2.xml
+++ b/xml/ha_config_hawk2.xml
@@ -74,9 +74,8 @@
        linkend="pro-ha-hawk2-service"/>.
      </para>
      <para>
-      If you have set up your cluster with the scripts from the
-       <systemitem class="resource">ha-cluster-bootstrap</systemitem> package,
-      the &hawk2; service is already enabled.
+      If you have set up your cluster with the bootstrap scripts provided by
+      the &crmshell;, the &hawk2; service is already enabled.
      </para>
     </listitem>
    </varlistentry>
@@ -169,9 +168,8 @@
   </para>
 
   <para>
-   When setting up the cluster with the
-   <systemitem
-     class="resource">ha-cluster-bootstrap</systemitem> scripts,
+   When setting up the cluster with the bootstrap scripts provided
+   by the &crmshell;,
    you will be asked whether to configure a virtual IP for cluster
    administration.
   </para>

--- a/xml/ha_hawk2_health_i.xml
+++ b/xml/ha_hawk2_health_i.xml
@@ -29,10 +29,7 @@
   details. To verify cluster health and generate the report, &hawk2; requires
   passwordless SSH access between the nodes. Otherwise it can only collect data
   from the current node. If you have set up your cluster with the bootstrap scripts,
-  provided by the
-  <systemitem xmlns='http://docbook.org/ns/docbook'
-   class='resource'>ha-cluster-bootstrap</systemitem>
-  package, passwordless SSH access is already configured. In case you need to
+  provided by the &crmshell;, passwordless SSH access is already configured. In case you need to
   configure it manually, see <xref linkend="sec-crmreport-nonroot-ssh"/>.
  </para>
 

--- a/xml/ha_lb_haproxy.xml
+++ b/xml/ha_lb_haproxy.xml
@@ -313,7 +313,7 @@ backend LB
    <note>
     <para>
      The &csync; configuration part assumes that the HA nodes were
-     configured using <command>ha-cluster-bootstrap</command>. For details,
+     configured using the bootstrap scripts provided by the &crmshell;. For details,
      see the &instquick;.
     </para>
    </note>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -22,7 +22,7 @@
     SBD without shared storage, by running it in diskless mode.
    </para>
    <para>
-    The <package>ha-cluster-bootstrap</package> scripts provide an automated
+    The cluster bootstrap scripts provide an automated
     way to set up a cluster with the option of using SBD as fencing mechanism.
     For details, see the <xref linkend="article-installation"/>. However,
     manually setting up SBD provides you with more options regarding the
@@ -368,7 +368,7 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
     <literal>stonith-timeout</literal> to <literal>288</literal>.
    </para>
     <para>
-     If you use the <package>ha-cluster-bootstrap</package> scripts to set up a
+     If you use the bootstrap scripts provided by the &crmshell; to set up a
      cluster and to initialize the SBD device, the relationship between these
      timeouts is automatically considered.
     </para>

--- a/xml/ha_yast_cluster.xml
+++ b/xml/ha_yast_cluster.xml
@@ -20,7 +20,7 @@
     However, if you prefer an automated approach for setting up a cluster,
     refer to <xref linkend="article-installation"/>. It describes how to install the
     needed packages and leads you to a basic two-node cluster, which is
-    set up with the <systemitem>ha-cluster-bootstrap</systemitem> scripts.
+    set up with the bootstrap scripts provided by the &crmshell;.
    </para>
    <para>
     You can also use a combination of both setup methods, for example: set up

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -8,9 +8,7 @@
 
 <!ENTITY abstract-instquick
 " This document guides you through the setup of a very basic two-node cluster,
-    using the bootstrap scripts provided by the
-    <systemitem xmlns='http://docbook.org/ns/docbook'
-    class='resource'>ha-cluster-bootstrap</systemitem> package.
+    using the bootstrap scripts provided by the &crmshell;.
     This includes the configuration of a virtual IP address as a cluster
     resource and the use of SBD on shared storage as a node fencing mechanism.">
 
@@ -24,9 +22,7 @@
  " &geo; clustering protects workloads across globally distributed data
    centers. This document guides you through the basic setup of a
    &geo; cluster, using the &geo; bootstrap scripts provided by the
-   <systemitem xmlns='http://docbook.org/ns/docbook'
-   class='resource'>ha-cluster-bootstrap</systemitem>
-   package.">
+   &crmshell;.">
 
 <!ENTITY abstract-geoguide
  " This document covers the setup options and parameters for &geo; clusters and


### PR DESCRIPTION
### Description
Part 2 of the work for SLE-23068: deprecate ha-cluster-bootstrap package (including the ones for Geo clustering).

Part 1 was done in https://github.com/SUSE/doc-sleha/commit/c5e7346cc00


No backports required.

