### PR TITLE
Add procedure for configuring multiple DLM resources

### DIFF
--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -4,11 +4,11 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter 
+<chapter
  xml:id="cha-ha-cluster-md"
- xmlns="http://docbook.org/ns/docbook" 
- xmlns:xi="http://www.w3.org/2001/XInclude" 
- xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
  version="5.0">
  <title>Cluster multi-device (Cluster MD)</title>
  <info>
@@ -66,7 +66,7 @@
    </listitem>
    <listitem>
     <para>A resource agent for DLM (see <xref
-     linkend="pro-dlm-resources"/> on how to configure DLM).</para>
+     linkend="sec-ha-storage-generic-dlm-config"/>).</para>
    </listitem>
    <listitem>
     <para>At least two shared disk devices. You can use an additional device as
@@ -154,7 +154,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
 <!--  <para>Before creating a clustered md device, make sure the DLM resource is up
    and running. To create a device, issue the following command on one cluster
    node:</para>
-   
+
    <screen># mdadm -\-create /dev/md0 -\-bitmap=clustered -\-raid-devices=2 -\-level=mirror
    /dev/sda /dev/sdb</screen>
   <para>This will create a new clustered MD device and initiate a resync of the
@@ -201,13 +201,13 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
   <screen># mdadm -\-detail -\-scan</screen>
   <para>The UUID must match the UUID stored in the superblock. For details on
    the UUID, refer to the <command>mdadm.conf</command> man page. </para>
-  <para> It may be advisable to add 
+  <para> It may be advisable to add
    <filename>/etc/mdadm.conf</filename> in the csync tools list of
    files so it is uniform in all nodes.</para>
 -->
 
  </sect1>
- 
+
  <sect1 xml:id="sec-ha-cluster-md-ra">
   <title>Configuring a resource agent</title>
   <para>Configure a CRM resource as follows:</para>
@@ -234,7 +234,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
     meta interleave=true target-role=Started</screen>
     </step>
    <step>
-    <para>Review your changes with 
+    <para>Review your changes with
      <command>show</command>.</para>
    </step>
    <step>
@@ -243,7 +243,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
   </procedure>
  </sect1>
- 
+
  <sect1 xml:id="sec-ha-cluster-md-dev-add">
   <title>Adding a device</title>
   <para>To add a device to an existing, active Cluster MD device, first ensure that
@@ -285,8 +285,8 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    To re-add the device, run the following command on one cluster node: </para>
   <screen>&prompt.root;<command>mdadm</command> --manage /dev/md0 --re-add /dev/sdb</screen>
  </sect1>
- 
- 
+
+
  <sect1 xml:id="sec-ha-cluster-md-dev-remove">
   <title>Removing a device</title>
   <para>Before removing a device at runtime for replacement, do the following:</para>

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -347,20 +347,6 @@
      the <systemitem class="resource">gfs2-1</systemitem> resource will only start
      on nodes that also have a <literal>dlm</literal> resource already running.
     </para>
-    <important>
-     <title>Do not use a group for multiple GFS2 resources</title>
-     <para>
-      Adding multiple GFS2 resources to a group creates a dependency between the
-      GFS2 volumes; for example, stopping <literal>gfs2-1</literal> will also
-      stop <literal>gfs2-2</literal>, and starting <literal>gfs2-2</literal>
-      will also start <literal>gfs2-1</literal>.
-     </para>
-     <para>
-      To use multiple GFS2 resources in the cluster, use colocation and order
-      constraints instead of a group. For an example of this configuration, see
-      <xref linkend="pro-ocfs2-mount-multiple"/>.
-     </para>
-    </important>
    </step>
    <step>
     <para>

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -337,27 +337,34 @@
    </step>
    <step>
     <para>
