### PR TITLE
Add note: SBD resource does not need to be a clone

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -771,7 +771,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     </listitem>
     <listitem>
      <para>
-      Configure the SBD &stonith; resource.
+      Configure the SBD &stonith; resource. You do not need to clone this resource.
      </para>
     </listitem>
    </itemizedlist>
@@ -866,10 +866,10 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
       devices for each node. In the following configuration, &node1; will win
       and survive in case of a split brain scenario:
       </para>
-      <screen>&prompt.crm.conf;<command>primitive</command> st-sbd-&node1; stonith:external/sbd params \
-       pcmk_host_list=&node1; pcmk_delay_base=20
+<screen>&prompt.crm.conf;<command>primitive</command> st-sbd-&node1; stonith:external/sbd params \
+pcmk_host_list=&node1; pcmk_delay_base=20
 &prompt.crm.conf;<command>primitive</command> st-sbd-&node2; stonith:external/sbd params \
-       pcmk_host_list=&node2; pcmk_delay_base=0</screen>
+pcmk_host_list=&node2; pcmk_delay_base=0</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -882,8 +882,8 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
        <parameter>pcmk_delay_base</parameter>, this parameter can be specified for
        a unified fencing resource targeting multiple nodes.
       </para>
-      <screen>&prompt.crm.conf;<command>primitive</command> stonith_sbd stonith:external/sbd
-  params pcmk_delay_max=30</screen>
+<screen>&prompt.crm.conf;<command>primitive</command> stonith_sbd stonith:external/sbd
+params pcmk_delay_max=30</screen>
       <warning>
        <title><parameter>pcmk_delay_max</parameter> might not prevent double reset
        in a split-brain scenario</title>


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
Added a note that the SBD STONITH resource doesn't need to be cloned. A primitive is sufficient.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-350
bsc#1186690