### PR TITLE
Structural changes for installation quickstart

### DIFF
--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -313,7 +313,7 @@
       <step>
        <para>
         Install it via command line using Zypper:</para>
-<screen>&prompt.root;<command>zypper</command> install -t pattern ha_sles</screen>
+<screen>&prompt.root;<command>zypper install -t pattern ha_sles</command></screen>
       </step>
       <step>
        <para>
@@ -384,14 +384,14 @@
       Enable the softdog watchdog:
      </para>
      <!-- See /usr/lib/ha-cluster-functions -->
-     <screen>&prompt.root;<command>echo</command> softdog > /etc/modules-load.d/watchdog.conf
-&prompt.root;<command>systemctl</command> restart systemd-modules-load</screen>
+     <screen>&prompt.root;<command>echo softdog > /etc/modules-load.d/watchdog.conf</command>
+&prompt.root;<command>systemctl restart systemd-modules-load</command></screen>
     </step>
     <step>
      <para>Test if the softdog module is loaded correctly:
      </para>
-     <screen>&prompt.root;<command>lsmod</command> | grep dog
-softdog                16384  1</screen>
+     <screen>&prompt.root;<command>lsmod | grep dog</command>
+softdog           16384  1</screen>
     </step>
   </procedure>
 
@@ -428,7 +428,7 @@ softdog                16384  1</screen>
     <para>
      Start the bootstrap script by executing:
     </para>
-    <screen>&prompt.root;<command>crm cluster init</command> --name <replaceable>CLUSTERNAME</replaceable></screen>
+    <screen>&prompt.root;<command>crm cluster init --name <replaceable>CLUSTERNAME</replaceable></command></screen>
     <para>Replace the <replaceable>CLUSTERNAME</replaceable>
      placeholder with a meaningful name, like the geographical location of your
      cluster (for example, <literal>&cluster1;</literal>).
@@ -551,7 +551,7 @@ softdog                16384  1</screen>
      <title>Secure password</title>
      <para>Replace the default password with a secure one as soon as possible:
      </para>
-     <screen>&prompt.root;<command>passwd</command> hacluster</screen>
+     <screen>&prompt.root;<command>passwd hacluster</command></screen>
     </important>
    </step>
    <step>
@@ -683,7 +683,7 @@ softdog                16384  1</screen>
       Open a terminal and ping <systemitem>&subnetII;.1</systemitem>,
       your virtual IP address:
      </para>
-     <screen>&prompt.root;<command>ping</command> &subnetII;.1</screen>
+     <screen>&prompt.root;<command>ping &subnetII;.1</command></screen>
     </step>
     <step>
      <para>
@@ -805,7 +805,7 @@ Active resources:
 
  stonith-sbd    (stonith:external/sbd): Started &node1;
 
-&prompt.root;&cmd.test.script; --fence-node &node2;
+&prompt.root;&cmd.test.script;<command> --fence-node &node2;</command>
 
 ==============================================
 Testcase:          Fence node &node2;

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -99,12 +99,8 @@
      <listitem>
       <para>
        Two servers with software as specified in <xref linkend="il-ha-inst-quick-req-sw"/>.
-      </para> &sys-req-hw-nodes;
-      <!--<para>
-     The servers can be bare metal or virtual machines. They do not require
-     identical hardware (memory, disk space, etc.), but they must have the
-     same architecture. Cross-platform clusters are not supported.
-     </para>-->
+      </para>
+      &sys-req-hw-nodes;
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -113,7 +109,28 @@
     </varlistentry>
     <varlistentry>
      <term>Node fencing/&stonith;</term>
