### PR TITLE
Add extra config line for UEFI with ReaR to work

### DIFF
--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -409,11 +409,12 @@
      <title>When your system is booted with UEFI</title>
      <para>
       If your system boots with a UEFI boot loader, install the package
-      <package>ebiso</package> and add the following line into
+      <package>ebiso</package> and add the following lines to
       <filename>/etc/rear/local.conf</filename>:
      </para>
     </formalpara>
-    <screen>ISO_MKISOFS_BIN=/usr/bin/ebiso</screen>
+    <screen>ISO_MKISOFS_BIN="/usr/bin/ebiso"
+SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"</screen>
    </listitem>
    <listitem>
     <formalpara>


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
Added `SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"` to UEFI list item in ReaR chapter.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-733
bsc#1203051