### PR TITLE
Simplify NFS virtual IP addresses

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -447,7 +447,7 @@ include /etc/drbd.d/*.res;</screen>
         <para>The following configuration examples assume that
          <systemitem class="ipaddress">&nfs-vip-exports;</systemitem> is the virtual
          IP address to use for an NFS server which serves clients in the
-         <systemitem class="ipaddress">&subnetII;.x/24</systemitem> subnet.</para>
+         <systemitem class="ipaddress">&subnetI;.x/24</systemitem> subnet.</para>
     </listitem>
     <listitem>
         <para>The service <!--hosts an NFSv4 virtual file system root

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -106,8 +106,8 @@
 
 <!-- Virtual IP addresses for the NFS Quick Start -->
 <!ENTITY nfs-vip-hawk    "&subnetI;.10">
-<!ENTITY nfs-vip-exports "&subnetII;.1">
-<!ENTITY nfs-clientspec  "&subnetII;.0/24">
+<!ENTITY nfs-vip-exports "&subnetI;.11">
+<!ENTITY nfs-clientspec  "&subnetI;.0/24">
 
 <!-- Virtual IP addresses for the Geo Quick Start -->
 <!ENTITY geo-vip-site1   "192.168.201.100">


### PR DESCRIPTION
### Description

Simplified the NFS virtual IP address on the assumption that network admins will know the options for their setup and can adjust accordingly.

Since I did this by updating an entity, here's the full result: 

[article-nfs-storage_color_en.pdf](https://github.com/SUSE/doc-sleha/files/9422174/article-nfs-storage_color_en.pdf)

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References

jsc#DOCTEAM-145
bsc#1158160

