### PR TITLE
SLE-22498 cluster graceful shutdown

### DIFF
--- a/xml/article_pacemaker_remote.xml
+++ b/xml/article_pacemaker_remote.xml
@@ -405,9 +405,9 @@ ssh: connect to host &node3; port 3121: Connection refused</screen>
    <para>To integrate the remote node into the cluster, proceed as follows:</para>
    <procedure>
     <step>
-     <para>Log in to each cluster node and make sure &pace; service is already
-      started:</para>
-     <screen>&prompt.root;<command>crm</command> cluster start</screen>
+     <para>Make sure the &pace; service is already started on all of the cluster
+      nodes:</para>
+     <screen>&prompt.root;<command>crm</command> cluster start --all</screen>
     </step>
     <step>
      <para>On node <systemitem class="domainname">&node1;</systemitem>,
@@ -638,9 +638,9 @@ ssh: connect to host &node4; port 3121: Connection refused</screen>
    <para>To integrate the guest node into the cluster, proceed as follows:</para>
    <procedure>
     <step>
-     <para>Log in to each cluster node and make sure &pace; service is already
-      started:</para>
-     <screen>&prompt.root;<command>crm</command> cluster start</screen>
+     <para>Make sure the &pace; service is already started on all of the cluster
+      nodes:</para>
+     <screen>&prompt.root;<command>crm</command> cluster start --all</screen>
     </step>
      <step xml:id="st-ha-pmremote-integrate-guestsintocluster-virsh-dump">
      <para>Dump the XML configuration of the KVM guest(s) that you need

--- a/xml/article_pacemaker_remote.xml
+++ b/xml/article_pacemaker_remote.xml
@@ -405,8 +405,10 @@ ssh: connect to host &node3; port 3121: Connection refused</screen>
    <para>To integrate the remote node into the cluster, proceed as follows:</para>
    <procedure>
     <step>
-     <para>Make sure the &pace; service is already started on all of the cluster
-      nodes:</para>
+     <para>
+      Make sure the cluster services are already started on all of the cluster nodes.
+      If not, run the following command to start the cluster services on all nodes:
+     </para>
      <screen>&prompt.root;<command>crm</command> cluster start --all</screen>
     </step>
     <step>
@@ -638,8 +640,10 @@ ssh: connect to host &node4; port 3121: Connection refused</screen>
    <para>To integrate the guest node into the cluster, proceed as follows:</para>
    <procedure>
     <step>
-     <para>Make sure the &pace; service is already started on all of the cluster
-      nodes:</para>
+     <para>
+      Make sure the cluster services are already started on all of the cluster nodes.
+      If not, run the following command to start the cluster services on all nodes:
+     </para>
      <screen>&prompt.root;<command>crm</command> cluster start --all</screen>
     </step>
      <step xml:id="st-ha-pmremote-integrate-guestsintocluster-virsh-dump">

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -385,10 +385,9 @@ Node <replaceable>&node2;</replaceable>: standby
   <title>Graceful shutdown not guaranteed</title>
   <para>
    The <option>--all</option> option alone does not guarantee graceful shutdown
-   of the cluster. Failure to stop the resources on a node might happen at the
-   application level, which is out of the scope of <option>--all</option>.
-   If a graceful shutdown is critical for your task, you might need to take additional
-   steps before stopping all of the cluster services. <!--Like what?-->
+   of the cluster, because of the unexpected fencing that might be triggered by
+   resource stop-failure at the application level. If applications are critical,
+   consider stopping them before stopping the cluster services for the whole cluster.
   </para>
  </warning>
 </sect1>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -201,6 +201,18 @@ Node <replaceable>&node2;</replaceable>: standby
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <!--<term>Stopping the cluster services for the whole cluster</term>-->
+    <term><xref linkend="sec-ha-maint-cluster-stop" xrefstyle="select:title"/></term>
+    <listitem>
+     <para>
+      Stopping the cluster services on all nodes at once allows you to shut down
+      a cluster while avoiding the mass migration of resources that would happen
+      if you shut down each node one by one. Because there are no nodes to migrate
+      to, all resources will be stopped.
+     </para>
+    </listitem>
+   </varlistentry>
    <varlistentry xml:id="vle-ha-maint-mode-node">
     <!--<term>Putting a node in maintenance mode</term>-->
     <term><xref linkend="sec-ha-maint-mode-node" xrefstyle="select:title"/></term>
@@ -259,12 +271,12 @@ Node <replaceable>&node2;</replaceable>: standby
      <para>
       If you want the cluster to also cease <emphasis>monitoring</emphasis> the
       resource, use the per-resource maintenance mode instead (see
-      <xref 
+      <xref
       linkend="vle-ha-maint-mode-rsc"/>).
      </para>
     </listitem>
    </varlistentry>
-   
+
   </variablelist>
  </sect1>
 
@@ -356,6 +368,29 @@ Node <replaceable>&node2;</replaceable>: standby
     </para>
    </step>
   </procedure>
