### PR TITLE
Convert two-column tables to lists

### DIFF
--- a/xml/ha_acl.xml
+++ b/xml/ha_acl.xml
@@ -47,7 +47,7 @@
    how to check this and upgrade the CIB version, see
    <xref linkend="note-ha-cib-upgrade"/>.
   </para>
-  <!--taroth 2020-03-11: commenting the following because we currently only publish 
+  <!--taroth 2020-03-11: commenting the following because we currently only publish
     11 SP4 docs (the others are out of maintenance)-->
    <!--<para>
    If you have upgraded from &productname; 11 SPx and kept your former
@@ -553,8 +553,6 @@
    <xref linkend="ex-ha-acl-excerpt" xrefstyle="select:label nopage"/>):
   </para>
   <screen>&prompt.root;<command>crm</command> configure show xml</screen>
-  <remark>taroth 2014-08-13: filed https://bugzilla.novell.com/show_bug.cgi?id=891695 for a future "Show CIB"
-   option in Hawk</remark>
   <example xml:id="ex-ha-acl-excerpt">
    <title>Excerpt of a cluster configuration in XML</title>
    <screen>&lt;cib>
@@ -585,125 +583,70 @@
    <literal>/cib/configuration/crm_config</literal>.
   </para>
   <para>
-   As an example, <xref linkend="tab-ha-acl-operator"/> shows the
-   parameters (access type and XPath expression) to create an
+   As an example, the following list shows the XPath expressions to create an
    <quote>operator</quote> role. Users with this role can only execute the
-   tasks mentioned in the second column&mdash;they cannot reconfigure
+   tasks listed here&mdash;they cannot reconfigure
    any resources (for example, change parameters or operations), nor change
    the configuration of colocation or ordering constraints.
   </para>
-  <table xml:id="tab-ha-acl-operator">
-   <title>Operator role&mdash;access types and XPath expressions</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        Type
-       </para>
-      </entry>
-      <entry>
-       <para>
-        XPath/Explanation
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        Write
-       </para>
-      </entry>
-      <entry>
-       <screen>//crm_config//nvpair[@name='maintenance-mode']</screen>
-       <para>
-        Turn cluster maintenance mode on or off.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Write
-       </para>
-      </entry>
-      <entry>
-       <screen>//op_defaults//nvpair[@name='record-pending']</screen>
-       <para>
-        Choose whether pending operations are recorded.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Write
-       </para>
-      </entry>
-      <entry>
-       <screen>//nodes/node//nvpair[@name='standby']</screen>
-       <para>
-        Set node in online or standby mode.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Write
-       </para>
-      </entry>
-      <entry>
-       <screen>//resources//nvpair[@name='target-role']</screen>
-       <para>
-        Start, stop, promote, or demote any resource.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Write
-       </para>
-      </entry>
-      <entry>
-       <screen>//resources//nvpair[@name='maintenance']</screen>
-       <para>
-        Select whether a resource should be put in maintenance mode or not.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Write
-       </para>
-      </entry>
-      <entry>
-       <screen>//constraints/rsc_location</screen>
-       <para>
-        Migrate/move resources from one node to another.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Read
-       </para>
-      </entry>
-      <entry>
-       <screen>/cib</screen>
-       <para>
-        View the status of the cluster.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
+  <variablelist>
+   <varlistentry>
+    <term><command>//crm_config//nvpair[@name='maintenance-mode']</command></term>
+    <listitem>
+     <para>
+      Turn cluster maintenance mode on or off.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>//op_defaults//nvpair[@name='record-pending']</command></term>
+    <listitem>
+     <para>
+      Choose whether pending operations are recorded.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>//nodes/node//nvpair[@name='standby']</command></term>
+    <listitem>
+     <para>
+      Set the node in online or standby mode.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>//resources//nvpair[@name='target-role']</command></term>
+    <listitem>
+     <para>
+      Start, stop, promote, or demote any resource.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>//resources//nvpair[@name='maintenance']</command></term>
+    <listitem>
+     <para>
+      Select whether a resource should be put in maintenance mode or not.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>//constraints/rsc_location</command></term>
+    <listitem>
+     <para>
+      Migrate/move resources from one node to another.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><command>/cib</command></term>
+    <listitem>
+     <para>
+      View the status of the cluster.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </sect1>
 
  <sect1 xml:id="sec-ha-acl-config-tag">

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -1010,286 +1010,187 @@ C = number of cluster nodes</screen>
     &hawk2; as described in
     <xref linkend="pro-conf-hawk2-primitive-add"/>.
    </para>
