### PR TITLE
Add notes about SBD_WATCHDOG_TIMEOUT with QDevice

### DIFF
--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -298,8 +298,9 @@ Heuristics COMMAND to run with absolute path; For multiple commands, use ";" to 
               or SBD will time out and fail to start.
              </para>
              <para>
-              In the file <filename>/etc/sysconfig/sbd</filename>, make sure that
-              <literal>SBD_WATCHDOG_TIMEOUT</literal> is set to at least <literal>31</literal>.
+              The default value for <literal>sync_timeout</literal> is 30 seconds.
+              Therefore, in the file <filename>/etc/sysconfig/sbd</filename>, make sure that <literal>SBD_WATCHDOG_TIMEOUT</literal> is set to a greater value,
+              for example <literal>35</literal>.
              </para>
             </important>
          </step>

--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -290,6 +290,18 @@ Heuristics COMMAND to run with absolute path; For multiple commands, use ";" to 
              remaining fields, you can accept the default values or change them
              if required.
             </para>
+            <important>
+             <title><literal>SBD_WATCHDOG_TIMEOUT</literal> for diskless SBD and &qdevice;</title>
+             <para>
+              If you use &qdevice; with diskless SBD, the <literal>SBD_WATCHDOG_TIMEOUT</literal>
+              value must be greater than &qdevice;'s <literal>sync_timeout</literal> value,
+              or SBD will time out and fail to start.
+             </para>
+             <para>
+              In the file <filename>/etc/sysconfig/sbd</filename>, make sure that
+              <literal>SBD_WATCHDOG_TIMEOUT</literal> is set to at least <literal>31</literal>.
+             </para>
+            </important>
          </step>
       </procedure>
    </sect1>

--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -299,8 +299,9 @@ Heuristics COMMAND to run with absolute path; For multiple commands, use ";" to 
              </para>
              <para>
               The default value for <literal>sync_timeout</literal> is 30 seconds.
-              Therefore, in the file <filename>/etc/sysconfig/sbd</filename>, make sure that <literal>SBD_WATCHDOG_TIMEOUT</literal> is set to a greater value,
-              for example <literal>35</literal>.
+              Therefore, in the file <filename>/etc/sysconfig/sbd</filename>, make sure
+              that <literal>SBD_WATCHDOG_TIMEOUT</literal> is set to a greater value,
+              such as <literal>35</literal>.
              </para>
             </important>
          </step>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -967,6 +967,18 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
        disk is used. When this parameter is missing, the <systemitem>sbd</systemitem>
        service does not start any watcher process for SBD devices.
       </para>
+      <important>
+       <title><literal>SBD_WATCHDOG_TIMEOUT</literal> for diskless SBD and &qdevice;</title>
+       <para>
+        If you use &qdevice; with diskless SBD, the <literal>SBD_WATCHDOG_TIMEOUT</literal>
+        value must be greater than &qdevice;'s <literal>sync_timeout</literal> value,
+        or SBD will time out and fail to start.
+       </para>
+       <para>
+        The default value for <literal>sync_timeout</literal> is 30 seconds. Therefore,
+        set <literal>SBD_WATCHDOG_TIMEOUT</literal> to at least <literal>31</literal>.
+       </para>
+      </important>
     </step>
     <step>
      <para>On each node, enable the SBD service:</para>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -975,8 +975,9 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
         or SBD will time out and fail to start.
        </para>
        <para>
-        The default value for <literal>sync_timeout</literal> is 30 seconds. Therefore,
-        set <literal>SBD_WATCHDOG_TIMEOUT</literal> to at least <literal>31</literal>.
+        The default value for <literal>sync_timeout</literal> is 30 seconds.
+        Therefore, set <literal>SBD_WATCHDOG_TIMEOUT</literal> to a greater value,
+        for example <literal>35</literal>.
        </para>
       </important>
     </step>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -977,7 +977,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
        <para>
         The default value for <literal>sync_timeout</literal> is 30 seconds.
         Therefore, set <literal>SBD_WATCHDOG_TIMEOUT</literal> to a greater value,
-        for example <literal>35</literal>.
+        such as <literal>35</literal>.
        </para>
       </important>
     </step>


### PR DESCRIPTION
### PR creator: Description

SBD fails if the watchdog timeout value is less than QDevice's sync timeout value.

I added a note about this to the diskless SBD section:

![image](https://user-images.githubusercontent.com/3069029/204998079-f8b27bdc-a5f3-4dd5-8755-b3d7880fe80c.png)


and the QDevice section: 
(The bootstrap script is fixed, so it should now be set to an appropriate value automatically, but it's still useful to check)

![image](https://user-images.githubusercontent.com/3069029/204997930-c840dbaa-a95b-4b11-a545-a1585583f29c.png)


### PR creator: Are there any relevant issues/feature requests?

* bsc#1205810
* jsc#DOCTEAM-827


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
  - [ ] 15
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
