### PR TITLE
Add warning about chance of double reset

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -847,7 +847,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Predictable static delays</term>
+     <term>Predictable static delay</term>
      <listitem>
       <para>This parameter adds a static delay before executing &stonith; actions.
       To prevent the nodes from being reset at the same time under split-brain of
@@ -865,7 +865,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Dynamic random delays</term>
+     <term>Dynamic random delay</term>
      <listitem>
       <para>This parameter adds a random delay for &stonith; actions on the fencing device.
        Rather than a static delay targeting a specific node, the parameter
@@ -876,6 +876,18 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
       </para>
       <screen>&prompt.crm.conf;<command>primitive</command> stonith_sbd stonith:external/sbd
   params pcmk_delay_max=30</screen>
+      <warning>
+       <title><parameter>pcmk_delay_max</parameter> might not prevent double reset
+       in a split-brain scenario</title>
+       <para>
+        The lower the value of <parameter>pcmk_delay_max</parameter>, the higher
+        the chance that a double reset might still occur.
+       </para>
+       <para>
+        If your aim is to have a predictable survivor, use a priority fencing delay
+        or predictable static delay.
+       </para>
+      </warning>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
### Description

I added a warning about the chance for a double reset in a split-brain scenario when using pcmk_delay_max.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-542
bsc#1196045