-     <listitem> &sys-req-hw-stonith; </listitem>
+     <listitem>
+      &sys-req-hw-stonith;
+      <para>To use SBD, the following requirements must be met:</para>
+      <itemizedlist>
+       <listitem>
+        <para>The path to the shared storage device must be persistent and
+         consistent across all nodes in the cluster. Use stable device names
+         such as <filename>/dev/disk/by-id/dm-uuid-part1-mpath-abcedf12345</filename>.
+        </para>
+       </listitem>
+       <listitem>
+        <para> The SBD device <emphasis>must not</emphasis>
+         use host-based RAID, LVM2, nor reside on a DRBD* instance.
+        </para>
+       </listitem>
+      </itemizedlist>
+      <para>
+       For details of how to set up shared storage, refer to the
+       <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
+       &storage_guide; for &sls; &productnumber;</link>.
+      </para>
+     </listitem>
     </varlistentry>
    </variablelist>
  </sect2>
@@ -324,10 +341,6 @@
 
  <sect1 xml:id="sec-ha-inst-quick-sbd">
   <title>Using SBD as fencing mechanism</title>
-  <!-- For more information, see:
-   * https://trello.com/c/rclDZHPR
-   * http://www.linux-ha.org/wiki/SBD_Fencing
-  -->
 
    <para>
     If you have shared storage, for example, a SAN (Storage Area Network),
@@ -336,69 +349,16 @@
     and the <literal>external/sbd</literal> &stonith; resource agent.
    </para>
 
-  <sect2 xml:id="sec-ha-inst-quick-sbd-req">
-   <title>Requirements for SBD</title>
    <para>
     During setup of the first node with <command>crm cluster init</command>, you
     can decide whether to use SBD. If yes, you need to enter the path to the shared
     storage device. By default, <command>crm cluster init</command> will automatically
     create a small partition on the device to be used for SBD.
    </para>
-   <para>To use SBD, the following requirements must be met:</para>
 
-   <itemizedlist>
-    <listitem>
-     <para>The path to the shared storage device must be persistent and
-      consistent across all nodes in the cluster. Use stable device names
-      such as <filename>/dev/disk/by-id/dm-uuid-part1-mpath-abcedf12345</filename>.
-     </para>
-    </listitem>
-    <listitem>
-     <para> The SBD device <emphasis>must not</emphasis>
-      use host-based RAID, LVM2, nor reside on a DRBD* instance.
-     </para>
-    </listitem>
-   </itemizedlist>
-
-  <para>
-   For details of how to set up shared storage, refer to the
-   <link
-    xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
-    &storage_guide; for &sls; &productnumber;</link>.
-  </para>
-  <!--<remark>toms, 2016-07-30: (kai) miss a link to set up FC storage</remark>
-  <remark>toms 2016-08-01: we don't have yet doc for FC storage.</remark>
-  <variablelist>
-   <varlistentry>
-    <term>iSCSI</term>
-    <listitem>
-     <para><link xlink:href="https://www.suse.com/doc/sles-12/stor_admin/data/cha_iscsi.html"/></para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>FCoE</term>
-   <listitem>
-    <para><link xlink:href="https://www.suse.com/doc/sles-12/stor_admin/data/cha_fcoe.html"/></para>
-   </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>FC</term>
-    <listitem>
-     <para><remark>taroth 2016-08-04: the following was based a proposal by kdupke,
-     replace with something more appropriate in the future (as soon as we have
-     covered this in the storage guide)</remark>
-      No special configuration needed, configure it as other FC storage.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>-->
-  </sect2>
-
-  <sect2 xml:id="sec-ha-inst-quick-sbd-setup">
-   <title>Enabling the softdog watchdog for SBD</title>
    <!--Taken from ha_storage_protection.xml (pro.ha.storage.protect.watchdog)?-->
    <para>
-    In &sls;, watchdog support in the kernel is enabled by default: It ships
+    In &sls;, watchdog support in the kernel is enabled by default: it ships
     with several kernel modules that provide hardware-specific
     watchdog drivers. The &hasi; uses the SBD daemon as the software component
     that <quote>feeds</quote> the watchdog.
@@ -412,10 +372,11 @@
    &important-softdog-limit;
 
    <procedure xml:id="pro-ha-inst-quick-sbd-setup">
+    <title>Enabling the softdog watchdog for SBD</title>
     <step>
      <para>