-   <table xml:id="tab-ha-basics-meta">
+   <variablelist>
     <title>Options for a primitive resource</title>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Option
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Default
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>priority</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         If not all resources can be active, the cluster will stop lower
-         priority resources to keep higher priority ones active.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>0</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>target-role</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         In what state should the cluster attempt to keep this resource?
-         Allowed values: <literal>Stopped</literal>, <literal>Started</literal>,
-         <literal>Unpromoted</literal>, <literal>Promoted</literal>.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>Started</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>is-managed</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Is the cluster allowed to start and stop the resource? Allowed
-         values: <literal>true</literal>, <literal>false</literal>. If the
-         value is set to <literal>false</literal>, the status of the
-         resource is still monitored and any failures are reported. This is
-         different from setting a resource to
-         <literal>maintenance="true"</literal>.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>true</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>maintenance</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Can the resources be touched manually? Allowed values:
-         <literal>true</literal>, <literal>false</literal>. If set to
-         <literal>true</literal>, all resources become unmanaged: the
-         cluster will stop monitoring them and thus be oblivious about their
-         status. You can stop or restart cluster resources at will, without
-         the cluster attempting to restart them.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>false</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>resource-stickiness</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         How much does the resource prefer to stay where it is?
-        </para>
-       </entry>
-       <entry>
-        <para>
-         calculated
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>migration-threshold</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         How many failures should occur for this resource on a node before
-         making the node ineligible to host this resource?
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>INFINITY</literal> (disabled)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>multiple-active</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         What should the cluster do if it ever finds the resource active on
-         more than one node? Allowed values: <literal>block</literal> (mark
-         the resource as unmanaged), <literal>stop_only</literal>,
-         <literal>stop_start</literal>.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>stop_start</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>failure-timeout</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         How many seconds to wait before acting as if the failure had not
-         occurred (and potentially allowing the resource back to the node on
-         which it failed)?
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>0</literal> (disabled)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>allow-migrate</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Allow resource migration for resources which support
-         <literal>migrate_to</literal>/<literal>migrate_from</literal>
-         actions.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>false</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>remote-node</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         The name of the remote node this resource defines. This both
-         enables the resource as a remote node and defines the unique name
-         used to identify the remote node. If no other parameters are set,
-         this value will also be assumed as the host name to connect to at
-         <varname>remote-port</varname>port.
-        </para>
-        <warning>
-         <title>Use unique IDs</title>
-         <para>
-          This value must not overlap with any existing resource or node
-          IDs.
-         </para>
-        </warning>
-       </entry>
-       <entry>
-        <para>
-         none (disabled)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>remote-port</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Custom port for the guest connection to pacemaker_remote.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>3121</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>remote-addr</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         The IP address or host name to connect to if the remote node’s
-         name is not the host name of the guest.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>remote-node</literal> (value used as host name)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>remote-connect-timeout</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         How long before a pending guest connection will time out.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>60s</literal>
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
+    <varlistentry>
+     <term><literal>priority</literal></term>
+     <listitem>
+      <para>
+       If not all resources can be active, the cluster stops lower
+       priority resources to keep higher priority resources active.
+      </para>
+      <para>
+       The default value is <literal>0</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>target-role</literal></term>
+     <listitem>
+      <para>
+       In what state should the cluster attempt to keep this resource?
+       Allowed values: <literal>Stopped</literal>, <literal>Started</literal>,
+       <literal>Unpromoted</literal>, <literal>Promoted</literal>.
+      </para>
+      <para>
+       The default value is <literal>Started</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>is-managed</literal></term>
+     <listitem>
+      <para>
+       Is the cluster allowed to start and stop the resource? Allowed
+       values: <literal>true</literal>, <literal>false</literal>. If the
+       value is set to <literal>false</literal>, the status of the
+       resource is still monitored and any failures are reported. This is
+       different from setting a resource to
+       <literal>maintenance="true"</literal>.
+      </para>
+      <para>
+       The default value is <literal>true</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>maintenance</literal></term>
+     <listitem>
+      <para>
+       Can the resources be touched manually? Allowed values:
+       <literal>true</literal>, <literal>false</literal>. If set to
+       <literal>true</literal>, all resources become unmanaged: the
+       cluster stops monitoring them and does not know their
+       status. You can stop or restart cluster resources without
+       the cluster attempting to restart them.
+      </para>
+      <para>
+       The default value is <literal>false</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>resource-stickiness</literal></term>
+     <listitem>
+      <para>
+       How much does the resource prefer to stay where it is?
+      </para>
+      <para>
+       The default value is <literal>1</literal> for individual clone instances,
+       and <literal>0</literal> for all other resources.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>migration-threshold</literal></term>
+     <listitem>
+      <para>
+       How many failures should occur for this resource on a node before
+       making the node ineligible to host this resource?
+      </para>
+      <para>
+       The default value is <literal>INFINITY</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>multiple-active</literal></term>
+     <listitem>
+      <para>
+       What should the cluster do if it ever finds the resource active on
+       more than one node? Allowed values: <literal>block</literal> (mark
+       the resource as unmanaged), <literal>stop_only</literal>,
+       <literal>stop_start</literal>.
+      </para>
+      <para>
+       The default value is <literal>stop_start</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>failure-timeout</literal></term>
+     <listitem>
+      <para>
+       How many seconds to wait before acting as if the failure did not
+       occur (and potentially allowing the resource back to the node on
+       which it failed)?
+      </para>
+      <para>
+       The default value is <literal>0</literal> (disabled).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>allow-migrate</literal></term>
+     <listitem>
+      <para>
+       Allow live migration for resources which support
+       <literal>migrate_to</literal>/<literal>migrate_from</literal>
+       actions.
+      </para>
+      <para>
+       The default value is <literal>true</literal> for
+       <literal>ocf:pacemaker:remote</literal> resources, and
+       <literal>false</literal> for all other resources.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>remote-node</literal></term>
+     <listitem>
+      <para>
+       The name of the remote node this resource defines. This both
+       enables the resource as a remote node and defines the unique name
+       used to identify the remote node. If no other parameters are set,
+       this value is also assumed as the host name to connect to at the
+       <varname>remote-port</varname> port.
+      </para>
+      <para>
+       This option is disabled by default.
+      </para>
+      <warning>
+       <title>Use unique IDs</title>
+       <para>
+        This value must not overlap with any existing resource or node IDs.
+       </para>
+      </warning>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>remote-port</literal></term>
+     <listitem>
+      <para>
+       Custom port for the guest connection to pacemaker_remote.
+      </para>
+      <para>
+       The default value is <literal>3121</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>remote-addr</literal></term>
+     <listitem>
+      <para>
+       The IP address or host name to connect to if the remote node's
+       name is not the host name of the guest.
+      </para>
+      <para>
+       The default value is the value set by <literal>remote-node</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>remote-connect-timeout</literal></term>
+     <listitem>
+      <para>
+       How long before a pending guest connection times out?
+      </para>
+      <para>
+       The default value is <literal>60s</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </sect2>
 
   <sect2 xml:id="sec-ha-config-basics-inst-attr">

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -1321,206 +1321,140 @@ monitor_0     interval=5s timeout=20s</screen>
    <para>
     By default, the cluster will not ensure that your resources are still
     healthy. To instruct the cluster to do this, you need to add a monitor
