### PR TITLE
Fix iscsi cluster diagram

### DIFF
--- a/images/src/svg/ha_cluster_example4.svg
+++ b/images/src/svg/ha_cluster_example4.svg
@@ -1650,19 +1650,19 @@
     <text
        xml:space="preserve"
        style="font-weight:500;font-size:4.23336px;line-height:1.25;font-family:Poppins;-inkscape-font-specification:'Poppins Medium';text-align:start;letter-spacing:0px;text-anchor:start;stroke-width:0.117833;stroke-miterlimit:4;stroke-dasharray:none"
-       x="88.871368"
-       y="171.44017"
+       x="86.871368"
+       y="173.46584"
        id="text2497-2-9"><tspan
          sodipodi:role="line"
-         x="88.871368"
-         y="171.44017"
+         x="86.871368"
+         y="173.46584"
          style="font-size:4.23336px;text-align:start;text-anchor:start;stroke-width:0.117833"
-         id="tspan4523-8">Fibre Channel</tspan><tspan
+         id="tspan4523-8">Ethernet switch</tspan><tspan
          sodipodi:role="line"
-         x="88.871368"
-         y="176.73187"
+         x="86.871368"
+         y="178.75754"
          style="font-size:4.23336px;text-align:start;text-anchor:start;stroke-width:0.117833"
-         id="tspan6837">switch</tspan></text>
+         id="tspan6837" /></text>
     <text
        xml:space="preserve"
        style="font-weight:500;font-size:4.23336px;line-height:1.25;font-family:Poppins;-inkscape-font-specification:'Poppins Medium';text-align:end;letter-spacing:0px;text-anchor:end;stroke-width:0.117833;stroke-miterlimit:4;stroke-dasharray:none"


### PR DESCRIPTION
### Description

The [iSCSI cluster configuration diagram](https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/cha-ha-concepts.html#id-1.4.3.3.6.7) says "Fibre Channel switch", which seems to be an error (the Fibre Channel diagram is the one above this). See the [12 SP5 version](https://documentation.suse.com/sle-ha/12-SP5/html/SLE-HA-all/cha-ha-concepts.html#id-1.3.3.3.6.6) for comparison. 

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


