### PR TITLE
Change /usr/lib/drbd/ to /lib/drbd/ for fence script

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -211,8 +211,8 @@
    }
 
    handlers { <co xml:id="co-ha-quick-nfs-fencing-handlers"/>
-      fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
-      after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
+      fence-peer "/lib/drbd/crm-fence-peer.9.sh";
+      after-resync-target "/lib/drbd/crm-unfence-peer.9.sh";
       # ...
    }
 

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -952,8 +952,8 @@ resource r0-U {
     # ...
   }
   handlers {
-    fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
-    after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
+    fence-peer "/lib/drbd/crm-fence-peer.9.sh";
+    after-resync-target "/lib/drbd/crm-unfence-peer.9.sh";
     # ...
   }
   ...


### PR DESCRIPTION
### Description

Changed `/usr/lib/drbd/crm-fence-peer.9.sh` and `/usr/lib/drbd/crm-unfence-peer.9.sh` to `/lib/drbd/crm-fence-peer.9.sh` and `/lib/drbd/crm-unfence-peer.9.sh`. Only found four instances total in the html-single "all" build. 

Checked in test VMs and only found this change in 15 SP4, not 15 SP3 (and presumably earlier), so currently no need for further backporting.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [ ] To maintenance/SLEHA15SP3
- [ ] To maintenance/SLEHA15SP2
- [ ] To maintenance/SLEHA15SP1
- [ ] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

jsc#DOCTEAM-696
bsc#1201901
