### PR TITLE
Remove pssh and add crm cluster run

### DIFF
--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -485,26 +485,23 @@ chmod 640 /etc/hawk/hawk.key /etc/hawk/hawk.pem</screen>
 
   <variablelist>
    <varlistentry>
-<!-- FATE#311413 -->
     <term>How can I run commands on all cluster nodes?</term>
     <listitem>
      <para>
-      Use the command <command>pssh</command> for this task. If necessary,
-      install <package>pssh</package>. Create a file
-      (for example <filename>hosts.txt</filename>) where you collect all
-      your IP addresses or host names you want to visit. Make sure you can
-      log in with <command>ssh</command> to each host listed in your
-      <filename>hosts.txt</filename> file. If everything is correctly
-      prepared, execute <command>pssh</command> and use the
-      <filename>hosts.txt</filename> file (option <option>-h</option>) and
-      the interactive mode (option <option>-i</option>) as shown in this
-      example:
+      Use the command <command>crm cluster run</command> for this task. For example:
      </para>
-<screen>pssh -i -h hosts.txt "ls -l /corosync/*.conf"
-[1] 08:28:32 [SUCCESS] root@&wsII;.&exampledomain;
--rw-r--r-- 1 root root 1480 Nov 14 13:37 /etc/corosync/corosync.conf
-[2] 08:28:32 [SUCCESS] root@&wsIIIip;
--rw-r--r-- 1 root root 1480 Nov 14 13:37 /etc/corosync/corosync.conf</screen>
+<screen>&prompt.root;<command>crm cluster run "ls -l /etc/corosync/*.conf"</command>
+INFO: [&node1;]
+-rw-r--r-- 1 root root 812 Oct 27 15:42 /etc/corosync/corosync.conf
+INFO: [&node2;]
+-rw-r--r-- 1 root root 812 Oct 27 15:42 /etc/corosync/corosync.conf
+INFO: [&node3;]
+-rw-r--r-- 1 root root 812 Oct 27 15:42 /etc/corosync/corosync.conf</screen>
+     <para>
+      By default, the specified command runs on all nodes in the cluster.
+      Alternatively, you can run the command on a specific node or group of nodes:
+     </para>
+<screen>&prompt.root;<command>crm cluster run "ls -l /etc/corosync/*.conf" &node1; &node2;</command></screen>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
### PR creator: Description

`pssh` was removed in SLE-HA 15 and replaced with `crm cluster run`.


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-840
* bsc#1205961

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
