### PR TITLE
SEO: Fix broken link in CLVM chapter

### DIFF
--- a/en/xml/ha_clvm.xml
+++ b/en/xml/ha_clvm.xml
@@ -7,12 +7,12 @@
 <!-- Converted by suse-upgrade version 1.1 -->
 <!--taroth 2010-02-10: todo: https://fate.novell.com/307380
   Testcase
-setup 
-1. start cmirrord 
-2. vgconvert -cy $VGNAME 
-3. lvcreate -m 1 ++name $LVNAME ++size $LVSIZE $VGNAME 
-   A mirrored $LVNAME should be created successfully with userspace log. 
-   recover: Following scenarios should be tested under stressed IO load . 
+setup
+1. start cmirrord
+2. vgconvert -cy $VGNAME
+3. lvcreate -m 1 ++name $LVNAME ++size $LVSIZE $VGNAME
+   A mirrored $LVNAME should be created successfully with userspace log.
+   recover: Following scenarios should be tested under stressed IO load .
    device failure during writing
    device failure during syncing
    system crash during writing
@@ -20,17 +20,17 @@ setup
 
 
 Testcase Fate#314367:
-1. create a cluster, at lease two nodes requires. for example /dev/sda 
-   is the shared storage 
-2. create a clustered VG which requires pacemaker have started dlmd and clvmd. 
-   pvcreate /dev/sda vgcreate -cy vg /dev/sda 
-3. create mirrored log lv in cluster lvcreate -nlv -m1 -l10%VG vg -\-mirrorlog mirrored 
-4. use lvs to show the sync percent. the sync percent should grow to 100% which means the mirrored disk synced. 
-5. now you have clustered /dev/vg/lv which have mirrored-log. 
-5.1 read or write /dev/vg/lv to test if the write is OK. 
-5.2 use lvchange -an to deactive and lvchange -ay to re-active 
-5.3 use lvconvert to convert mirrored-log to disk-log use lvconvert to convert disk-log to mirrored-log. 
-6. create a mirrored-log lv in a another cluster VG which is a different vg from previous vg. 
+1. create a cluster, at lease two nodes requires. for example /dev/sda
+   is the shared storage
+2. create a clustered VG which requires pacemaker have started dlmd and clvmd.
+   pvcreate /dev/sda vgcreate -cy vg /dev/sda
+3. create mirrored log lv in cluster lvcreate -nlv -m1 -l10%VG vg -\-mirrorlog mirrored
+4. use lvs to show the sync percent. the sync percent should grow to 100% which means the mirrored disk synced.
+5. now you have clustered /dev/vg/lv which have mirrored-log.
+5.1 read or write /dev/vg/lv to test if the write is OK.
+5.2 use lvchange -an to deactive and lvchange -ay to re-active
+5.3 use lvconvert to convert mirrored-log to disk-log use lvconvert to convert disk-log to mirrored-log.
+6. create a mirrored-log lv in a another cluster VG which is a different vg from previous vg.
    run the same command in step 5 for both cluster LV(mirrored log) at same time.
 
 -->
@@ -136,7 +136,7 @@ cLVM) for more information and details to integrate here - really helpful-->
      </para>
     </formalpara>
    </listitem>
-   <!--taroth 2015-09-23: willl not be shipped for SP1--> 
+   <!--taroth 2015-09-23: willl not be shipped for SP1-->
    <!--<listitem>
      <formalpara>
      <title>Cluster MD</title>
@@ -380,7 +380,7 @@ cLVM) for more information and details to integrate here - really helpful-->
     <step>
      <para>
       Create a clustered volume group (VG):
-<!-- which requires 
+<!-- which requires
           Pacemaker to have started dlmd and clvmd-->
      </para>
 <screen>&prompt.root;<command>pvcreate</command> /dev/sda /dev/sdb
@@ -508,7 +508,7 @@ cLVM) for more information and details to integrate here - really helpful-->
    </procedure>
    <para>
     If you need further information regarding LVM2, refer to the &sls;
