### PR TITLE
Add step for passing SSH_AUTH_SOCK via sudo

### DIFF
--- a/xml/ha_crmreport_passl.xml
+++ b/xml/ha_crmreport_passl.xml
@@ -7,9 +7,9 @@
 <!-- Converted by suse-upgrade version 1.1 -->
 <!--https://fate.suse.com/314907:  cluster reports without ssh root access  -->
 <appendix xml:id="app-crmreport-nonroot"
- xmlns="http://docbook.org/ns/docbook" 
- xmlns:xi="http://www.w3.org/2001/XInclude" 
- xmlns:xlink="http://www.w3.org/1999/xlink" 
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
  version="5.0" >
  <title>Running cluster reports without &rootuser; access</title>
  <info>
@@ -62,7 +62,7 @@
   </listitem>
  </orderedlist>
  <para>
-  By default when <command>crm report</command> is run, it attempts to 
+  By default when <command>crm report</command> is run, it attempts to
   log in to
   remote nodes first as &rootuser;, then as user
   <systemitem class="username">hacluster</systemitem>. However, if your
@@ -175,7 +175,7 @@
    <para>
     If the SSH port change is going to be made on all nodes in the cluster,
     it is useful to modify the SSH configuration file,
-    <filename>/etc/ssh/sshd_config</filename>. 
+    <filename>/etc/ssh/sshd_config</filename>.
     </para>
    <step>
     <para>
@@ -371,7 +371,7 @@ ALL     ALL=(ALL) ALL
 #ALL     ALL=(ALL) ALL</screen>
    </step>
    <step>
-    <para>Look for the <literal>User privilege specification</literal>.</para>
+    <para>Look for the <literal>User privilege specification</literal> category.</para>
    </step>
    <step>
     <para>After having defined the aliases above, you can now add the following
@@ -380,6 +380,19 @@ ALL     ALL=(ALL) ALL
     <para>The <literal>NOPASSWORD</literal> option ensures that the user
       <systemitem class="username">hareport</systemitem> can execute the cluster
      report without providing a password.</para>
+   </step>
+   <step>
+    <para>
+     Look for the <literal>Defaults specification</literal> category. Add the
+     following line to allow SSH agent forwarding for the commands defined by the
+     <literal>HA_ALLOWED</literal> alias:
+    </para>
+<screen>Defaults!HA_ALLOWED env_keep+=SSH_AUTH_SOCK</screen>
+    <para>
+     When a user logs into a node via <command>ssh -A</command> and uses <command>sudo</command>
+     to run <command>crm report</command>, their local SSH keys are passed to the node for
+     authentication.
+    </para>
    </step>
   </procedure>
 
@@ -394,7 +407,7 @@ ALL     ALL=(ALL) ALL
  <sect1 xml:id="sec-crmreport-nonroot-execute">
   <title>Generating a cluster report</title>
   <para>To run cluster reports with the settings you have configured above, you need to be logged
-   in to one of the nodes as user <systemitem class="username">hareport</systemitem>. 
+   in to one of the nodes as user <systemitem class="username">hareport</systemitem>.
    To start a cluster report, use the  <command>crm report</command> command.
    For example: </para>
   <screen>&prompt.root;<command>crm report</command> -f 0:00 -n "&node1; &node2; &node3;"</screen>

--- a/xml/ha_crmreport_passl.xml
+++ b/xml/ha_crmreport_passl.xml
@@ -384,8 +384,8 @@ ALL     ALL=(ALL) ALL
    <step>
     <para>
      Look for the <literal>Defaults specification</literal> category. Add the
-     following line to allow SSH agent forwarding for the commands defined by the
-     <literal>HA_ALLOWED</literal> alias:
+     following line to preserve the <literal>SSH_AUTH_SOCK</literal> environment
+     variable, which is required for SSH agent forwarding:
     </para>
 <screen>Defaults!HA_ALLOWED env_keep+=SSH_AUTH_SOCK</screen>
     <para>

--- a/xml/ha_crmreport_passl.xml
+++ b/xml/ha_crmreport_passl.xml
@@ -371,10 +371,8 @@ ALL     ALL=(ALL) ALL
 #ALL     ALL=(ALL) ALL</screen>
    </step>
    <step>
-    <para>Look for the <literal>User privilege specification</literal> category.</para>
-   </step>
-   <step>
-    <para>After having defined the aliases above, you can now add the following
+    <para>Look for the <literal>User privilege specification</literal> category.
+     After having defined the aliases above, you can now add the following
      rule there:</para>
     <screen>HA	CLUSTER = (R) NOPASSWD:HA_ALLOWED</screen>
     <para>The <literal>NOPASSWORD</literal> option ensures that the user

--- a/xml/ha_crmreport_passl.xml
+++ b/xml/ha_crmreport_passl.xml
@@ -381,16 +381,15 @@ ALL     ALL=(ALL) ALL
       <systemitem class="username">hareport</systemitem> can execute the cluster
      report without providing a password.</para>
    </step>
-   <step>
+   <step performance="optional">
     <para>
-     Look for the <literal>Defaults specification</literal> category. Add the
-     following line to preserve the <literal>SSH_AUTH_SOCK</literal> environment
-     variable, which is required for SSH agent forwarding:
+     To allow the user <systemitem class="username">hareport</systemitem> to run cluster reports using your local SSH keys, add the following line to the <literal>Defaults specification</literal> category. This preserves the <literal>SSH_AUTH_SOCK</literal> environment
+     variable, which is required for SSH agent forwarding.
     </para>
 <screen>Defaults!HA_ALLOWED env_keep+=SSH_AUTH_SOCK</screen>
     <para>
-     When a user logs into a node via <command>ssh -A</command> and uses <command>sudo</command>
-     to run <command>crm report</command>, their local SSH keys are passed to the node for
+     When you log into a node as the user <systemitem class="username">hareport</systemitem> via <command>ssh -A</command>, and use <command>sudo</command>
+     to run <command>crm report</command>, your local SSH keys are passed to the node for
      authentication.
     </para>
    </step>


### PR DESCRIPTION
### Description
<!--
 Add a few sentences describing the overall goals of this pull request.
 If there are relevant Bugzilla or Jira entries, reference them.
-->
Added a step to pass a user's local SSH keys to the node for `crm report` in https://documentation.suse.com/sle-ha/15-SP3/html/SLE-HA-all/app-crmreport-nonroot.html#sec-crmreport-nonroot-sudo

Looks like my editor also removed some trailing whitespace.

### Backports
<!--
 Are backports required? Check all items that apply.
-->

- [x] To maintenance/SLEHA15SP4
- [x] To maintenance/SLEHA15SP3
- [x] To maintenance/SLEHA15SP2
- [x] To maintenance/SLEHA15SP1
- [x] To maintenance/SLEHA15
- [x] To maintenance/SLEHA12SP5
- [x] To maintenance/SLEHA12SP4


### References
<!--
Reference any Bugzilla or Jira issues
-->
jsc#DOCTEAM-667
bsc#1200367