-     Create a base group that consists of the <literal>dlm</literal>
-     primitive you created in <xref linkend="pro-dlm-resources"/> and the
-     <literal>gfs2-1</literal> primitive. Clone the group:
+     Add the <literal>gfs2-1</literal> primitive
+     to the <literal>g-storage</literal> group you created in
+     <xref linkend="pro-dlm-resources"/>.
     </para>
-<screen>&prompt.crm.conf;<command>group</command> g-storage dlm  gfs2-1
-     <command>clone</command> cl-storage g-storage \
-     meta interleave="true"</screen>
+<screen>&prompt.crm.conf;<command>modgroup</command> g-storage add gfs2-1</screen>
     <para>
-     Because of the base group's internal colocation and ordering, Pacemaker
-     will only start the <systemitem class="resource">gfs2-1</systemitem>
-     resource on nodes that also have a <literal>dlm</literal> resource
-     already running.
+     Because of the base group's internal colocation and ordering,
+     the <systemitem class="resource">gfs2-1</systemitem> resource will only start
+     on nodes that also have a <literal>dlm</literal> resource already running.
     </para>
+    <important>
+     <title>Do not use a group for multiple GFS2 resources</title>
+     <para>
+      Adding multiple GFS2 resources to a group creates a dependency between the
+      GFS2 volumes; for example, stopping <literal>gfs2-1</literal> will also
+      stop <literal>gfs2-2</literal>, and starting <literal>gfs2-2</literal>
+      will also start <literal>gfs2-1</literal>.
+     </para>
+     <para>
+      To use multiple GFS2 resources in the cluster, use colocation and order
+      constraints instead of a group. For an example of this configuration, see
+      <xref linkend="pro-ocfs2-mount-multiple"/>.
+     </para>
+    </important>
    </step>
    <step>
     <para>
      Review your changes with <command>show</command>.
-<!--taroth 2014-08-28: appendix file commented for now, because it needs
-      alignement with changes here:
-      To check if you have configured all needed resources, also refer to
-      <xref linkend="cha-ha-config-example"/>.-->
     </para>
    </step>
    <step>

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -154,8 +154,8 @@
   </procedure>
 
   <para>
-    For details on configuring the resource group for DLM, see <xref
-     linkend="pro-dlm-resources"/>.
+    For details on configuring the resource for DLM, see <xref
+     linkend="sec-ha-storage-generic-dlm-config"/>.
   </para>
  </sect1>
  <sect1 xml:id="sec-ha-gfs2-create">

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -268,8 +268,8 @@
   </procedure>
 
   <para>
-    For details on configuring the resource group for DLM, see <xref
-     linkend="pro-dlm-resources"/>.
+    For details on configuring the resource for DLM, see <xref
+     linkend="sec-ha-storage-generic-dlm-config"/>.
   </para>
  </sect1>
  <sect1 xml:id="sec-ha-ocfs2-create">

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -578,7 +578,7 @@
    <important role="compact">
     <para>
      Do <emphasis>not</emphasis> add multiple &ocfs; resources to a group with DLM.
-     This createses a dependency between the &ocfs; volumes. For example, if
+     This creates a dependency between the &ocfs; volumes. For example, if
      <literal>ocfs2-1</literal> and <literal>ocfs2-2</literal> are in the same group,
      then stopping <literal>ocfs2-1</literal> will also stop <literal>ocfs2-2</literal>.
     </para>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -512,7 +512,7 @@
    </step>
    <step>
     <para>
-     Run <command>crm</command> <option>configure</option>.
+     Run <command>crm configure</command>.
     </para>
    </step>
    <step>
@@ -541,9 +541,11 @@
     <important>
      <title>Do not use a group for multiple &ocfs; resources</title>
      <para>
