### PR TITLE
Clarify resource actions while in maintenance mode

### DIFF
--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -617,9 +617,10 @@ Node <replaceable>&node2;</replaceable>: standby
     <note>
       <title>Implications</title>
       <para>
-       If the cluster or a node is in maintenance mode, you can manually touch
-       the services that are managed by the cluster resources. The &hasi; will
-       not monitor them or attempt to restart them.
+       If the cluster or a node is in maintenance mode, you can use tools external
+       to the cluster stack (for example, <command>systemctl</command>) to manually
+       operate the components that are managed by the cluster as resources.
+       The &hasi; will not monitor them or attempt to restart them.
       </para>
       <para>
        If you stop the cluster services on a node, all daemons and processes

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -617,9 +617,12 @@ Node <replaceable>&node2;</replaceable>: standby
     <note>
       <title>Implications</title>
       <para>
-       If the cluster or a node is in maintenance mode, you can stop or restart cluster
-       resources at will&mdash;the &hasi; will not attempt to restart them. If
-       you stop the cluster services on a node, all daemons and processes
+       If the cluster or a node is in maintenance mode, you can manually touch
+       the services that are managed by the cluster resources. The &hasi; will
+       not monitor them or attempt to restart them.
+      </para>
+      <para>
+       If you stop the cluster services on a node, all daemons and processes
        (originally started as &pace;-managed cluster resources) will continue
        to run.
       </para>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -636,11 +636,8 @@ Node <replaceable>&node2;</replaceable>: standby
       </para>
      </note>
 
-   <procedure>
-    <para>
-    If you want to take down a node while either the cluster or the node is in
-    <literal>maintenance mode</literal>, proceed as follows:
-    </para>
+   <procedure xml:id="pro-ha-maint-reboot-node">
+    <title>Rebooting a cluster node while the cluster or node is in maintenance mode</title>
     <step>
     <para>
      On the node you want to reboot or shut down, log in as &rootuser; or


### PR DESCRIPTION
### Description

Clarified the action you can take on cluster resources when the cluster or node is in maintenance mode.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
DOCTEAM-682
bsc#1200858