### PR TITLE
Fix csync2 TCP port

### DIFF
--- a/xml/geo_sync_i.xml
+++ b/xml/geo_sync_i.xml
@@ -13,7 +13,7 @@
  <para>
   To replicate important configuration files across all nodes in the cluster
   and across &geo; clusters, use &csync;.
-<!--taroth 2014-09-25: the following is copied from ha_installation.xml, 
+<!--taroth 2014-09-25: the following is copied from ha_installation.xml,
      varlistentry vle.csync2-->
   &csync; can handle any number of hosts, sorted into synchronization groups.
   Each synchronization group has its own list of member hosts and its
@@ -29,7 +29,7 @@
  </para>
  <para>
   &csync; will contact other servers via a TCP port (by default
-  <literal>6556</literal>), and start remote &csync; instances. For detailed
+  <literal>30865</literal>), and start remote &csync; instances. For detailed
   information about &csync;, refer to
   <link xlink:href="http://oss.linbit.com/csync2/paper.pdf"/>
  </para>


### PR DESCRIPTION
### Description

CSync2 TCP port should be 30865. See https://github.com/LINBIT/csync2/blob/master/doc/csync2.adoc. 

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References

bsc#1186022
DOCTEAM-587