-      Adding multiple &ocfs; resources to a group creates a dependency between the
-      &ocfs; volumes; for example, stopping <literal>ocfs2-1</literal> will also
-      stop <literal>ocfs2-2</literal>, and starting <literal>ocfs2-2</literal>
+      Adding multiple &ocfs; resources to a group creates a dependency between
+      the &ocfs; volumes. For example, if you created a group with
+      <command>crm configure group g-storage dlm ocfs2-1 ocfs2-2</command>,
+      then stopping <literal>ocfs2-1</literal> will also stop
+      <literal>ocfs2-2</literal>, and starting <literal>ocfs2-2</literal>
       will also start <literal>ocfs2-1</literal>.
      </para>
      <para>
@@ -573,11 +575,14 @@
     resource for each volume, and colocate them with the <literal>dlm</literal>
     resource you created in <xref linkend="pro-dlm-multiple-resources"/>.
    </para>
-   <para>
-    Do <emphasis>not</emphasis> add multiple &ocfs; resources to a group with DLM.
-    This introduces a dependency between the &ocfs; volumes; for example, stopping
-    <literal>ocfs2-1</literal> will also stop <literal>ocfs2-2</literal>.
-   </para>
+   <important role="compact">
+    <para>
+     Do <emphasis>not</emphasis> add multiple &ocfs; resources to a group with DLM.
+     This createses a dependency between the &ocfs; volumes. For example, if
+     <literal>ocfs2-1</literal> and <literal>ocfs2-2</literal> are in the same group,
+     then stopping <literal>ocfs2-1</literal> will also stop <literal>ocfs2-2</literal>.
+    </para>
+   </important>
    <step>
     <para>
      Log in to a node as &rootuser; or equivalent.
@@ -585,7 +590,7 @@
    </step>
    <step>
     <para>
-     Run <command>crm</command> <option>configure</option>.
+     Run <command>crm configure</command>.
     </para>
    </step>
    <step>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -533,8 +533,8 @@
      <xref linkend="pro-dlm-resources"/>.
     </para>
 <screen>&prompt.crm.conf;<command>modgroup</command> g-storage add ocfs2-1</screen>
-    <para>The <command>add</command> subcommand appends the new group
-     member by default. Because of the base group's internal colocation and ordering,
+    <para>
+     Because of the base group's internal colocation and ordering,
      the <systemitem class="resource">ocfs2-1</systemitem> resource will only start
      on nodes that also have a <literal>dlm</literal> resource already running.
     </para>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -456,6 +456,9 @@
    You can either mount an &ocfs; volume manually or with the cluster
    manager, as described in <xref linkend="pro-ocfs2-mount-cluster"/>.
   </para>
+  <para>
+   To mount multiple &ocfs; volumes, see <xref linkend="pro-ocfs2-mount-multiple"/>.
+  </para>
 
   <procedure xml:id="pro-ocfs2-mount-manual">
    <title>Manually mounting an &ocfs; volume</title>
@@ -497,14 +500,14 @@
    <title>Mounting an &ocfs; volume with the cluster resource manager</title>
    <para>
     To mount an &ocfs; volume with the &ha; software, configure an
-    ocfs2 file system resource in the cluster. The following procedure uses
+    &ocfs; file system resource in the cluster. The following procedure uses
     the <command>crm</command> shell to configure the cluster resources.
     Alternatively, you can also use &hawk2; to configure the resources as
     described in <xref linkend="sec-ha-ocfs2-rsc-hawk2"/>.
    </para>
    <step>
     <para>
-     Start a shell and log in as &rootuser; or equivalent.
+     Log in to a node as &rootuser; or equivalent.
     </para>
    </step>
    <step>
@@ -531,19 +534,27 @@
     </para>
 <screen>&prompt.crm.conf;<command>modgroup</command> g-storage add ocfs2-1</screen>
     <para>The <command>add</command> subcommand appends the new group
-     member by default. Because of the base group's internal colocation and ordering, Pacemaker
-     will only start the <systemitem class="resource">ocfs2-1</systemitem>
-     resource on nodes that also have a <literal>dlm</literal> resource
-     already running.
+     member by default. Because of the base group's internal colocation and ordering,
+     the <systemitem class="resource">ocfs2-1</systemitem> resource will only start
+     on nodes that also have a <literal>dlm</literal> resource already running.
     </para>
