### PR TITLE
Add -r to csync2 command for DRBD

### DIFF
--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -236,10 +236,10 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
     <step>
       <para>
         If you have configured &csync; (which should be the default), the
-        DRBD configuration files are already included in the list of files
-        need to be synchronized. To synchronize them, use:
+        DRBD configuration files are already included in the list of files that
+        need to be synchronized. To synchronize them, run the following command:
       </para>
-      <screen>&prompt.root;<command>csync2</command> -xv /etc/drbd.d/</screen>
+      <screen>&prompt.root;<command>csync2</command> -xrv /etc/drbd.d/</screen>
       <para>
         If you do not have &csync; (or do not want to use it), copy the DRBD
         configuration files manually to the other node:


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
I've added `-r` to the `csync2 -xv /etc/drbd.d/` command. In addition to the bug report requesting it, I also had better results using `-r` in my test cluster than I did without it, and I can't think of any potential drawbacks to adding it.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-735
bsc#1203168