-    operation to the resource’s definition. Monitor operations can be
+    operation to the resource's definition. Monitor operations can be
     added for all classes or resource agents. For more information, refer to
     <xref linkend="sec-ha-config-basics-monitoring"/>.
    </para>
-   <table>
+   <variablelist>
     <title>Resource operation properties</title>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Operation
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>id</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Your name for the action. Must be unique. (The ID is not shown).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>name</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         The action to perform. Common values: <literal>monitor</literal>,
+    <varlistentry>
+     <term><literal>id</literal></term>
+     <listitem>
+      <para>
+       Your name for the action. Must be unique. (The ID is not shown).
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>name</literal></term>
+     <listitem>
+      <para>
+       The action to perform. Common values: <literal>monitor</literal>,
          <literal>start</literal>, <literal>stop</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>interval</literal></term>
+     <listitem>
+      <para>
+       How frequently to perform the operation, in seconds.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>timeout</literal></term>
+     <listitem>
+      <para>
+       How long to wait before declaring the action has failed.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>requires</literal></term>
+     <listitem>
+      <para>
+       What conditions need to be satisfied before this action occurs.
+       Allowed values: <literal>nothing</literal>,
+       <literal>quorum</literal>, <literal>fencing</literal>. The default
+       depends on whether fencing is enabled and if the resource's class
+       is <literal>stonith</literal>. For &stonith; resources, the
+       default is <literal>nothing</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>on-fail</literal></term>
+     <listitem>
+      <para>
+       The action to take if this action ever fails. Allowed values:
+      </para>
+      <itemizedlist>
+       <listitem>
         <para>
-         <literal>interval</literal>
+         <literal>ignore</literal>: Pretend the resource did not fail.
         </para>
-       </entry>
-       <entry>
+       </listitem>
+       <listitem>
         <para>
-         How frequently to perform the operation. Unit: seconds
+         <literal>block</literal>: Do not perform any further operations
+         on the resource.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
+       </listitem>
+       <listitem>
         <para>
-         <literal>timeout</literal>
+         <literal>stop</literal>: Stop the resource and do not start it
+         elsewhere.
         </para>
-       </entry>
-       <entry>
+       </listitem>
+       <listitem>
         <para>
-         How long to wait before declaring the action has failed.
+         <literal>restart</literal>: Stop the resource and start it again
+         (possibly on a different node).
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
+       </listitem>
+       <listitem>
         <para>
-         <literal>requires</literal>
+         <literal>fence</literal>: Bring down the node on which the
+         resource failed (&stonith;).
         </para>
-       </entry>
-       <entry>
+       </listitem>
+       <listitem>
         <para>
