### PR TITLE
Add tip for enabling live migration of VirtualDomain

### DIFF
--- a/xml/article_pacemaker_remote.xml
+++ b/xml/article_pacemaker_remote.xml
@@ -697,6 +697,13 @@ ssh: connect to host &node4; port 3121: Connection refused</screen>
       so it is not necessary to create a recurring monitor on the
       <systemitem>VirtualDomain</systemitem> resource.
      </para>
+     <tip>
+      <title>Enabling live migration</title>
+      <para>
+       To enable live migration of the resource, set the meta attribute <option>allow-migrate</option>
+       to <literal>true</literal>. The default is <literal>false</literal>.
+      </para>
+     </tip>
     </step>
     <step>
      <para>Check the status of the cluster with the command

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -1126,8 +1126,8 @@ C = number of cluster nodes</screen>
      <term><literal>allow-migrate</literal></term>
      <listitem>
       <para>
-       Allow live migration for resources which support
-       <literal>migrate_to</literal>/<literal>migrate_from</literal>
+       Allow live migration for resources that support
+       <literal>migrate_to</literal> and <literal>migrate_from</literal>
        actions.
       </para>
       <para>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -1126,9 +1126,11 @@ C = number of cluster nodes</screen>
      <term><literal>allow-migrate</literal></term>
      <listitem>
       <para>
-       Allow live migration for resources that support
+       Whether to allow live migration for resources that support
        <literal>migrate_to</literal> and <literal>migrate_from</literal>
-       actions.
+       actions. If the value is set to <literal>true</literal>, the resource can
+       be migrated without loss of state. If the value is set to <literal>false</literal>,
+       the resource will be shut down on the first node and restarted on the second node.
       </para>
       <para>
        The default value is <literal>true</literal> for


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
Added a tip about live migration to the pacemaker remote guide.

Also made small edits to the description of `allow-migrate` in the admin guide. Only the main branch says "live migration"; that was a recent change that I need to backport along with this PR.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-588
bsc#1178970