-    &productnumber; <citetitle>&storage;</citetitle>: <link xlink:href="dsc;/sles-12/html/SLES-all/cha-lvm.html"></link>.
+    &productnumber; <citetitle>&storage;</citetitle>: <link xlink:href="&dsc;/sles-12/html/SLES-all/cha-lvm.html"></link>.
    </para>
   </sect2>
 
@@ -541,43 +541,43 @@ cLVM) for more information and details to integrate here - really helpful-->
     Configure only one SAN box first. Each SAN box needs to export its own
     iSCSI target. Proceed as follows:
    </para>
-<!-- 
+<!--
     Another setup:
     1. Configure iSCSI daemon on file /etc/ietd.conf
-    
+
     Target iqn.2010-03.de.&wsI;disks
     Lun 0 Sectors=x,Type=nullio
     Lun 1 Path=/dev/sda1,Type=blockio,ScsiId=0
     Lun 2 Path=/dev/sda2,Type=blockio,ScsiId=1
-    
+
     Lun 0 are used only for testing and tuning purpose.
-    
+
     2. Start the Daemon:
     # rciscsitarget start
-    
+
     3. Check:
     # netstat -nltp | grep iet
     tcp 0 0 0.0.0.0:3260 0.0.0.0:* LISTEN 12586/ietd
     tcp 0 0 :::3260 :::* LISTEN 12586/ietd
-    
+
     # tail /var/log/messages
     <ADD LOG MESSAGE>
-    
+
     => Disks are shared over Ethernet
-    
-    
+
+
     Configuring Node Machines:
     1. /etc/iscsi/iscsi.conf:
     node.start = automatic
-    
+
     2. rcopen-iscsi start
-    
+
     3. Detect remote disks:
     # iscsi_discovery <SERVER_IP>
     192.168.1.2:3260,1 iqn.2010-03.&wsI;disks
     192.168.1.2:3260,1 iqn.2010-03.&wsI;disks
-    
-    
+
+
    -->
    <procedure xml:id="pro-ha-clvm-scenario-iscsi-targets">
     <title>Configuring iSCSI Targets (SAN)</title>
@@ -795,7 +795,7 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
       Free PE               127
       Allocated PE          0
       PV UUID               52okH4-nv3z-2AUL-GhAN-8DAZ-GMtU-Xrn9Kh
-      
+
       --- Physical volume ---
       PV Name               /dev/sde
       VG Name               clustervg
@@ -844,19 +844,19 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
     resource, for example OCFS. For more information, see
     <xref linkend="cha-ha-ocfs2"/>.
    </para>