-         What conditions need to be satisfied before this action occurs.
-         Allowed values: <literal>nothing</literal>,
-         <literal>quorum</literal>, <literal>fencing</literal>. The default
-         depends on whether fencing is enabled and if the resource’s class
-         is <literal>stonith</literal>. For &stonith; resources, the
-         default is <literal>nothing</literal>.
+         <literal>standby</literal>: Move <emphasis>all</emphasis>
+         resources away from the node on which the resource failed.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>on-fail</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         The action to take if this action ever fails. Allowed values:
-        </para>
-        <itemizedlist>
-         <listitem>
-          <para>
-           <literal>ignore</literal>: Pretend the resource did not fail.
-          </para>
-         </listitem>
-         <listitem>
-          <para>
-           <literal>block</literal>: Do not perform any further operations
-           on the resource.
-          </para>
-         </listitem>
-         <listitem>
-          <para>
-           <literal>stop</literal>: Stop the resource and do not start it
-           elsewhere.
-          </para>
-         </listitem>
-         <listitem>
-          <para>
-           <literal>restart</literal>: Stop the resource and start it again
-           (possibly on a different node).
-          </para>
-         </listitem>
-         <listitem>
-          <para>
-           <literal>fence</literal>: Bring down the node on which the
-           resource failed (&stonith;).
-          </para>
-         </listitem>
-         <listitem>
-          <para>
-           <literal>standby</literal>: Move <emphasis>all</emphasis>
-           resources away from the node on which the resource failed.
-          </para>
-         </listitem>
-        </itemizedlist>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>enabled</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         If <literal>false</literal>, the operation is treated as if it does
-         not exist. Allowed values: <literal>true</literal>,
-         <literal>false</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>role</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Run the operation only if the resource has this role.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>record-pending</literal>
-        </para>
-       </entry>
-       <entry>
-<!--lmb 20210-03-09: record-pending can be set either globally or on a per-resource basis to
-         have the CIB reflect the state of "in-flight" operations on resources.
-         Normally the CIB only gets updated once an op finishes.
-         This allows user interfaces to display transient state more accurately
-         and timely (for example, a database would be shown to be "starting"
-         instead of still "stopped"), but since it causes additional CIB updates
-         (the start of every operation needs to be recorded) there is a marginal
-         performance cost, so it isn't enabled by default.-->
-        <para>
-         Can be set either globally or for individual resources. Makes the
+       </listitem>
+      </itemizedlist>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>enabled</literal></term>
+     <listitem>
+      <para>
+       If <literal>false</literal>, the operation is treated as if it does
+       not exist. Allowed values: <literal>true</literal>,
+       <literal>false</literal>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>role</literal></term>
+     <listitem>
+      <para>
+       Run the operation only if the resource has this role.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>record-pending</literal></term>
+     <listitem>
+      <para>
+       Can be set either globally or for individual resources. Makes the
          CIB reflect the state of <quote>in-flight</quote> operations on
          resources.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>description</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description of the operation.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>description</literal></term>
+     <listitem>
+      <para>
+       Description of the operation.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
   </sect2>
 
   <sect2 xml:id="sec-ha-config-basics-timeouts">

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -1010,8 +1010,10 @@ C = number of cluster nodes</screen>
     &hawk2; as described in
     <xref linkend="pro-conf-hawk2-primitive-add"/>.
    </para>
+   <para>
+    The following resource options are available:
+   </para>
    <variablelist>
-    <title>Options for a primitive resource</title>
     <varlistentry>
      <term><literal>priority</literal></term>
      <listitem>
@@ -1325,8 +1327,10 @@ monitor_0     interval=5s timeout=20s</screen>
     added for all classes or resource agents. For more information, refer to
     <xref linkend="sec-ha-config-basics-monitoring"/>.
    </para>
+   <para>
+    Monitor operations can have the following properties:
+   </para>
    <variablelist>
-    <title>Resource operation properties</title>
     <varlistentry>
      <term><literal>id</literal></term>
      <listitem>

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -50,91 +50,51 @@
    the following utilities for management of GFS2 volumes. For syntax
    information, see their man pages.
   </para>
-
-  <table>
-   <title>GFS2 utilities</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        GFS2 Utility
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        fsck.gfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Checks the file system for errors and optionally repairs errors.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        gfs2_jadd
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Adds additional journals to a GFS2 file system.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        gfs2_grow
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Grow a GFS2 file system.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        mkfs.gfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Create a GFS2 file system on a device, usually a shared device or
-        partition.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        tunegfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Allows viewing and manipulating the GFS2 file system parameters such
-        as <varname>UUID</varname>, <varname>label</varname>,
-        <varname>lockproto</varname> and <varname>locktable</varname>.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
+  <variablelist>
+   <varlistentry>
+    <term>fsck.gfs2</term>
+    <listitem>
+     <para>
+      Checks the file system for errors and optionally repairs errors.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>gfs2_jadd</term>
+    <listitem>
+     <para>
+      Adds additional journals to a GFS2 file system.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>gfs2_grow</term>
+    <listitem>
+     <para>
+      Grow a GFS2 file system.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>mkfs.gfs2</term>
+    <listitem>
+     <para>
+      Create a GFS2 file system on a device, usually a shared device or
+      partition.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>tunegfs2</term>
+    <listitem>
+     <para>
+      Allows viewing and manipulating the GFS2 file system parameters such
+      as <varname>UUID</varname>, <varname>label</varname>,
+      <varname>lockproto</varname> and <varname>locktable</varname>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </sect1>
  <sect1 xml:id="sec-ha-gfs2-create-service">
   <title>Configuring GFS2 services and a &stonith; resource</title>

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -186,84 +186,48 @@
    Then create and format the GFS2 volume with the
    <command>mkfs.gfs2</command> as described in
    <xref linkend="pro-gfs2-volume"/>. The most important parameters for the