-      Create a persistent, shared storage as described in <xref
-       linkend="sec-ha-inst-quick-sbd-req"/>.
+      Create a persistent, shared storage as described in <!--xref
+       linkend="sec-ha-inst-quick-sbd-req"/-->. <remark>Don't need this step if it's a prereq</remark>
      </para>
     </step>
     <step>
@@ -427,10 +388,6 @@
 &prompt.root;<command>systemctl</command> restart systemd-modules-load</screen>
     </step>
     <step>
-      <!--for the records: <remark>toms 2016-08-09: krig: "The script uses wdctl to check for the
-      watchdog, so it should catch the case where the node is created but no
-      module is loaded. However, I am not sure it'll be able to spot the case
-      where the wrong module is loaded." (ha-devel, 2016-08-08)</remark>-->
      <para>Test if the softdog module is loaded correctly:
      </para>
      <screen>&prompt.root;<command>lsmod</command> | grep dog
@@ -445,11 +402,10 @@ softdog                16384  1</screen>
     Usually it boils down to "sbd -d DEV list" and "sbd -d DEV message &node2; test"
    </remark>
    <para>
-    We highly recommend to test the SBD fencing mechanism for proper function
-    to prevent a split scenario. Such a test can be done by blocking the &corosync;
+    We highly recommend testing the SBD fencing mechanism for proper function
+    to prevent a split brain scenario. Such a test can be done by blocking the &corosync;
     cluster communication.
    </para>
-  </sect2>
  </sect1>
 
  <sect1 xml:id="sec-ha-inst-quick-setup-1st-node">

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -110,9 +110,21 @@
     <varlistentry>
      <term>Node fencing/&stonith;</term>
      <listitem>
-      &sys-req-hw-stonith;
-      <para>To use SBD, the following requirements must be met:</para>
+      <para>
+       A node fencing (&stonith;) device to avoid split brain scenarios. This can
+       be either a physical device (a power switch) or a mechanism like SBD
+       (&stonith; by disk) in combination with a watchdog.
+      </para>
+      <para>This document describes using SBD for node fencing. To use SBD, the
+       following requirements must be met:</para>
       <itemizedlist>
+       <listitem>
+        <para>
+         Shared storage. For information on setting up shared storage, see the
+       <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
+       &storage_guide; for &sls;</link>.
+        </para>
+       </listitem>
        <listitem>
         <para>The path to the shared storage device must be persistent and
          consistent across all nodes in the cluster. Use stable device names
@@ -126,9 +138,8 @@
        </listitem>
       </itemizedlist>
       <para>
-       For details of how to set up shared storage, refer to the
-       <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
-       &storage_guide; for &sls; &productnumber;</link>.
+       For more information on &stonith;, see <xref linkend="cha-ha-fencing"/>.
+       For more information on SBD, see <xref linkend="cha-ha-storage-protect"/>.
       </para>
      </listitem>
     </varlistentry>
@@ -340,8 +351,7 @@
   </sect1>
 
  <sect1 xml:id="sec-ha-inst-quick-sbd">
-  <title>Using SBD as fencing mechanism</title>
-
+  <title>Using SBD for node fencing</title>
    <para>
     If you have shared storage, for example, a SAN (Storage Area Network),
     you can use it to avoid split brain scenarios. To do so, configure SBD
@@ -373,12 +383,6 @@
 
    <procedure xml:id="pro-ha-inst-quick-sbd-setup">
     <title>Enabling the softdog watchdog for SBD</title>
-    <step>
-     <para>
-      Create a persistent, shared storage as described in <!--xref
-       linkend="sec-ha-inst-quick-sbd-req"/-->. <remark>Don't need this step if it's a prereq</remark>
-     </para>
-    </step>
     <step>
      <para>
       Enable the softdog watchdog:

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -48,10 +48,9 @@
     </listitem>
     <listitem>
      <para>