-<!-- 
+<!--
      Create the cmirrord daemon:
      This is already done with cLVM (taroth 2010-09-28: according to lmb, Xin
      Wei extended the clvm RA to always just start cmirrord as well,
      so it doesn't need to be manually configured anymore).
      If you want to create one
      manually, to the following:
-     
+
      &prompt.crm.conf;primitive cmirrord ocf:lvm2:cmirrord
      &prompt.crm.conf;commit
-    
+
      Not clear: Does cmirrord needs to be in the group dlm-clvm?
-    
+
     -->
 <!--<procedure id="">
     <title>Configure iSCSI Initiator (Clients)</title>
@@ -1041,7 +1041,7 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
 <screen>filter = [ "a|/dev/drbd.*|", "a|/dev/.*/by-id/dm-uuid-mpath-.*|",<!--
 --> "r/.*/" ]</screen>
    </step>
-<!--   
+<!--
    <step>
     <para>
      Explicitly accept all the eligible devices, and reject all others.

--- a/ja/xml/ha_clvm.xml
+++ b/ja/xml/ha_clvm.xml
@@ -78,8 +78,8 @@
      </para>
     </formalpara>
    </listitem>
-    
-   
+
+
   </itemizedlist>
   <para>
    次の前提条件を満たしていることを確認してください。
@@ -152,7 +152,7 @@
     </step>
    </procedure>
 
-   
+
   </sect2>
 
   <sect2 xml:id="sec-ha-clvm-config-cmirrord">
@@ -306,7 +306,7 @@
     </step>
    </procedure>
    <para>
-    LVM2に関する詳細情報が必要な場合は、『SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">12 SP5</phrase></phrase> <citetitle>ストレージ管理ガイド</citetitle>』(<link xlink:href="dsc;/sles-12/html/SLES-all/cha-lvm.html"/>)を参照してください。
+    LVM2に関する詳細情報が必要な場合は、『SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">12 SP5</phrase></phrase> <citetitle>ストレージ管理ガイド</citetitle>』(<link xlink:href="&dsc;/sles-12/html/SLES-all/cha-lvm.html"/>)を参照してください。
    </para>
   </sect2>
 
@@ -526,7 +526,7 @@ Login to [iface: default, target: iqn.2010-03.de.jupiter:san1, portal: 192.168.3
       Free PE               127
       Allocated PE          0
       PV UUID               52okH4-nv3z-2AUL-GhAN-8DAZ-GMtU-Xrn9Kh
-      
+
       --- Physical volume ---
       PV Name               /dev/sde
       VG Name               clustervg

--- a/zh_cn/xml/ha_clvm.xml
+++ b/zh_cn/xml/ha_clvm.xml
@@ -78,8 +78,8 @@
      </para>
     </formalpara>
    </listitem>
-    
-   
+
+
   </itemizedlist>
   <para>
    请确保已满足以下先决条件：
@@ -152,7 +152,7 @@
     </step>
    </procedure>
 
-   
+
   </sect2>
 
   <sect2 xml:id="sec-ha-clvm-config-cmirrord">
@@ -306,7 +306,7 @@
     </step>
    </procedure>
    <para>
-    如需有关 LVM2 的更多信息，请参见《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">12 SP5</phrase></phrase> <citetitle> 储存管理指南</citetitle>》：<link xlink:href="dsc;/sles-12/html/SLES-all/cha-lvm.html"/>。
+    如需有关 LVM2 的更多信息，请参见《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">12 SP5</phrase></phrase> <citetitle> 储存管理指南</citetitle>》：<link xlink:href="&dsc;/sles-12/html/SLES-all/cha-lvm.html"/>。
    </para>
   </sect2>
 
@@ -526,7 +526,7 @@ Login to [iface: default, target: iqn.2010-03.de.jupiter:san1, portal: 192.168.3
       Free PE               127
       Allocated PE          0
       PV UUID               52okH4-nv3z-2AUL-GhAN-8DAZ-GMtU-Xrn9Kh
-      
+
       --- Physical volume ---
       PV Name               /dev/sde
       VG Name               clustervg

--- a/zh_tw/xml/ha_clvm.xml
+++ b/zh_tw/xml/ha_clvm.xml
@@ -78,8 +78,8 @@
      </para>
     </formalpara>
    </listitem>
-    
-   
+
+
   </itemizedlist>
   <para>
    請確定您已符合以下先決條件︰
@@ -152,7 +152,7 @@
     </step>
    </procedure>
 
-   
+
   </sect2>
 
   <sect2 xml:id="sec-ha-clvm-config-cmirrord">
@@ -306,7 +306,7 @@
     </step>
    </procedure>
    <para>
-    如需關於 LVM2 的更多資訊，請參閱《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">12 SP5</phrase></phrase> <citetitle> 儲存管理指南</citetitle>》：<link xlink:href="dsc;/sles-12/html/SLES-all/cha-lvm.html"/>。
+    如需關於 LVM2 的更多資訊，請參閱《SUSE Linux Enterprise Server <phrase role="productnumber"><phrase os="sles">12 SP5</phrase></phrase> <citetitle> 儲存管理指南</citetitle>》：<link xlink:href="&dsc;/sles-12/html/SLES-all/cha-lvm.html"/>。
    </para>
   </sect2>
 
@@ -526,7 +526,7 @@ Login to [iface: default, target: iqn.2010-03.de.jupiter:san1, portal: 192.168.3
       Free PE               127
       Allocated PE          0
       PV UUID               52okH4-nv3z-2AUL-GhAN-8DAZ-GMtU-Xrn9Kh
-      
+
       --- Physical volume ---
       PV Name               /dev/sde
       VG Name               clustervg


### PR DESCRIPTION
### Description

Here's the same fix (missing `&` on entity) for the translation branch. This should fix rows 1, 7, and 8 in the spreadsheet.

Also with auto-deleted blank space :shrug: 