-   command are listed in <xref linkend="tab-ha-gfs2-mkfs-gfs2-params"/>. For
+   command are listed below. For
    more information and the command syntax, refer to the
    <command>mkfs.gfs2</command> man page.
   </para>
-
-  <table xml:id="tab-ha-gfs2-mkfs-gfs2-params">
-   <title>Important GFS2 parameters</title>
-   <tgroup cols="2">
-    <colspec colname="c1" colwidth="1*"/>
-    <colspec colname="c2" colwidth="3*"/>
-    <thead>
-     <row>
-      <entry>
-       <para>
-        GFS2 Parameter
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description and Recommendation
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        Lock Protocol Name (<option>-p</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        The name of the locking protocol to use. Acceptable locking
-        protocols are lock_dlm (for shared storage) or if you are using GFS2
-        as a local file system (1 node only), you can specify the
-        lock_nolock protocol. If this option is not specified, lock_dlm
-        protocol will be assumed.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Lock Table Name (<option>-t</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        The lock table field appropriate to the lock module you are using.
-        It is
-        <replaceable>clustername</replaceable>:<replaceable>fsname</replaceable>.
-        <replaceable>clustername</replaceable> must match that in the
-        cluster configuration file, &corosync.conf;. Only members of this
-        cluster are permitted to use this file system.
-        <replaceable>fsname</replaceable> is a unique file system name used
-        to distinguish this GFS2 file system from others created (1 to 16
-        characters).
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Number of Journals (<option>-j</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        The number of journals for gfs2_mkfs to create. You need at least
-        one journal per machine that will mount the file system. If this
-        option is not specified, one journal will be created.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
+  <variablelist>
+   <varlistentry>
+    <term>Lock Protocol Name (<option>-p</option>)</term>
+    <listitem>
+     <para>
+      The name of the locking protocol to use. Acceptable locking
+      protocols are lock_dlm (for shared storage) or, if you are using GFS2
+      as a local file system (1 node only), you can specify the
+      lock_nolock protocol. If this option is not specified, lock_dlm
+      protocol is assumed.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Lock Table Name (<option>-t</option>)</term>
+    <listitem>
+     <para>
+      The lock table field appropriate to the lock module you are using. It is
+      <replaceable>clustername</replaceable>:<replaceable>fsname</replaceable>.
+      The <replaceable>clustername</replaceable> value must match that in the
+      cluster configuration file, &corosync.conf;. Only members of this
+      cluster are permitted to use this file system.
+      The <replaceable>fsname</replaceable> value is a unique file system name used
+      to distinguish this GFS2 file system from others created (1 to 16 characters).
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Number of Journals (<option>-j</option>)</term>
+    <listitem>
+     <para>
+      The number of journals for gfs2_mkfs to create. You need at least
+      one journal per machine that will mount the file system. If this
+      option is not specified, one journal is created.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
 
   <procedure xml:id="pro-gfs2-volume">
    <title>Creating and formatting a GFS2 volume</title>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -153,93 +153,53 @@
    provides the following utilities for management of &ocfs; volumes. For
    syntax information, see their man pages.
   </para>
-
-  <table>
-   <title>&ocfs; utilities</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        &ocfs; Utility
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        debugfs.ocfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Examines the state of the OCFS file system for debugging.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        fsck.ocfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Checks the file system for errors and optionally repairs errors.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        mkfs.ocfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Creates an &ocfs; file system on a device, usually a partition on
+  <variablelist>
+   <varlistentry>
+    <term>debugfs.ocfs2</term>
+    <listitem>
+     <para>
+      Examines the state of the OCFS file system for debugging.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>fsck.ocfs2</term>
+    <listitem>
+     <para>
+      Checks the file system for errors and optionally repairs errors.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>mkfs.ocfs2</term>
+    <listitem>
+     <para>
+      Creates an &ocfs; file system on a device, usually a partition on
         a shared physical or logical disk.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        mounted.ocfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Detects and lists all &ocfs; volumes on a clustered system.
-        Detects and lists all nodes on the system that have mounted an
-        &ocfs; device or lists all &ocfs; devices.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        tunefs.ocfs2
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Changes &ocfs; file system parameters, including the volume
-        label, number of node slots, journal size for all node slots, and
-        volume size.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>mounted.ocfs2</term>
+    <listitem>
+     <para>
+      Detects and lists all &ocfs; volumes on a clustered system.
+      Detects and lists all nodes on the system that have mounted an
+      &ocfs; device or lists all &ocfs; devices.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>tunefs.ocfs2</term>
+    <listitem>
+     <para>
+      Changes &ocfs; file system parameters, including the volume
+      label, number of node slots, journal size for all node slots, and
+      volume size.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </sect1>
  <sect1 xml:id="sec-ha-ocfs2-create-service">
   <title>Configuring &ocfs; services and a &stonith; resource</title>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -300,150 +300,100 @@
    Then create and format the &ocfs; volume with the
    <command>mkfs.ocfs2</command> as described in
    <xref linkend="pro-ocfs2-volume"/>. The most important parameters for the
-   command are listed in <xref linkend="tab-ha-ofcs2-mkfs-ocfs2-params"/>.
+   command are listed below.
    For more information and the command syntax, refer to the
    <command>mkfs.ocfs2</command> man page.
   </para>
 
-  <table xml:id="tab-ha-ofcs2-mkfs-ocfs2-params">
-   <title>Important &ocfs; parameters</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        &ocfs; Parameter
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description and Recommendation
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        Volume Label (<option>-L</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        A descriptive name for the volume to make it uniquely identifiable
-        when it is mounted on different nodes. Use the
-        <command>tunefs.ocfs2</command> utility to modify the label as
-        needed.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Cluster Size (<option>-C</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Cluster size is the smallest unit of space allocated to a file to
-        hold the data. For the available options and recommendations, refer
-        to the <command>mkfs.ocfs2</command> man page.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Number of Node Slots (<option>-N</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        The maximum number of nodes that can concurrently mount a volume.
-        For each of the nodes, &ocfs; creates separate system files, such
-        as the journals. Nodes that access the volume
-        can be a combination of little-endian architectures (such as &amd64;/&intel64;)
-        and big-endian architectures (such as &s390;x).
-       </para>
-       <para>
-        Node-specific files are called local files. A node slot
-        number is appended to the local file. For example:
-        <literal>journal:0000</literal> belongs to whatever node is assigned
-        to slot number <literal>0</literal>.
-       </para>
-       <para>
-        Set each volume's maximum number of node slots when you create it,
-        according to how many nodes that you expect to concurrently mount
-        the volume. Use the <command>tunefs.ocfs2</command> utility to
-        increase the number of node slots as needed. Note that the value
-        cannot be decreased, and one node slot will consume about 100&nbsp;MiB
-        of disk space.
-       </para>
-       <para>
-        In case the <option>-N</option> parameter is not specified, the
-        number of node slots is decided based on the size of the file system.
-        For the default value, refer to the <command>mkfs.ocfs2</command> man page.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Block Size (<option>-b</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        The smallest unit of space addressable by the file system. Specify
-        the block size when you create the volume. For the available options
-        and recommendations, refer to the <command>mkfs.ocfs2</command> man
-        page.
-<!-- Brendo, 17.11.2010: to detect the blocksize of the device, use:
-             blockdev -\-getbsz &lt;block-device&gt;. -->
-       </para>
-      </entry>
-     </row>
-<!--https://bugzilla.novell.com/show_bug.cgi?id=586242#c11-->
-     <row>
-      <entry>
-       <para>
-        Specific Features On/Off (<option>--fs-features</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        A comma separated list of feature flags can be provided, and
-        <systemitem>mkfs.ocfs2</systemitem> will try to create the file
-        system with those features set according to the list. To turn a
-        feature on, include it in the list. To turn a feature off, prepend
-        <literal>no</literal> to the name.
-       </para>
-       <para>
-        For an overview of all available flags, refer to the
-        <command>mkfs.ocfs2</command> man page.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        Pre-Defined Features (<option>--fs-feature-level</option>)
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Allows you to choose from a set of pre-determined file system
-        features. For the available options, refer to the
-        <command>mkfs.ocfs2</command> man page.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
-<!--https://bugzilla.novell.com/show_bug.cgi?id=586242#c15-->
+  <variablelist>
+   <varlistentry>
+    <term>Volume Label (<option>-L</option>)</term>
+    <listitem>
+     <para>
+      A descriptive name for the volume to make it uniquely identifiable
+      when it is mounted on different nodes. Use the
+      <command>tunefs.ocfs2</command> utility to modify the label as needed.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Cluster Size (<option>-C</option>)</term>
+    <listitem>
+     <para>
+      The smallest unit of space allocated to a file to
+      hold the data. For the available options and recommendations, refer
+      to the <command>mkfs.ocfs2</command> man page.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Number of Node Slots (<option>-N</option>)</term>
+    <listitem>
+     <para>
+      The maximum number of nodes that can concurrently mount a volume.
+      For each of the nodes, &ocfs; creates separate system files, such
+      as the journals. Nodes that access the volume
+      can be a combination of little-endian architectures (such as &amd64;/&intel64;)
+      and big-endian architectures (such as &s390;x).
+     </para>
+     <para>
+      Node-specific files are called local files. A node slot
+      number is appended to the local file. For example:
+      <literal>journal:0000</literal> belongs to whatever node is assigned
+      to slot number <literal>0</literal>.
+     </para>
+     <para>
+      Set each volume's maximum number of node slots when you create it,
+      according to how many nodes that you expect to concurrently mount
+      the volume. Use the <command>tunefs.ocfs2</command> utility to
+      increase the number of node slots as needed. Note that the value
+      cannot be decreased, and one node slot will consume about 100&nbsp;MiB
+      of disk space.
+     </para>
+     <para>
+      If the <option>-N</option> parameter is not specified, the
+      number of node slots is decided based on the size of the file system.
+      For the default value, refer to the <command>mkfs.ocfs2</command> man page.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Block Size (<option>-b</option>)</term>
+    <listitem>
+     <para>
+      The smallest unit of space addressable by the file system. Specify
+      the block size when you create the volume. For the available options
+      and recommendations, refer to the <command>mkfs.ocfs2</command> man page.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Specific Features On/Off (<option>--fs-features</option>)</term>
+    <listitem>
+     <para>
+      A comma separated list of feature flags can be provided, and
+      <systemitem>mkfs.ocfs2</systemitem> will try to create the file
+      system with those features set according to the list. To turn a
+      feature on, include it in the list. To turn a feature off, prepend
+      <literal>no</literal> to the name.
+     </para>
+     <para>
+      For an overview of all available flags, refer to the
+      <command>mkfs.ocfs2</command> man page.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Pre-Defined Features (<option>--fs-feature-level</option>)</term>
+    <listitem>
+     <para>
+      Allows you to choose from a set of pre-determined file system
+      features. For the available options, refer to the
+      <command>mkfs.ocfs2</command> man page.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
 
   <para>
    If you do not specify any features when creating and formatting

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -371,7 +371,7 @@
     <term>Specific Features On/Off (<option>--fs-features</option>)</term>
     <listitem>
      <para>
-      A comma separated list of feature flags can be provided, and
+      A comma-separated list of feature flags can be provided, and
       <systemitem>mkfs.ocfs2</systemitem> will try to create the file
       system with those features set according to the list. To turn a
       feature on, include it in the list. To turn a feature off, prepend
@@ -384,10 +384,10 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Pre-Defined Features (<option>--fs-feature-level</option>)</term>
+    <term>Predefined Features (<option>--fs-feature-level</option>)</term>
     <listitem>
      <para>
-      Allows you to choose from a set of pre-determined file system
+      Allows you to choose from a set of predetermined file system
       features. For the available options, refer to the
       <command>mkfs.ocfs2</command> man page.
      </para>

--- a/xml/ha_requirements.xml
+++ b/xml/ha_requirements.xml
@@ -88,75 +88,35 @@
 
 &sys-req-sw-modules;
 
-   <para>
-   Depending on the <systemitem>system roles</systemitem> you select during
+  <para>
+   Depending on the system role you select during
    installation, the following software patterns are installed by default:
- </para>
- <table>
-  <title>System roles and installed patterns</title>
-  <tgroup cols="2">
-   <colspec colnum="1" colname="1" colwidth="50*"/>
-   <colspec colnum="2" colname="2" colwidth="50*"/>
-   <thead>
-    <row>
-     <entry>
-      <para>
-       System Role
-      </para>
-     </entry>
-     <entry>
-      <para>
-       Software Pattern (&yast;/Zypper)
-      </para>
-     </entry>
-    </row>
-   </thead>
-   <tbody>
-    <row>
-     <entry>
-      <para>
-       HA Node
-      </para>
-     </entry>
-     <entry>
-       <itemizedlist>
-        <listitem>
-         <para>
-          &ha; (sles_ha)
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-         Enhanced Base System (enhanced_base)
-         </para>
-        </listitem>
-       </itemizedlist>
-     </entry>
-    </row>
-    <row>
-     <entry>
-      <para>
-       HA GEO Node
-      </para>
-     </entry>
-      <entry>
-       <itemizedlist>
-        <listitem>
-         <para>
-          &geo; Clustering for &ha; (ha_geo)
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          Enhanced Base System (enhanced_base)
-         </para>
-        </listitem>
-       </itemizedlist>
-      </entry>
-    </row>
-   </tbody>
-  </tgroup>
- </table>
+  </para>
+  <variablelist>
+   <varlistentry>
+    <term>HA Node system role</term>
+    <listitem>
+     <para>
+      &ha; (<literal>sles_ha</literal>)
+     </para>
+     <para>
+      Enhanced Base System (<literal>enhanced_base</literal>)
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>HA GEO Node system role</term>
+    <listitem>
+     <para>
+      &geo; Clustering for &ha; (<literal>ha_geo</literal>)
+     </para>
+     <para>
+      Enhanced Base System (<literal>enhanced_base</literal>)
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
   <note>
    <title>Minimal installation</title>
    <para>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -377,16 +377,10 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
  <sect1 xml:id="sec-ha-storage-protect-watchdog">
   <title>Setting up the watchdog</title>
   <para> &productname; ships with several kernel modules that provide
-   hardware-specific watchdog drivers. For a list of the most commonly used
-   ones, see <xref
-   linkend="tab-ha-storage-protect-watchdog-drivers" xrefstyle="select:title
-   nopage"/>.
- </para>
- <para>
-  For clusters in production environments we recommend to use a hardware-specific
-  watchdog driver. However, if no watchdog matches your hardware,
-  <systemitem class="resource">softdog</systemitem> can be used as kernel
-  watchdog module.
+   hardware-specific watchdog drivers. For clusters in production environments,
+   we recommend using a hardware-specific watchdog driver. However, if no watchdog
+   matches your hardware, <systemitem class="resource">softdog</systemitem> can
+   be used as kernel watchdog module.
  </para>
  <para>
    The &hasi; uses the SBD daemon as the software component that <quote>feeds</quote>
@@ -396,57 +390,51 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
    <title>Using a hardware watchdog</title>
 
    <para>Finding the right watchdog kernel module for a given system is not
-    trivial. Automatic probing fails very often. As a result, lots of modules
+    trivial. Automatic probing fails very often. As a result, many modules
     are already loaded before the right one gets a chance.</para>
-
-  <para>
-   <xref linkend="tab-ha-storage-protect-watchdog-drivers" xrefstyle="select:label"/>
-   lists the most commonly used watchdog drivers. If your hardware is not listed there,
-   the directories
-   <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/watchdog</filename>
-   or
-   <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/ipmi</filename>
-   give you a list of choices, too. Alternatively, ask your hardware or
-   system vendor for details on system specific watchdog configuration.
+   <para>
+    The following watchdog drivers are commonly used:
    </para>
-
-     <table xml:id="tab-ha-storage-protect-watchdog-drivers">
-        <title>Commonly used watchdog drivers</title>
-        <tgroup cols="2">
-         <thead>
-          <row>
-           <entry>Hardware</entry>
-           <entry>Driver</entry>
-          </row>
-         </thead>
-         <tbody>
-          <row>
-           <entry>HP</entry>
-           <entry><systemitem class="resource">hpwdt</systemitem></entry>
-          </row>
-          <row>
-           <entry>Dell, Lenovo (Intel TCO)</entry>
-           <entry><systemitem class="resource">iTCO_wdt</systemitem></entry>
-          </row>
-          <row>
-           <entry>Fujitsu</entry>
-           <entry><systemitem class="resource">ipmi_watchdog</systemitem></entry>
-          </row>
-          <row>
-           <entry>VM on z/VM on IBM mainframe</entry>
-           <entry><systemitem class="resource">vmwatchdog</systemitem></entry>
-          </row>
-          <row>
-           <entry>Xen VM (DomU)</entry>
-           <entry><systemitem class="resource">xen_xdt</systemitem></entry>
-          </row>
-          <row>
-           <entry>Generic</entry>
-           <entry><systemitem class="resource">softdog</systemitem></entry>
-          </row>
-         </tbody>
-        </tgroup>
-       </table>
+   <itemizedlist>
+    <listitem>
+     <para>
+      <systemitem class="resource">hpwdt</systemitem> for HP
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <systemitem class="resource">iTCO_wdt</systemitem> for Dell and Lenovo (Intel TCO)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <systemitem class="resource">ipmi_watchdog</systemitem> for Fujitsu
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <systemitem class="resource">vmwatchdog</systemitem> for VMs on IBM z/VM
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <systemitem class="resource">xen_xdt</systemitem> for Xen VMs (DomU)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <systemitem class="resource">softdog</systemitem> for generic hardware
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    If your hardware is not listed here, the directories
+    <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/watchdog</filename>
+    and
+    <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/ipmi</filename>
+    also give you a list of choices. Alternatively, ask your hardware or
+    system vendor for details on system specific watchdog configuration.
+   </para>
 
  <important>
     <title>Accessing the watchdog timer</title>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -433,7 +433,7 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
     and
     <filename>/lib/modules/<replaceable>KERNEL_VERSION</replaceable>/kernel/drivers/ipmi</filename>
     also give you a list of choices. Alternatively, ask your hardware or
-    system vendor for details on system specific watchdog configuration.
+    system vendor for details on system-specific watchdog configuration.
    </para>
 
  <important>


### PR DESCRIPTION
### Description

I converted some tables into lists, where it made sense to do so. I did a little bit of editing in a couple of them, but mostly tried to avoid changing the content at all. 

Conveniently, all of the tables I could find that needed converting were in the Administration Guide. Here's a PDF of the new version:

[book-administration_color_en.pdf](https://github.com/SUSE/doc-sleha/files/9069283/book-administration_color_en.pdf)

Here's a list of the tables I converted: 

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-requirements.html#id-1.4.3.4.4.5 System roles and installed patterns
New: See 2.2 Software requirements in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-config-basics.html#tab-ha-basics-meta Options for a primitive resource
New: See 6.3.6 Resource options (meta attributes) in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-config-basics.html#id-1.4.4.3.5.10.3 Resource operation properties
New: See 6.3.8 Resource operations in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-storage-protect.html#tab-ha-storage-protect-watchdog-drivers Commonly used watchdog drivers
New: See 11.6.1 Using a hardware watchdog in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-acl.html#tab-ha-acl-operator Operator role—access types and XPath expressions
New: See 13.7 Setting ACL rules via XPath expressions in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-ocfs2.html#id-1.4.5.4.4.4 OCFS2 utilities
New: See 19.2 OCFS2 packages and management utilities in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-ocfs2.html#tab-ha-ofcs2-mkfs-ocfs2-params Important OCFS2 parameters
New: See 19.4 Creating OCFS2 volumes in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-gfs2.html#id-1.4.5.5.3.4 GFS2 utilities
New: See 20.1 GFS2 packages and management utilities in the PDF

Old: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-gfs2.html#tab-ha-gfs2-mkfs-gfs2-params Important GFS2 parameters
New: See 20.3 Creating GFS2 volumes in the PDF

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [ ] To maintenance/SLEHA15SP3
- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

DOCTEAM-114