-      A floating, virtual IP address (<systemitem class="ipaddress"
-       >&subnetII;.1</systemitem>) which
-      allows clients to connect to the service no matter which physical node it
-      is running on.
+      A floating, virtual IP address (<systemitem class="ipaddress">&subnetII;.1</systemitem>)
+      that allows clients to connect to the service no matter which node it is running on.
+      This IP address is used to connect to the graphical management tool &hawk2;.
      </para>
     </listitem>
     <listitem>
@@ -66,13 +65,6 @@
      </para>
     </listitem>
    </itemizedlist>
-   <para>
-    After setup of the cluster with the bootstrap scripts, we will monitor
-    the cluster with the graphical &hawk2;. It is one of the cluster management
-    tools included with &productnamereg;. As a basic test of whether failover of resources
-    works, we will put one of the nodes into standby mode and check if the
-    virtual IP address is migrated to the second node.
-   </para>
    <para>
     You can use the two-node cluster for testing purposes or as a minimal
     cluster configuration that you can extend later on. Before using the
@@ -301,29 +293,21 @@
  </sect1>
 
   <sect1 xml:id="sec-ha-inst-quick-installation">
-    <title>Installing &productname;</title>
+    <title>Installing the &productname;</title>
     <para>
-      The packages for configuring and managing a cluster with the
-      &hasi; are included in the <literal>&ha;</literal> installation
-      pattern (named <literal>sles_ha</literal> on the command line).
-      This pattern is only available after &productname; has been
-      installed as an extension to &slsreg;.
-    </para>
-    <para>
-      For information on how to install
-      extensions, see the <link
-       xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-add-ons.html">
-       &deploy; for &sls; &productnumber;</link>.
+      The packages for configuring and managing a cluster
+      are included in the <literal>&ha;</literal> installation pattern.
+      This pattern is only available after the &productname; has been installed.
+      For information on how to install extensions, see the
+      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/article-modules.html#sec-modules-install">
+      &modulesquick;</link>.
     </para>
 
     <procedure xml:id="pro-ha-inst-quick-pattern">
       <title>Installing the <literal>&ha;</literal> pattern</title>
-       <para>
-        If the pattern is not installed yet, proceed as follows:
-       </para>
       <step>
        <para>
-        Install it via command line using Zypper:</para>
+        Install the &ha; pattern via command line using Zypper:</para>
 <screen>&prompt.root;<command>zypper install -t pattern ha_sles</command></screen>
       </step>
       <step>
@@ -342,7 +326,7 @@
       </step>
       <step>
        <para>
-         Register the machines at &scc;. Find more information in the <link
+         Register the machines at the &scc;. Find more information in the <link
           xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-upgrade-offline.html#sec-update-registersystem">
          &upgrade_guide; for &sls; &productnumber;</link>.
        </para>
@@ -403,7 +387,7 @@ softdog           16384  1</screen>
    </step>
    <step>
     <para>
-     Start the bootstrap script by executing:
+     Start the bootstrap script:
     </para>
     <screen>&prompt.root;<command>crm cluster init --name <replaceable>CLUSTERNAME</replaceable></command></screen>
     <para>Replace the <replaceable>CLUSTERNAME</replaceable>
@@ -413,7 +397,7 @@ softdog           16384  1</screen>
      as it simplifies the identification of a site.
     </para>
     <para>
-     If you need multicast instead of unicast (the default) for your cluster
+     If you need to use multicast instead of unicast (the default) for your cluster
      communication, use the option <option>--multicast</option> (or <option>-U</option>).
     </para>
     <para>
@@ -444,23 +428,21 @@ softdog           16384  1</screen>
    </step>
    <step>
     <para>
-    Set up SBD as node fencing mechanism:</para>
+    Set up SBD as the node fencing mechanism:</para>
     <substeps>
      <step>
       <para>Confirm with <literal>y</literal> that you want to use SBD.</para>
      </step>
      <step>
       <para>Enter a persistent path to the partition of your block device that
-       you want to use for SBD, see <xref linkend="sec-ha-inst-quick-sbd"/>.
+       you want to use for SBD.
        The path must be consistent across all nodes in the cluster.</para>
        <para>The script creates a small partition on the device to be used for SBD.</para>
      </step>
     </substeps>
    </step>
    <step xml:id="st-crm-cluster-init-ip">