+    <important>
+     <title>Do not use a group for multiple &ocfs; resources</title>
+     <para>
+      Adding multiple &ocfs; resources to a group creates a dependency between the
+      &ocfs; volumes; for example, stopping <literal>ocfs2-1</literal> will also
+      stop <literal>ocfs2-2</literal>, and starting <literal>ocfs2-2</literal>
+      will also start <literal>ocfs2-1</literal>.
+     </para>
+     <para>
+      To use multiple &ocfs; resources in the cluster, use colocation and order
+      constraints as described in <xref linkend="pro-ocfs2-mount-multiple"/>.
+     </para>
+    </important>
    </step>
    <step>
     <para>
      Review your changes with <command>show</command>.
-<!--taroth 2014-08-28: appendix file commented for now, because it needs
-      alignement with changes here:
-      To check if you have configured all needed resources, also refer to
-      <xref linkend="cha-ha-config-example"/>.-->
     </para>
    </step>
    <step>
@@ -551,6 +562,82 @@
      If everything is correct, submit your changes with
      <command>commit</command> and leave the crm live configuration with
      <command>quit</command>.
+    </para>
+   </step>
+  </procedure>
+
+  <procedure xml:id="pro-ocfs2-mount-multiple">
+   <title>Mounting multiple &ocfs; volumes with the cluster resource manager</title>
+   <para>
+    To mount multiple &ocfs; volumes in the cluster, configure an &ocfs; file system
+    resource for each volume, and colocate them with the <literal>dlm</literal>
+    resource you created in <xref linkend="pro-dlm-multiple-resources"/>.
+   </para>
+   <para>
+    Do <emphasis>not</emphasis> add multiple &ocfs; resources to a group with DLM.
+    This introduces a dependency between the &ocfs; volumes; for example, stopping
+    <literal>ocfs2-1</literal> will also stop <literal>ocfs2-2</literal>.
+   </para>
+   <step>
+    <para>
+     Log in to a node as &rootuser; or equivalent.
+    </para>
+   </step>
+   <step>
+    <para>
+     Run <command>crm</command> <option>configure</option>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Create the primitive for the first &ocfs; volume:
+    </para>
+<screen>&prompt.crm.conf;<command>primitive</command> ocfs2-1 Filesystem \
+  params directory="/srv/ocfs2-1" fstype=ocfs2 device="/dev/disk/by-partlabel/ocfs2-1" \
+  op monitor interval=20 timeout=40 \
+  op start timeout=60 interval=0 \
+  op stop timeout=60 interval=0</screen>
+   </step>
+   <step>
+    <para>
+     Create the primitive for the second &ocfs; volume:
+    </para>
+<screen>&prompt.crm.conf;<command>primitive</command> ocfs2-2 Filesystem \
+  params directory="/srv/ocfs2-2" fstype=ocfs2 device="/dev/disk/by-partlabel/ocfs2-2" \
+  op monitor interval=20 timeout=40 \
+  op start timeout=60 interval=0 \
+  op stop timeout=60 interval=0</screen>
+   </step>
+   <step>
+    <para>
+     Clone the &ocfs; resources so that they can run on all nodes:
+    </para>
+<screen>&prompt.crm.conf;<command>clone</command> cl-ocfs2-1 ocfs2-1 meta interleave=true
+&prompt.crm.conf;<command>clone</command> cl-ocfs2-2 ocfs2-2 meta interleave=true</screen>
+   </step>
+   <step>
+    <para>
+     Add a colocation constraint for both &ocfs; resources so that they can only
+     run on nodes where DLM is also running:
+    </para>
+<screen>&prompt.crm.conf;<command>colocation</command> co-ocfs2-with-dlm inf: ( cl-ocfs2-1 cl-ocfs2-2 ) cl-dlm</screen>
+   </step>
+   <step>
+    <para>
+     Add an order constraint for both &ocfs; resources so that they can only
+     start after DLM is already running:
+    </para>
+<screen>&prompt.crm.conf;<command>order</command> o-dlm-before-ocfs2 Mandatory: cl-dlm ( cl-ocfs2-1 cl-ocfs2-2 )</screen>
+   </step>
+   <step>
+    <para>
+     Review your changes with <command>show</command>.
+    </para>
+   </step>
+   <step>
+    <para>
+     If everything is correct, submit your changes with <command>commit</command>
+     and leave the crm live configuration with <command>quit</command>.
     </para>
    </step>
   </procedure>