+</sect1>
+
+<sect1 xml:id="sec-ha-maint-cluster-stop">
+ <title>Stopping the cluster services for the whole cluster</title>
+ <para>
+  To stop the cluster services on all nodes at once, use the following command:
+ </para>
+<screen>&prompt.root;<command>crm</command> cluster stop --all</screen>
+ <para>
+  To start the cluster services again after your maintenance work is done, use
+  the following command:
+ </para>
+<screen>&prompt.root;<command>crm</command> cluster start --all</screen>
+ <warning>
+  <title>Graceful shutdown not guaranteed</title>
+  <para>
+   The <option>--all</option> option alone does not guarantee graceful shutdown
+   of the cluster. Failure to stop the resources on a node might happen at the
+   application level, which is out of the scope of <option>--all</option>.
+   If a graceful shutdown is critical for your task, you might need to take additional
+   steps before stopping all of the cluster services. <!--Like what?-->
+  </para>
+ </warning>
 </sect1>
 
  <sect1 xml:id="sec-ha-maint-mode-node">

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -960,9 +960,17 @@
     </step>
     <step>
      <para>
-      Start the cluster stack with:
+      Log in to a cluster node and start the cluster stack on all nodes:
      </para>
-<screen>&prompt.root;<command>crm</command> cluster start</screen>
+<screen>&prompt.root;<command>crm</command> cluster start --all</screen>
+     <note>
+      <title><option>--all</option> option only available in version 15 SP4</title>
+      <para>
+       The <option>--all</option> option was added in &productname; 15 SP4.
+       In earlier versions, you must run the <command>crm cluster start</command>
+       command on each node one by one.
+      </para>
+     </note>
     </step>
     <step>
      <para>

--- a/xml/ha_yast_cluster.xml
+++ b/xml/ha_yast_cluster.xml
@@ -325,12 +325,12 @@
     files for a multicast and a unicast setup in
     <filename>/usr/share/doc/packages/corosync/</filename>.
    </para>
-   
+
    <para>If you are using IPv4 addresses, node IDs are optional. If you are using
     IPv6 addresses, node IDs are required. Instead of specifying IDs manually
     for each node, the &yast; cluster module contains an option to automatically
     generate a unique ID for every cluster node.</para>
- 
+
    <procedure xml:id="pro-ha-installation-setup-channel1-udp">
     <title>Defining the first communication channel (multicast)</title>
     <para>
@@ -340,7 +340,7 @@
      other by using the same multicast address. For different clusters, use
      different multicast addresses.
     <!--taroth 2011-10-26: for the records a statement by lmb: Setting up two or more
-     clusters that use the same multicast address, but a different port, also works, 
+     clusters that use the same multicast address, but a different port, also works,
      but is less efficient)-->
     </para>
     <step>
@@ -512,7 +512,7 @@
      </imageobject>
     </mediaobject>
    </figure>
-   
+
    <para>
     If network device bonding cannot be used for any reason, the second
     best choice is to define a redundant communication channel (a second
@@ -553,7 +553,7 @@
      </para>
     </listitem>
    </itemizedlist>
-   
+
   <procedure xml:id="pro-ha-installation-setup-channel2">
    <title>Defining a redundant communication channel</title>
    <important>
@@ -1017,11 +1017,10 @@ Finished with 1 errors.</screen>
   </sect1>
 
   <sect1 xml:id="sec-ha-installation-start">
-   <title>Bringing the cluster online node by node</title>
+   <title>Bringing the cluster online</title>
    <para>
     After the initial cluster configuration is done, start the cluster
-    services on <emphasis>each</emphasis> cluster node to bring the stack
-    online:
+    services on all cluster nodes to bring the stack online:
    </para>
    <procedure>
     <title>Starting cluster services and checking the status</title>
@@ -1032,22 +1031,13 @@ Finished with 1 errors.</screen>
     </step>
     <step>
      <para>
-      Check if the service is already running:
+      Start the cluster services on all cluster nodes:
      </para>
-<screen>&prompt.root;<command>crm</command> cluster status</screen>
-     <para>
-      If not, start the cluster services now:
-     </para>
-<screen>&prompt.root;<command>crm</command> cluster start</screen>
+<screen>&prompt.root;<command>crm</command> cluster start --all</screen>
     </step>
     <step>
      <para>
-      Repeat the steps above for each of the cluster nodes.
-     </para>
-    </step>
-    <step>
-     <para>
-      On one of the nodes, check the cluster status with the
+      Check the cluster status with the
       <command>crm&nbsp;status</command> command. If all nodes are
       online, the output should be similar to the following:
      </para>


### PR DESCRIPTION
### Description

This PR comes in two parts:

1. Added a new section for `crm cluster stop --all`. See xml/ha_maintenance in the diff. There are two new paragraphs. Are these descriptions accurate? Is there more information I should include?

2. Added `--all` to commands that seem like they could use it. See the other files in the diff. Are these changes appropriate, or should I undo any of them? 

@liangxin1300 @zzhou1 can you please review?

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [ ] To maintenance/SLEHA15SP3
- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

jsc#SLE-22498
