### PR TITLE
Add QDevice question to crm cluster init

### DIFF
--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -254,9 +254,13 @@
     <term>&qdevice;/&qnet;</term>
     <listitem>
      <para>
-      This setup is not covered here. To use a &qnet; server,
-      set it up with the bootstrap script as described in
-      <xref linkend="cha-ha-qdevice"/>.
+      It asks you whether to configure &qdevice;/&qnet; to participate in
+      quorum decisions. We recommend using &qdevice; and &qnet; for clusters
+      with an even number of nodes, and especially for two-node clusters.
+     </para>
+     <para>
+      This configuration is not covered here, but you can set it up later as
+      described in <xref linkend="cha-ha-qdevice"/>.
      </para>
     </listitem>
    </varlistentry>
@@ -479,20 +483,6 @@ softdog                16384  1</screen>
      It generates the public and private SSH keys used for SSH access and
      &csync; synchronization and starts the respective services.
     </para>
-    <!--<itemizedlist>
-     <listitem>
-      <para>Checks for a hardware watchdog device.</para>
-     </listitem>
-     <listitem>
-      <para>
-       Generate the public and private SSH keys, used for SSH access and
-       &csync; syncronization.
-      </para>
-     </listitem>
-     <listitem>
-      <para>Start the SSH and &csync; services.</para>
-     </listitem>
-    </itemizedlist>-->
    </step>
    <step>
     <para>
@@ -529,7 +519,6 @@ softdog                16384  1</screen>
     </substeps>
    </step>
    <step xml:id="st-crm-cluster-init-ip">
-    <!-- taroth 2015-09-22: fate#318549: cluster-init: configure virtual IP for HAWK  -->
     <para>Configure a virtual IP address for cluster administration with
     &hawk2;. (We will use this virtual IP resource for testing successful
     failover later on).</para>
@@ -545,6 +534,14 @@ softdog                16384  1</screen>
        you can connect to the virtual IP address.</para>
      </step>
     </substeps>
+   </step>
+   <step>
+    <para>
+     Choose whether to configure &qdevice; and &qnet;. For the minimal setup
+     described in this document, decline with <literal>n</literal> for now.
+     You can set up &qdevice; and &qnet; later, as described in
+     <xref linkend="cha-ha-qdevice"/>.
+    </para>
    </step>
   </procedure>
   <para>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -193,15 +193,14 @@
     <term>NTP</term>
     <listitem>
      <para>
-      If NTP has not been configured to start at boot time, a message appears.
-      Since &productname; 15, chrony is the default implementation of NTP.
+      Checks if NTP is configured to start at boot time. If not, a message appears.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>SSH</term>
     <listitem>
-     <para>It creates SSH keys for passwordless login between cluster nodes.
+     <para>Creates SSH keys for passwordless login between cluster nodes.
      </para>
     </listitem>
    </varlistentry>
@@ -209,7 +208,7 @@
     <term>&csync;</term>
     <listitem>
      <para>
-      It configures &csync; to replicate configuration files across all nodes
+      Configures &csync; to replicate configuration files across all nodes
       in a cluster.
      </para>
     </listitem>
@@ -217,33 +216,33 @@
    <varlistentry>
     <term>&corosync;</term>
     <listitem>
-     <para>It configures the cluster communication system.</para>
+     <para>Configures the cluster communication system.</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>SBD/watchdog</term>
     <listitem>
-     <para>It checks if a watchdog exists and asks you whether to configure SBD
+     <para>Checks if a watchdog exists and asks you whether to configure SBD
       as node fencing mechanism.</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Virtual floating IP</term>
     <listitem>
-     <para>It asks you whether to configure a virtual IP address for cluster
+     <para>Asks you whether to configure a virtual IP address for cluster
       administration with &hawk2;.</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Firewall</term>
     <listitem>
-     <para>It opens the ports in the firewall that are needed for cluster communication.</para>
+     <para>Opens the ports in the firewall that are needed for cluster communication.</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Cluster name</term>
     <listitem>
-     <para>It defines a name for the cluster, by default
+     <para>Defines a name for the cluster, by default
         <systemitem>hacluster</systemitem>. This
       is optional and mostly useful for &geo; clusters. Usually, the cluster
       name reflects the location and makes it easier to distinguish a site
@@ -254,7 +253,7 @@
     <term>&qdevice;/&qnet;</term>
     <listitem>
      <para>
-      It asks you whether to configure &qdevice;/&qnet; to participate in
+      Asks you whether to configure &qdevice;/&qnet; to participate in
       quorum decisions. We recommend using &qdevice; and &qnet; for clusters
       with an even number of nodes, and especially for two-node clusters.
      </para>