--- a/xml/ha_storage_basics.xml
+++ b/xml/ha_storage_basics.xml
@@ -73,6 +73,13 @@
    <para>
     If you have a setup that includes both &ocfs; and &clvm;, configuring
     <emphasis>one</emphasis> DLM resource for both &ocfs; and &clvm; is enough.
+    In this case, configure DLM using <xref linkend="pro-dlm-resources"/>.
+   </para>
+   <para>
+    However, if you need to keep the resources that use DLM independent from one
+    another (such as multiple &ocfs; mount points), use separate colocation and
+    ordering constraints instead of a group. In this case, configure DLM using
+    <emphasis>an xref that doesn't exist yet</emphasis>.
    </para>
   </note>
 

--- a/xml/ha_storage_basics.xml
+++ b/xml/ha_storage_basics.xml
@@ -79,14 +79,14 @@
     However, if you need to keep the resources that use DLM independent from one
     another (such as multiple &ocfs; mount points), use separate colocation and
     ordering constraints instead of a group. In this case, configure DLM using
-    <emphasis>an xref that doesn't exist yet</emphasis>.
+    <xref linkend="pro-dlm-multiple-resources"/>.
    </para>
   </note>
 
   <procedure xml:id="pro-dlm-resources">
    <title>Configuring a base group for DLM</title>
    <para>
-    The configuration consists of a base group that includes several primitives
+    This configuration consists of a base group that includes several primitives
     and a base clone. Both base group and base clone can be used in various
     scenarios afterward (for both &ocfs; and &clvm;, for example). You only need
     to extend the base group with the respective primitives as needed. As the
@@ -104,19 +104,19 @@
    </step>
    <step>
     <para>
-     Run <command>crm</command> <option>configure</option>.
+     Run <command>crm configure</command>.
     </para>
    </step>
    <step>
     <para>
-     Enter the following to create the primitive resource for DLM:
+     Create the primitive resource for DLM:
     </para>
 <screen>&prompt.crm.conf;<command>primitive</command> dlm ocf:pacemaker:controld \
   op monitor interval="60" timeout="60"</screen>
    </step>
    <step>
     <para>
-     Create a base group for the DLM resource and further storage-related
+     Create a base group for the <literal>dlm</literal> resource and further storage-related
      resources:
     </para>
 <screen>&prompt.crm.conf;<command>group</command> g-storage dlm</screen>
@@ -148,8 +148,58 @@
     Clusters without &stonith; are not supported. If you set the global cluster
     option <varname>stonith-enabled</varname> to <literal>false</literal> for
     testing or troubleshooting purposes, the DLM resource and all services
-    depending on it (such as &clvm;, GFS2, and OCFS2) will fail to start.
+    depending on it (such as &clvm;, GFS2, and &ocfs;) will fail to start.
    </para>
   </note>
