### PR TITLE
Add -u hareport to crm report

### DIFF
--- a/xml/ha_crmreport_passl.xml
+++ b/xml/ha_crmreport_passl.xml
@@ -405,9 +405,9 @@ ALL     ALL=(ALL) ALL
   <title>Generating a cluster report</title>
   <para>To run cluster reports with the settings you have configured above, you need to be logged
    in to one of the nodes as user <systemitem class="username">hareport</systemitem>.
-   To start a cluster report, use the  <command>crm report</command> command.
+   To start a cluster report, use the <command>crm report</command> command.
    For example: </para>
-  <screen>&prompt.root;<command>crm report</command> -f 0:00 -n "&node1; &node2; &node3;"</screen>
+  <screen><prompt role="user">hareport &gt; </prompt><command>sudo crm report -u hareport -f 0:00 -n "&node1; &node2; &node3;"</command></screen>
   <para>This command will extract all information since <literal>0 am</literal> on the named nodes
    and create a <literal>*.tar.bz2</literal> archive named
      <filename>pcmk-<replaceable>DATE</replaceable>.tar.bz2</filename> in
@@ -419,8 +419,6 @@ ALL     ALL=(ALL) ALL
      <command>crm report</command> to modify the client's SSH port. For example,
      if your custom SSH port is <literal>5022</literal>, use the following
      command:</para>
-    <!--taroth 2015-08-22: fate#314906: Support for a non-standard SSH port in
-     cluster report script-->
     <screen>&prompt.root;crm report -X "-p 5022" [...]</screen>
    </step>
    <step>


### PR DESCRIPTION
### PR creator: Description

Added the `hareport` user to the `crm cluster` command, as it fails otherwise. This won't be required in 15 SP5 due to a new feature being worked on right now, and which will also be backported to 15 SP4. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1206167
* jsc#DOCTEAM-854


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