--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -14,13 +14,15 @@
    <info>
       <abstract>
          <para>
-            &qdevice; and &qnet; participate in quorum decisions.
-            With the assistance from the arbitrator <systemitem
-               class="daemon">corosync-qnetd</systemitem>, <systemitem
-               class="daemon">corosync-qdevice</systemitem> provides
-            a configurable number of votes, so allowing a cluster
-            to sustain more node failures than the standard quorum rules
-            allow. We strongly recommend deploying <systemitem class="daemon">corosync-qnetd</systemitem> and <systemitem class="daemon">corosync-qdevice</systemitem> for two-node clusters, but using &qnet; and &qdevice; is also recommended in general for clusters with an even number of nodes.
+            &qdevice; and &qnet; participate in quorum decisions. With the
+            assistance from the arbitrator <systemitem class="daemon">corosync-qnetd</systemitem>,
+            <systemitem class="daemon">corosync-qdevice</systemitem> provides
+            a configurable number of votes, so allowing a cluster to sustain
+            more node failures than the standard quorum rules allow. We strongly
+            recommend deploying <systemitem class="daemon">corosync-qnetd</systemitem>
+            and <systemitem class="daemon">corosync-qdevice</systemitem> for
+            two-node clusters, but using &qnet; and &qdevice; is also recommended
+            in general for clusters with an even number of nodes.
          </para>
       </abstract>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -50,7 +52,8 @@
          </listitem>
          <listitem>
             <para>
-               You can write your own heuristics scripts to affect votes. This is especially useful for complex setups, such as SAP applications.
+               You can write your own heuristics scripts to affect votes.
+               This is especially useful for complex setups, such as SAP applications.
             </para>
          </listitem>
          <listitem>

--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -4,7 +4,7 @@
     %entities;
 ]>
 <!--
- 
+
 -->
 <chapter version="5.0" xml:id="cha-ha-qdevice"
    xmlns="http://docbook.org/ns/docbook"
@@ -20,7 +20,7 @@
                class="daemon">corosync-qdevice</systemitem> provides
             a configurable number of votes, so allowing a cluster
             to sustain more node failures than the standard quorum rules
-            allow. We strongly recommend deploying <systemitem class="daemon">corosync-qnetd</systemitem> and <systemitem class="daemon">corosync-qdevice</systemitem> for two-node clusters, but using &qnet; and &qdevice; is also recommended in general for clusters with an even number of nodes.  
+            allow. We strongly recommend deploying <systemitem class="daemon">corosync-qnetd</systemitem> and <systemitem class="daemon">corosync-qdevice</systemitem> for two-node clusters, but using &qnet; and &qdevice; is also recommended in general for clusters with an even number of nodes.
          </para>
       </abstract>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -254,53 +254,37 @@
       <para>
          After you have set up your &qnet; server, you can set up
          and run the clients.
-         You can connect the clients to the &qnet; server during the installation of your cluster
-         or you can add them later. In the following procedure we use
-         the latter approach. We assume a cluster with two cluster nodes
-         (&node1; and &node2;) and the &qnet; server (&node3;).
+         You can connect the clients to the &qnet; server during the installation
+         of your cluster, or you can add them later. This procedure documents how
+         to add them later.
       </para>
       <procedure>
-         <remark>toms 2020-05-11: Is step 2 and step 3 really needed? Can I just
-         jump to step 3?</remark>
          <step>
             <para>
-               On all nodes, make sure you have installed the package
-               <package>corosync-qdevice</package>:
+             On all nodes, install the package <package>corosync-qdevice</package>:
             </para>
             <screen>&prompt.root;<command>zypper</command> install corosync-qdevice</screen>
          </step>
          <step>
             <para>
-               On &node1;, initialize your cluster:
+             On one of the nodes, run the following command to configure &qdevice;:
             </para>
-            <screen>&prompt.root;<command>crm</command> cluster init -y</screen>
-         </step>
-         <step>
+<screen>&prompt.root;<command>crm</command> cluster init qdevice
+Do you want to configure QDevice (y/n)? <command>y</command>
+HOST or IP of the QNetd server to be used []<command><replaceable>QNETD_SERVER</replaceable></command>
+TCP PORT of QNetd server [5403]
+QNetd decision ALGORITHM (ffsplit/lms) [ffsplit]
+QNetd TIE_BREAKER (lowest/highest/valid node id) [lowest]
+Whether using TLS on QDevice/QNetd (on/off/required) [on]
+Heuristics COMMAND to run with absolute path; For multiple commands, use ";" to separate []</screen>
             <para>