-    <para>Configure a virtual IP address for cluster administration with
-    &hawk2;. (We will use this virtual IP resource for testing successful
-    failover later on).</para>
+    <para>Configure a virtual IP address for cluster administration with &hawk2;:</para>
     <substeps>
      <step>
       <para>Confirm with <literal>y</literal> that you want to configure a
@@ -499,11 +481,8 @@ softdog           16384  1</screen>
      cookies are enabled. </para>
    </step>
    <step>
-    <para> As URL, enter the IP address or host name of any cluster node running
-     the &hawk; Web service. Alternatively, enter the address of the virtual
-     IP address that you configured in <xref linkend="st-crm-cluster-init-ip"/>
-     of <xref linkend="pro-ha-inst-quick-setup-crm-cluster-init"/>: </para>
-    <screen>https://<replaceable>HAWKSERVER</replaceable>:7630/</screen>
+    <para>As URL, enter the virtual IP address that you configured with the bootstrap script:</para>
+    <screen>https://192.168.2.1:7630/</screen>
     <note>
      <title>Certificate warning</title>
      <para> If a certificate warning appears when you try to access the URL for
@@ -513,16 +492,12 @@ softdog           16384  1</screen>
       certificate. </para>
      <para> To proceed anyway, you can add an exception in the browser to bypass
       the warning. </para>
-     <!--FIXME: HAWK1 - see https://bugzilla.suse.com/show_bug.cgi?id=979095
-      <para> For information on how to replace the self-signed certificate with a
-      certificate signed by an official Certificate Authority, refer to
-      <xref linkend="vle-ha-hawk-certificate"/>.</para>-->
     </note>
    </step>
    <step>
     <para> On the &hawk2; login screen, enter the
       <guimenu>Username</guimenu> and <guimenu>Password</guimenu> of the
