### PR TITLE
Fix Cluster Stack in virt guest nodes SVG

### DIFF
--- a/images/src/svg/ha_pmremote-virt-guest-nodes.svg
+++ b/images/src/svg/ha_pmremote-virt-guest-nodes.svg
@@ -291,11 +291,11 @@
          id="tspan6331-9"
          x="87.076309"
          y="131.1756"
-         style="font-size:3.88056px;text-align:center;text-anchor:middle;stroke-width:0.264583;fill:#ffffff;">Physical</tspan><tspan
+         style="font-size:3.88056px;text-align:center;text-anchor:middle;stroke-width:0.264583;fill:#ffffff;">Pacemaker</tspan><tspan
          x="87.076309"
          y="136.02629"
          style="font-size:3.88056px;text-align:center;text-anchor:middle;stroke-width:0.264583;fill:#ffffff;"
-         id="tspan6335-9">host</tspan></text>
+         id="tspan6335-9">Corosync</tspan></text>
     <text
        xml:space="preserve"
        style="font-weight:500;font-size:4.23333px;line-height:1.25;font-family:Poppins;-inkscape-font-specification:'Poppins Medium';text-align:end;letter-spacing:0px;text-anchor:end;stroke-width:0.264583"
@@ -496,11 +496,11 @@
          id="tspan6331-9-7"
          x="150.66188"
          y="131.28424"
-         style="font-size:3.88056px;text-align:center;text-anchor:middle;stroke-width:0.264583;fill:#ffffff;">Physical</tspan><tspan
+         style="font-size:3.88056px;text-align:center;text-anchor:middle;stroke-width:0.264583;fill:#ffffff;">Pacemaker</tspan><tspan
          x="150.66188"
          y="136.13493"
          style="font-size:3.88056px;text-align:center;text-anchor:middle;stroke-width:0.264583;fill:#ffffff;"
-         id="tspan6335-9-4">host</tspan></text>
+         id="tspan6335-9-4">Corosync</tspan></text>
     <g
        id="g4629-5-4-6"
        transform="translate(90.128862,-27.606722)">


### PR DESCRIPTION
### Description

The "cluster stack" section duplicated the text "physical host" from the "hardware" section. It should actually be Pacemaker and Corosync (see [the previous version](https://documentation.suse.com/sle-ha/12-SP3/html/SLE-HA-all/images/ha_pmremote-virt-guest-nodes.svg) and [the other diagrams in that guide](https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/article-pacemaker-remote.html#sec-ha-pmremote-concept)).

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4

