### PR TITLE
Remove outdated drbdadm bash completion step

### DIFF
--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -167,20 +167,6 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
     <package>drbd-kmp-<replaceable>FLAVOR</replaceable></package>,
     <package>drbd-utils</package>, and <package>yast2-drbd</package>.
   </para>
-
-  <para>
-   To simplify the work with <command>drbdadm</command>, use the Bash
-   completion support.
-   If you want to enable it in your current shell session, insert the
-   following command:
-  </para>
-
-<screen>&prompt.root;<command>source</command> /etc/bash_completion.d/drbdadm.sh</screen>
-
-  <para>
-   To use it permanently for &rootuser;, create, or extend a file
-   <filename>/root/.bashrc</filename> and insert the previous line.
-  </para>
  </sect1>
  <sect1 xml:id="sec-ha-drbd-configure">
   <title>Setting up DRBD service</title>


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
Removed the drbdadm bash completion step as it isn't required in SLE15. 

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#jiranotworkingrip
bsc#1203483