-       user that has been created during the bootstrap procedure (user <systemitem
+       user that was created by the bootstrap script (user <systemitem
        class="username">hacluster</systemitem>, password
       <literal>linux</literal>).</para>
     <important>
@@ -534,9 +509,8 @@ softdog           16384  1</screen>
    </step>
    <step>
     <para>
-     Click <guimenu>Log In</guimenu>. After login, the &hawk2; Web interface
-     shows the Status screen by default, displaying the current cluster
-     status at a glance:
+     Click <guimenu>Log In</guimenu>. The &hawk2; Web interface
+     shows the Status screen by default:
     </para>
     <figure xml:id="fig-ha-inst-quick-one-node-status">
      <title>Status of the one-node cluster in &hawk2;</title>
@@ -553,37 +527,31 @@ softdog           16384  1</screen>
  <sect1 xml:id="sec-ha-inst-quick-setup-2nd-node">
   <title>Adding the second node</title>
   <para>
-    If you have a one-node cluster up and running, add the second cluster
-    node with the <command>crm cluster join</command> bootstrap
-    script, as described in <xref linkend="pro-ha-inst-quick-setup-crm-cluster-join"
-    xrefstyle="select:label nopage"/>.
+    Add a second node to the cluster with the <command>crm cluster join</command>
+    bootstrap script.
     The script only needs access to an existing cluster node and
     will complete the basic setup on the current machine automatically.
-    For details, refer to the <command>crm cluster join</command> man page.
   </para>
   <para>
-   The bootstrap scripts take care of changing the configuration specific to
-   a two-node cluster, for example, SBD, &corosync;.
+   For more information, see the <command>crm cluster join</command> man page.
   </para>
   <procedure xml:id="pro-ha-inst-quick-setup-crm-cluster-join">
    <title>Adding the second node (<systemitem class="server">&node2;</systemitem>) with
     <command>crm cluster join</command></title>
    <step>
     <para>
-     Log in as &rootuser; to the physical or virtual machine supposed to
-     join the cluster.
+     Log in as &rootuser; to the physical or virtual machine you want to add to the cluster.
     </para>
    </step>
    <step>
     <para>
-     Start the bootstrap script by executing:
+     Start the bootstrap script:
     </para>
 <screen>&prompt.root;<command>crm cluster join</command></screen>
     <para>
      If NTP has not been configured to start at boot time, a message
-     appears. The script also checks for a hardware watchdog device (which
-     is important in case you want to configure SBD). You are warned if none
-     is present.
+     appears. The script also checks for a hardware watchdog device.
+     You are warned if none is present.
     </para>
    </step>
    <step>
@@ -596,15 +564,15 @@ softdog           16384  1</screen>
    </step>
    <step>
     <para>
-     If you have not already configured a passwordless SSH access between
+     If you have not already configured passwordless SSH access between
      both machines, you will be prompted for the &rootuser; password
      of the existing node.
     </para>
     <para>
      After logging in to the specified node, the script will copy the
-     &corosync; configuration, configure SSH, &csync;, and will
-     bring the current machine online as new cluster node. Apart from that,
-     it will start the service needed for &hawk2;. <!--
+     &corosync; configuration, configure SSH and &csync;,
+     bring the current machine online as new cluster node, and
+     start the service needed for &hawk2;. <!--
      If you have configured shared storage with OCFS2, it will also
      automatically create the mount point directory for the OCFS2 file system.
      -->
@@ -615,8 +583,7 @@ softdog           16384  1</screen>
    Check the cluster status in &hawk2;. Under <menuchoice>
     <guimenu>Status</guimenu>
     <guimenu>Nodes</guimenu>
-   </menuchoice> you should see two nodes with a green status (see
-   <xref linkend="fig-ha-inst-quick-two-node-cluster"/>).
+   </menuchoice> you should see two nodes with a green status:
   </para>
 
   <figure xml:id="fig-ha-inst-quick-two-node-cluster">
@@ -676,25 +643,21 @@ softdog           16384  1</screen>
     </step>
     <step>
      <para>
-      Log in to your cluster as described in <xref
-       linkend="pro-ha-inst-quick-hawk2-login"/>.
+      Log in to &hawk2;.
      </para>
     </step>
     <step>
      <para>
-      In &hawk2; <menuchoice>
-       <guimenu>Status</guimenu>
-       <guimenu>Resources</guimenu>
-      </menuchoice>,
+      Under <menuchoice><guimenu>Status</guimenu><guimenu>Resources</guimenu></menuchoice>,
       check which node the virtual IP address (resource
       <systemitem>admin_addr</systemitem>) is running on.
-      We assume the resource is running on <systemitem class="server">&node1;</systemitem>.
+      This procedure assumes the resource is running on <systemitem class="server">&node1;</systemitem>.
       </para>
     </step>
     <step>
      <para>
       Put <systemitem class="server">&node1;</systemitem> into
-      <guimenu>Standby</guimenu> mode (see <xref linkend="fig-ha-inst-quick-standby"/>).
+      <guimenu>Standby</guimenu> mode:
      </para>
      <figure xml:id="fig-ha-inst-quick-standby">
       <title>Node <systemitem class="server">&node1;</systemitem> in standby mode</title>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -103,7 +103,7 @@
      <term>Node fencing/&stonith;</term>
      <listitem>
       <para>
-       A node fencing (&stonith;) device to avoid split brain scenarios. This can
+       A node fencing (&stonith;) device to avoid split-brain scenarios. This can
        be either a physical device (a power switch) or a mechanism like SBD
        (&stonith; by disk) in combination with a watchdog.
       </para>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -632,34 +632,39 @@ softdog           16384  1</screen>
   <sect1 xml:id="sec-ha-inst-quick-test">
    <title>Testing the cluster</title>
    <para>
-    <xref linkend="sec-ha-inst-quick-test-resource-failover"/> is a simple test to check if the
-    cluster moves the virtual IP address to the other node if the node
-    that currently runs the resource is set to <literal>standby</literal>.
+    The following tests can help you identify issues with the cluster setup.
+    However, a realistic test involves specific use cases and scenarios.
+    Before using the cluster in a production environment, test it thoroughly
+    according to your use cases.
    </para>
-   <para>However, a realistic test involves specific use cases and scenarios,
-    including testing of your fencing mechanism to avoid a split brain
-    situation. If you have not set up your fencing mechanism correctly, the cluster
-    will not work properly.</para>
-   <para>Before using the cluster in a production environment, test it thoroughly
-    according to your use cases or by using the &cmd.test.script;
-    command.
-    <!-- toms 2016-08-01: For SP3, refer to the "Testing Cluster Guide" or
-     to Lars Pinnes iptable rules
-    -->
-   </para>
-   <!--remark>toms 2018-04-05: we need to add a bit more info here how you do
-    the tests and what to do when it fails.
-    However, this needs some further info from our developers. Some info can
-    be found in ha_storage_protection.xml.
-    Usually it boils down to "sbd -d DEV list" and "sbd -d DEV message &node2; test"
-   </remark-->
+   <itemizedlist>
+    <listitem>
+     <para>
+      The command <command>sbd -d <replaceable>DEVICE_NAME</replaceable> list</command>
+      lists all of the nodes that are visible to SBD. For the setup described in
+      this document, the output should show both <systemitem class="server">&node1;</systemitem>
+      and <systemitem class="server">&node2;</systemitem>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <xref linkend="sec-ha-inst-quick-test-resource-failover"/> is a simple test
+      to check if the cluster moves the virtual IP address to the other node if
+      the node that currently runs the resource is set to <literal>standby</literal>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <xref linkend="sec-ha-inst-quick-test-with-cluster-script"/> simulates cluster
+      failures and reports the results.
+     </para>
+    </listitem>
+   </itemizedlist>
    <sect2 xml:id="sec-ha-inst-quick-test-resource-failover">
     <title>Testing resource failover</title>
     <para>
      As a quick test, the following procedure checks on resource failovers:
     </para>
-   <remark>toms 2016-07-27: Fate#321073
-    Tool for Standardize Testing of Basic Cluster Functionality</remark>
    <procedure xml:id="pro-ha-inst-quick-test">
     <title>Testing resource failover</title>
     <step>
@@ -682,8 +687,7 @@ softdog           16384  1</screen>
        <guimenu>Resources</guimenu>
       </menuchoice>,
       check which node the virtual IP address (resource
-      <systemitem>admin_addr</systemitem>) is running on. <!--As we did not
-      configure any preferences, it will be an arbitrary node.-->
+      <systemitem>admin_addr</systemitem>) is running on.
       We assume the resource is running on <systemitem class="server">&node1;</systemitem>.
       </para>
     </step>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -120,7 +120,7 @@
       <itemizedlist>
        <listitem>
         <para>
