### PR TITLE
Move maintenance and upgrade chapters to new part

### DIFF
--- a/xml/book_administration.xml
+++ b/xml/book_administration.xml
@@ -39,13 +39,12 @@
 <!-- Part: Installation and Setup                                          -->
 <!-- ===================================================================== -->
  <part xml:id="part-install">
-  <title>Installation, setup and upgrade</title>
+  <title>Installation and setup</title>
   <info/>
   <xi:include href="ha_concepts.xml"/>
   <xi:include href="ha_requirements.xml"/>
   <xi:include href="ha_install.xml"/>
   <xi:include href="ha_yast_cluster.xml"/>
-  <xi:include href="ha_migration.xml"/>
  </part>
 
 <!-- ===================================================================== -->
@@ -65,7 +64,6 @@
   <xi:include href="ha_netbonding.xml"/>
   <xi:include href="ha_loadbalancing.xml"/>
   <xi:include href="ha_geocluster.xml"/>
-  <xi:include href="ha_maintenance.xml"/>
  </part>
 
 <!-- ===================================================================== -->
@@ -83,6 +81,16 @@
   <xi:include href="ha_samba.xml"/>
   <xi:include href="ha_rear.xml"/>
  </part>
+
+<!-- ===================================================================== -->
+<!-- Part: Maintenance and Upgrade                                    -->
+<!-- ===================================================================== -->
+<part xml:id="part-maintenance">
+ <title>Maintenance and upgrade</title>
+ <info/>
+ <xi:include href="ha_maintenance.xml"/>
+ <xi:include href="ha_migration.xml"/>
+</part>
 
 <!-- ===================================================================== -->
 <!-- Part: Appendix                                                        -->


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
I've moved the maintenance and update/upgrade chapters to a new part. This is quite simple to backport as it only involves moving the includes.

PDF: [book-administration_color_en.pdf](https://github.com/SUSE/doc-sleha/files/9712656/book-administration_color_en.pdf)

I'd also like to restructure the upgrade chapter a bit, but currently I think that's better left for Smart Docs.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-112