### PR TITLE
Change to unicast as default in crm cluster init

### DIFF
--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -470,17 +470,9 @@ softdog                16384  1</screen>
      This is especially helpful to create a &geo; cluster later on,
      as it simplifies the identification of a site.
     </para>
-    <remark>toms 2016-08-11: the following para relates to
-     (a) FATE#320604 allow unicast,
-     (b) FATE#320605 identify AWS and use unicast</remark>
     <para>
-     If you need unicast instead of multicast (the default) for your cluster
-     communication, use the option <option>-u</option>. After installation,
-     find the value <literal>udpu</literal> in the file
-     <filename>/etc/corosync/corosync.conf</filename>.
-     If <command>crm cluster init</command> detects a node running on
-     Amazon Web Services (AWS), the script will use unicast automatically as
-     default for cluster communication.
+     If you need multicast instead of unicast (the default) for your cluster
+     communication, use the option <option>--multicast</option> (or <option>-U</option>).
     </para>
     <para>
      The scripts checks for NTP configuration and a hardware watchdog service.
@@ -517,15 +509,7 @@ softdog                16384  1</screen>
      </step>
      <step>
       <para>
-       Enter a multicast address. The script proposes a random address that
-       you can use as default. Of course, your particular network needs to
-       support this multicast address.
-      </para>
-     </step>
-     <step>
-      <para>
-       Enter a multicast port. The script proposes <literal>5405</literal>
-       as default.
+       Accept the proposed port (<literal>5405</literal>) or enter a different one.
       </para>
      </step>
     </substeps>


### PR DESCRIPTION
### Description

Switched the default from multicast to unicast. Updated steps based on a couple of quick tests.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [ ] To maintenance/SLEHA15SP3
- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

jsc#DOCTEAM-496