-         Shared storage. For information on setting up shared storage, see the
+         A shared storage device. For information on setting up shared storage, see the
        <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
        &storage_guide; for &sls;</link>.
         </para>
@@ -353,23 +353,8 @@
  <sect1 xml:id="sec-ha-inst-quick-sbd">
   <title>Using SBD for node fencing</title>
    <para>
-    If you have shared storage, for example, a SAN (Storage Area Network),
-    you can use it to avoid split brain scenarios. To do so, configure SBD
-    as node fencing mechanism. SBD uses watchdog support
-    and the <literal>external/sbd</literal> &stonith; resource agent.
-   </para>
-
-   <para>
-    During setup of the first node with <command>crm cluster init</command>, you
-    can decide whether to use SBD. If yes, you need to enter the path to the shared
-    storage device. By default, <command>crm cluster init</command> will automatically
-    create a small partition on the device to be used for SBD.
-   </para>
-
-   <!--Taken from ha_storage_protection.xml (pro.ha.storage.protect.watchdog)?-->
-   <para>
-    In &sls;, watchdog support in the kernel is enabled by default: it ships
-    with several kernel modules that provide hardware-specific
+    Before you can configure SBD with the bootstrap script, you must enable a watchdog.
+    &sls; ships with several kernel modules that provide hardware-specific
     watchdog drivers. The &hasi; uses the SBD daemon as the software component
     that <quote>feeds</quote> the watchdog.
    </para>
