### PR TITLE
Add explanation for fencing policy line

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -199,7 +199,6 @@
        Create the file <filename>/etc/drbd.d/nfs.res</filename> with the
         following contents:
       </para>
-      <!--<remark>toms 2016-07-25: TODO bsc#981560</remark>-->
 <screen>resource nfs {
    device /dev/drbd0; <co xml:id="co-ha-quick-nfs-drbd-device"/>
    disk   /dev/nfs/work; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
@@ -207,7 +206,7 @@
 
    net {
       protocol  C; <co xml:id="co-ha-quick-nfs-drbd-protocol"/>
-      fencing resource-and-stonith;
+      fencing resource-and-stonith; <co xml:id="co-ha-quick-nfs-fencing-policy"/>
    }
 
    handlers { <co xml:id="co-ha-quick-nfs-fencing-handlers"/>
@@ -249,6 +248,12 @@
         <para>The specified protocol to be used for this connection. For protocol
          <literal>C</literal>, a write is considered to be complete when
          it has reached all disks, be they local or remote.
+        </para>
+       </callout>
+       <callout arearefs="co-ha-quick-nfs-fencing-policy">
+        <para>
+         Specifies the fencing policy. For clusters with a &stonith; device
+         configured, use <literal>resource-and-stonith</literal>.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-fencing-handlers">


### PR DESCRIPTION
### Description

Added a callout explaining the purpose of the `fencing` line.

### Backports

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References

jsc#DOCTEAM-439
bsc#1193441

