### PR TITLE
Add firewall warning for diskless SDB

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -924,7 +924,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     <title>Do not block Corosync traffic in the local firewall</title>
     <para>
      Diskless SBD relies on reformed membership and loss of quorum to achieve
-     fencing. Corosync traffic must be able pass through all network interfaces,
+     fencing. Corosync traffic must be able to pass through all network interfaces,
      including the loopback interface, and must not be blocked by a local firewall.
      Otherwise, Corosync cannot reform a new membership, which can cause a
      split-brain scenario that cannot be handled by diskless SBD fencing.

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -921,13 +921,13 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     primitive is needed in the CIB.
    </para>
    <important>
-    <title>Do not block <literal>localhost</literal> UDP traffic in the firewall</title>
+    <title>Do not block Corosync traffic in the local firewall</title>
     <para>
      Diskless SBD relies on reformed membership and loss of quorum to achieve
-     fencing. Always make sure the local firewall does <emphasis>not</emphasis>
-     block cluster communication. Otherwise, Corosync cannot reform a new
-     membership, which can cause a split-brain scenario that cannot be handled
-     by diskless SBD fencing.
+     fencing. Corosync traffic must be able pass through all network interfaces,
+     including the loopback interface, and must not be blocked by a local firewall.
+     Otherwise, Corosync cannot reform a new membership, which can cause a
+     split-brain scenario that cannot be handled by diskless SBD fencing.
     </para>
    </important>
     <important>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -920,6 +920,14 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     the quorum and some reasonable assumptions. No &stonith; SBD resource
     primitive is needed in the CIB.
    </para>
+   <important>
+    <title>Do not block <literal>localhost</literal> UDP traffic in the firewall</title>
+    <para>
+     Diskless SBD relies on reformed membership and loss of quorum to achieve fencing.
+     However, Corosync cannot reform a new membership if the local firewall blocks
+     cluster communication. This can cause a split-brain scenario.
+    </para>
+   </important>
     <important>
      <title>Number of cluster nodes</title>
        <remark>toms 2020-05-14: yan: there are still some self-contradictions

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -923,9 +923,11 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
    <important>
     <title>Do not block <literal>localhost</literal> UDP traffic in the firewall</title>
     <para>
-     Diskless SBD relies on reformed membership and loss of quorum to achieve fencing.
-     However, Corosync cannot reform a new membership if the local firewall blocks
-     cluster communication. This can cause a split-brain scenario.
+     Diskless SBD relies on reformed membership and loss of quorum to achieve
+     fencing. Always make sure the local firewall does <emphasis>not</emphasis>
+     block cluster communication. Otherwise, Corosync cannot reform a new
+     membership, which can cause a split-brain scenario that cannot be handled
+     by diskless SBD fencing.
     </para>
    </important>
     <important>


### PR DESCRIPTION
### Description

Added a warning about blocking cluster communication in the local firewall, especially for diskless SBD.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
DOCTEAM-659
BSC#1200331