@@ -398,18 +383,6 @@
 softdog           16384  1</screen>
     </step>
   </procedure>
-
-   <remark>toms 2018-04-05: we need to add a bit more info here how you do
-    the tests and what to do when it fails.
-    However, this needs some further info from our developers. Some info can
-    be found in ha_storage_protection.xml.
-    Usually it boils down to "sbd -d DEV list" and "sbd -d DEV message &node2; test"
-   </remark>
-   <para>
-    We highly recommend testing the SBD fencing mechanism for proper function
-    to prevent a split brain scenario. Such a test can be done by blocking the &corosync;
-    cluster communication.
-   </para>
  </sect1>
 
  <sect1 xml:id="sec-ha-inst-quick-setup-1st-node">
@@ -444,7 +417,7 @@ softdog           16384  1</screen>
      communication, use the option <option>--multicast</option> (or <option>-U</option>).
     </para>
     <para>
-     The scripts checks for NTP configuration and a hardware watchdog service.
+     The script checks for NTP configuration and a hardware watchdog service.
      It generates the public and private SSH keys used for SSH access and
      &csync; synchronization and starts the respective services.
     </para>
@@ -480,6 +453,7 @@ softdog           16384  1</screen>
       <para>Enter a persistent path to the partition of your block device that
        you want to use for SBD, see <xref linkend="sec-ha-inst-quick-sbd"/>.
        The path must be consistent across all nodes in the cluster.</para>
+       <para>The script creates a small partition on the device to be used for SBD.</para>
      </step>
     </substeps>
    </step>
@@ -673,6 +647,12 @@ softdog           16384  1</screen>
      to Lars Pinnes iptable rules
     -->
    </para>
+   <!--remark>toms 2018-04-05: we need to add a bit more info here how you do
+    the tests and what to do when it fails.
+    However, this needs some further info from our developers. Some info can
+    be found in ha_storage_protection.xml.
+    Usually it boils down to "sbd -d DEV list" and "sbd -d DEV message &node2; test"
+   </remark-->
    <sect2 xml:id="sec-ha-inst-quick-test-resource-failover">
     <title>Testing resource failover</title>
     <para>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -384,7 +384,7 @@
       connection). A fencing mechanism isolates the node in question
       (usually by resetting or powering off the node). This is also called
       &stonith; (<quote>Shoot the other node in the head</quote>). A node fencing
-      mechanism can be either a physical device (a power  switch) or a mechanism
+      mechanism can be either a physical device (a power switch) or a mechanism
       like SBD (&stonith; by disk) in combination with a watchdog. Using SBD
       requires shared storage.
      </para>" >
@@ -640,7 +640,7 @@
      working even if all CPUs are stuck.
     </para>
     <para>Before using the cluster in a production environment, we highly
-     recommend to replace the <systemitem>softdog</systemitem> module with the
+     recommend replacing the <systemitem>softdog</systemitem> module with the
      hardware module that best fits your hardware.
     </para>
     <para>However, if no watchdog matches your hardware,


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
Restructured the quickstart a bit, mostly based on the suggestions in DOCTEAM-94, with a couple of extras while I was at it: 

1. Moved the SBD requirements to the system requirements chapter.
2. Removed some extra info from the STONITH requirements section and the SBD section. It didn't match the minimalism of the rest of the guide.
3. Restructured the intro to the Testing chapter, to clearly show the options.
4. Updated commands to have the whole command inside the command tags, per style guide. Eventually I'll do this for all the HA guides.
5. Generally applied some more minimalism.

Here's a PDF: 
[article-installation_color_en.pdf](https://github.com/SUSE/doc-sleha/files/9595933/article-installation_color_en.pdf)

@taroth21 are you happy with these changes? Anything more/less you'd like me to do?

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [ ] To maintenance/SLEHA12SP5
- [ ] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-94