-               On &node2;, join the cluster:
-            </para>
-            <screen>&prompt.root;<command>crm</command> cluster join -c &node1; -y</screen>
-         </step>
-         <step>
-            <para>
-               On &node1; and &node2;, bootstrap the <literal>qdevice</literal> stage.
-               In most cases the default settings are fine.
-               Provide at least <option>--qnetd-hostname</option> and the host name or
-               IP address of the &qnet; server (&node3; in our case):
-            </para>
-            <screen>&prompt.root;<command>crm</command> cluster init qdevice --qnetd-hostname=&node3;</screen>
-            <para>
-               If you want to change the default settings, get a list of all
-               possible options with the command <command
-                  >crm cluster init qdevice --help</command>.
-               All options related to &qdevice; start with
-               <option>--qdevice-<replaceable>NAME</replaceable></option>.
+             Confirm with <literal>y</literal> that you want to configure &qdevice;,
+             then enter the host name or IP address of the &qnet; server. For the
+             remaining fields, you can accept the default values or change them
+             if required.
             </para>
          </step>
       </procedure>
-      <para>
-         If you have used the default settings, the command above creates a &qdevice; that has TLS enabled  and  uses the FFSplit algorithm.
-      </para>
    </sect1>
 
    <sect1 xml:id="sec-ha-qdevice-heuristic">

--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -14,15 +14,14 @@
    <info>
       <abstract>
          <para>
-            &qdevice; and &qnet; participate in quorum decisions. With the
+            &qdevice; and &qnet; participate in quorum decisions. With
             assistance from the arbitrator <systemitem class="daemon">corosync-qnetd</systemitem>,
             <systemitem class="daemon">corosync-qdevice</systemitem> provides
-            a configurable number of votes, so allowing a cluster to sustain
-            more node failures than the standard quorum rules allow. We strongly
+            a configurable number of votes, allowing a cluster to sustain
+            more node failures than the standard quorum rules allow. We
             recommend deploying <systemitem class="daemon">corosync-qnetd</systemitem>
             and <systemitem class="daemon">corosync-qdevice</systemitem> for
-            two-node clusters, but using &qnet; and &qdevice; is also recommended
-            in general for clusters with an even number of nodes.
+            clusters with an even number of nodes, and especially for two-node clusters.
          </para>
       </abstract>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -229,18 +228,24 @@
             <para>
                On the machine that will become the  &qnet; server, install
                &sls; &productnumber;.
-               <remark>toms 2020-05-15: See also bsc#1171681</remark>
             </para>
          </step>
          <step>
+          <para>
+           Enable the &productname; using the command listed in
+           <command>SUSEConnect --list-extensions</command>.
+          </para>
+         </step>
+         <step>
             <para>
-               Log in to the &qnet; server and install the following package:
+               Install the <package>corosync-qnetd</package> package:
             </para>
             <screen>&prompt.root;<command>zypper</command> install corosync-qnetd</screen>
             <para>
-               You do not need to manually start the <systemitem class="daemon"
-                  >corosync-qnetd</systemitem> service. The bootstrap scripts
-               will take care of the start-up process during the qdevice stage.
+               You do not need to manually start the
+               <systemitem class="daemon">corosync-qnetd</systemitem> service.
+               It will be started automatically when you configure &qdevice; on
+               the cluster.
       </para>
          </step>
       </procedure>
@@ -255,8 +260,7 @@
    <sect1 xml:id="sec-ha-qdevice-qdevice">
       <title>Connecting &qdevice; clients to the &qnet; server</title>
       <para>
-         After you have set up your &qnet; server, you can set up
-         and run the clients.
+         After you set up your &qnet; server, you can set up and run the clients.
          You can connect the clients to the &qnet; server during the installation
          of your cluster, or you can add them later. This procedure documents how
          to add them later.
@@ -264,7 +268,7 @@
       <procedure>
          <step>
             <para>
-             On all nodes, install the package <package>corosync-qdevice</package>:
+             On all nodes, install the <package>corosync-qdevice</package> package:
             </para>
             <screen>&prompt.root;<command>zypper</command> install corosync-qdevice</screen>
          </step>


### PR DESCRIPTION
### Description

You can configure QDevice using the bootstrap script in interactive mode. I've kept the quickstart minimal for now, but the question needed to at least be mentioned. 

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

jsc#DOCTEAM-499
bsc#1195100
