### PR TITLE
Fix green text by simplifying xref

### DIFF
--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -394,7 +394,7 @@ crm resource cleanup <replaceable>rscid</replaceable> [<replaceable>node</replac
           However, it is possible to investigate more than one resource. Append
           the resource names after the first.
          </para>
-         <para>If you followed some naming conventions (see section <xref linkend="app-naming" xrefstyle="select:number"/>), the
+         <para>If you followed some naming conventions (see <xref linkend="app-naming"/>), the
          <command>resource</command> command makes it easier to investigate
           a group of resources. For example, this command investigates all
           primitives starting with <literal>db</literal>:


### PR DESCRIPTION
### PR creator: Description

Some text had turned green due to a faulty xref (somehow??). This is now fixed. 


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-847


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
