### PR TITLE
Recommend stable device names for mdadm

### DIFF
--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -90,7 +90,6 @@
      and check the resource status with the command:
     </para>
     <screen>&prompt.root;<command>crm_resource</command> -r dlm -W</screen>
-    <!--<screen>&prompt.root;<command>crm_mon</command> -rn.mdadm</screen>-->
    </step>
    <step>
     <para>Create the Cluster MD device:</para>
@@ -109,11 +108,6 @@
        For other useful options, refer to the man page of
         <command>mdadm</command>. Monitor the progress of the re-sync in
         <filename>/proc/mdstat</filename>. </para>
-      <!--
-       This will create a new clustered MD device and initiate a resync of the
-       two devices. A clustered bitmap is a device internal bitmap, with one
-       bitmaps for each node.
-      -->
      </listitem>
      <listitem>
       <para>
@@ -142,8 +136,7 @@
    </step>
    <step>
     <para>Open <filename>/etc/mdadm.conf</filename> and add the md device name
-     and the devices associated with it. Use the UUID from the previous step,
-     and stable device names: </para>
+     and the devices associated with it. Use the UUID from the previous step: </para>
 <screen>DEVICE /dev/sda /dev/sdb
 ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
@@ -157,62 +150,6 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
 }</screen>
    </step>
   </procedure>
-
-<!--  <para>Before creating a clustered md device, make sure the DLM resource is up
-   and running. To create a device, issue the following command on one cluster
-   node:</para>
-
-   <screen># mdadm -\-create /dev/md0 -\-bitmap=clustered -\-raid-devices=2 -\-level=mirror
-   /dev/sda /dev/sdb</screen>
-  <para>This will create a new clustered MD device and initiate a resync of the
-   two devices. A clustered bitmap is a device internal bitmap, with one bitmaps
-   for each node. You can monitor the progress of the resync in
-    <filename>/proc/mdstat</filename>. You can still use the device as the
-    resync is being performed.</para>
-  <para>You can specify the following options while creating the clustered MD
-   device:</para>
-  <variablelist>
-   <title>Other options</title>
-   <varlistentry>
-    <term><option>-\-nodes</option></term>
-    <listitem>
-     <para>Takes an argument for the maximum number of cluster nodes which can
-      be used with the device. If not specified, the default value is 4. </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><option>-\-home-cluster</option></term>
-    <listitem>
-     <para>Takes an argument for the cluster name. Not specifying
-      this option will cause mdadm to probe the cluster for the cluster name,
-      and also need to ensure the argument is same as cluster name. </para>
-      <remark>No note needed anymore, see bsc#981511</remark>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><option>-\-spare-devices</option></term>
-    <listitem>
-     <para>In order to create a cluster-md device with a spare for automatic
-     failover, execute the following command on one cluster node: </para>
-     <screen># mdadm -\-create /dev/md0 -\-bitmap=clustered -\-raid-devices=2 -\-level=mirror
-      -\-spare-devices=1 /dev/sda /dev/sdb /dev/sdc</screen>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-  <para>Before creating a resource, edit
-   <filename>/etc/mdadm.conf</filename> to add the device name and devices
-   associated:</para>
-  <screen>DEVICE /dev/sda /dev/sdb
-   ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
-  <para>To get the UUID and the related md path, use:</para>
-  <screen># mdadm -\-detail -\-scan</screen>
-  <para>The UUID must match the UUID stored in the superblock. For details on
-   the UUID, refer to the <command>mdadm.conf</command> man page. </para>
-  <para> It may be advisable to add
-   <filename>/etc/mdadm.conf</filename> in the csync tools list of
-   files so it is uniform in all nodes.</para>
--->
-
  </sect1>
 
  <sect1 xml:id="sec-ha-cluster-md-ra">

--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -136,8 +136,9 @@
    </step>
    <step>
     <para>Open <filename>/etc/mdadm.conf</filename> and add the md device name
-     and the devices associated with it. Use the UUID from the previous step: </para>
-      <screen>DEVICE /dev/sda /dev/sdb
+     and the devices associated with it. Use the UUID from the previous step,
+     and stable device names: </para>
+<screen>DEVICE /dev/disk/by-id/<replaceable>DEVICE1_ID</replaceable> /dev/disk/by-id/<replaceable>DEVICE2_ID</replaceable>
 ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
    <step>

--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -77,6 +77,12 @@
    </listitem>
   </itemizedlist>
 
+  <para>
+   This procedure uses <literal>/dev/sd<replaceable>X</replaceable></literal>
+   device names as examples. For better stability, use persistent device names
+   such as <literal>/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></literal>.
+  </para>
+
   <procedure>
    <step>
     <para>
@@ -138,7 +144,7 @@
     <para>Open <filename>/etc/mdadm.conf</filename> and add the md device name
      and the devices associated with it. Use the UUID from the previous step,
      and stable device names: </para>
-<screen>DEVICE /dev/disk/by-id/<replaceable>DEVICE1_ID</replaceable> /dev/disk/by-id/<replaceable>DEVICE2_ID</replaceable>
+<screen>DEVICE /dev/sda /dev/sdb
 ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
    <step>


### PR DESCRIPTION
### PR creator: Description

Changed the sdX names in mdadm.conf to stable device names.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1199688
* jsc#DOCTEAM-648


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