+
+  <procedure xml:id="pro-dlm-multiple-resources">
+   <title>Configuring independent DLM resources</title>
+   <para>
+    This configuration consists of a primitive and a clone, but no group.
+    By adding separate colocation and ordering contraints, you can avoid
+    introducing dependencies between multiple resources that use DLM
+    (such as multiple &ocfs; mount points).
+   </para>
+   <para>
+    Follow the steps below on one node in the cluster:
+   </para>
+   <step>
+    <para>
+     Start a shell and log in as &rootuser; or equivalent.
+    </para>
+   </step>
+   <step>
+    <para>
+     Run <command>crm configure</command>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Create the primitive resource for DLM:
+    </para>
+<screen>&prompt.crm.conf;<command>primitive</command> dlm ocf:pacemaker:controld \
+  op start timeout=90 interval=0 \
+  op stop timeout=100 interval=0 \
+  op monitor interval=60 timeout=60</screen>
+   </step>
+   <step>
+    <para>
+     Clone the <literal>dlm</literal> resource so that it runs on all nodes:
+    </para>
+<screen>&prompt.crm.conf; <command>clone</command> cl-dlm dlm meta interleave=true</screen>
+   </step>
+   <step>
+    <para>
+     Review your changes with <command>show</command>.
+    </para>
+   </step>
+   <step>
+    <para>
+     If everything is correct, submit your changes with
+     <command>commit</command> and leave the crm live configuration with
+     <command>quit</command>.
+    </para>
+   </step>
+  </procedure>
  </sect1>
 </chapter>

--- a/xml/ha_storage_basics.xml
+++ b/xml/ha_storage_basics.xml
@@ -78,7 +78,7 @@
    <para>
     However, if you need to keep the resources that use DLM independent from one
     another (such as multiple &ocfs; mount points), use separate colocation and
-    ordering constraints instead of a group. In this case, configure DLM using
+    order constraints instead of a group. In this case, configure DLM using
     <xref linkend="pro-dlm-multiple-resources"/>.
    </para>
   </note>
@@ -94,12 +94,9 @@
     overall setup as you do not need to specify several individual groups,
     clones and their dependencies.
    </para>
-   <para>
-    Follow the steps below on one node in the cluster:
-   </para>
    <step>
     <para>
-     Start a shell and log in as &rootuser; or equivalent.
+     Log in to a node as &rootuser; or equivalent.
     </para>
    </step>
    <step>
@@ -153,19 +150,16 @@
   </note>
 
   <procedure xml:id="pro-dlm-multiple-resources">
-   <title>Configuring independent DLM resources</title>
+   <title>Configuring an independent DLM resource</title>
    <para>
     This configuration consists of a primitive and a clone, but no group.
-    By adding separate colocation and ordering contraints, you can avoid
-    introducing dependencies between multiple resources that use DLM
-    (such as multiple &ocfs; mount points).
-   </para>
-   <para>
-    Follow the steps below on one node in the cluster:
+    By adding colocation and order contraints, you can avoid introducing
+    dependencies between multiple resources that use DLM (such as multiple &ocfs;
+    mount points).
    </para>
    <step>
     <para>
-     Start a shell and log in as &rootuser; or equivalent.
+     Log in to a node as &rootuser; or equivalent.
     </para>
    </step>
    <step>

--- a/xml/ha_storage_basics.xml
+++ b/xml/ha_storage_basics.xml
@@ -153,7 +153,7 @@
    <title>Configuring an independent DLM resource</title>
    <para>
     This configuration consists of a primitive and a clone, but no group.
-    By adding colocation and order contraints, you can avoid introducing
+    By adding colocation and order constraints, you can avoid introducing
     dependencies between multiple resources that use DLM (such as multiple &ocfs;
     mount points).
    </para>


### PR DESCRIPTION
### Description

I added procedures for adding separate colocation and order constraints for resources on top of DLM, as opposed to putting them all in one group. This is based on Roger's suggestions from bsc#1179267. I didn't follow it exactly, and made changes in a few places, so I'll add details in a further comment.

(And as usual, my text editor stripped out some wayward blank space).

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

jsc#DOCTEAM-82
bsc#1179267
