### PR TITLE
Improve quickstart installation sections

### DIFF
--- a/xml/article_geo_clustering.xml
+++ b/xml/article_geo_clustering.xml
@@ -228,73 +228,43 @@
    bootstrap process can be modified later (by modifying booth settings,
    modifying resources etc.). For details, see the <xref linkend="book-administration"/>.
   </para>
-
-<!--taroth 2017-07-03: the following is not really true by now, the man pages
-     are rather basic ATM:
-     <para>Each script comes with a man page covering the range of functions, the
-      script's options, and an overview of the files the script can create and modify.
-    </para>-->
  </sect1>
+
  <sect1 xml:id="sec-ha-geo-quick-inst">
-  <title>Installation</title>
-
+  <title>Installing the &ha; and &geo; clustering packages</title>
   <para>
-   Support for using &ha; clusters across unlimited distances is available with &productname;.
+   The packages for configuring and managing a &geo; cluster are included in the
+   <literal>&ha;</literal> and <literal>&geo; Clustering for &ha;</literal> installation
+   patterns. These patterns are only available after the &productname; is installed.
   </para>
   <para>
-   For setting up a &geo; cluster you need the packages included in the
-   following installation patterns:
+   You can register to the &scc; and install the &hasi; while installing &sles;,
+   or after installation. For more information, see the
+   <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-register-sle.html">
+   &deploy;</link> for &sles;.
   </para>
-
-  <itemizedlist>
-   <listitem>
+  <procedure xml:id="pro-ha-geo-quick-inst-pattern">
+   <title>Installing the &ha; and &geo; clustering patterns</title>
+   <step>
     <para>
-     <literal>&ha;</literal> (named <literal>sles_ha</literal> on the command line)
-    </para>
-   </listitem>
-   <listitem>
+     Install the &ha; and &geo; clustering patterns from the command line:</para>
+<screen>&prompt.root;<command>zypper install -t pattern ha_sles ha_geo</command></screen>
+   </step>
+   <step>
     <para>
-     <literal>&geo; Clustering for &ha;</literal> (named <literal>ha_geo</literal> on the command line)
+       Install the &ha; and &geo; clustering patterns on <emphasis>all</emphasis> machines that
+       will be part of your cluster.
     </para>
-   </listitem>
-  </itemizedlist>
-
-  <para>
-   Both patterns are only available if you have registered your system at &scc;
-   (or a local registration server) and have added the respective modules or
-   installation media as an extension. For information on how to
-   install extensions, see the <link
-   xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-add-ons.html">
-   &deploy; for &sle; &productnumber;</link>.
-  </para>
-  <para>
-     To install the packages from both patterns via command line, use Zypper:
-    </para>
-<screen>&prompt.root;<command>zypper</command> install -t pattern ha_sles ha_geo</screen>
-
-  <important>
-   <title>Installing software packages on all parties</title>
-   <para>
-    The software packages needed for &ha; and &geo; clusters are
-    <emphasis>not</emphasis> automatically copied to the cluster nodes.
-   </para>
-   <itemizedlist>
-    <listitem>
+    <note>
+     <title>Installing software packages on all nodes</title>
      <para>
-      Install &sls; &productnumber; and the <literal>ha_sles</literal> and
-      <literal>ha_geo</literal> patterns on <emphasis>all</emphasis> machines
-      that will be part of your &geo; cluster.
+      For an automated installation of &sls; &productnumber; and the &hasi;,
+      use &ay; to clone existing nodes. For more
+      information, see <xref linkend="sec-ha-installation-autoyast"/>.
      </para>
-    </listitem>
-    <listitem>
-     <para>
-      Instead of manually installing the packages on all machines that will be
-      part of your cluster, use &ay; to clone existing nodes. Find more
-      information at <xref linkend="sec-ha-installation-autoyast"/>.
-     </para>
-    </listitem>
-   </itemizedlist>
-  </important>
+    </note>
+   </step>
+ </procedure>
  </sect1>
  <sect1 xml:id="sec-ha-geo-quick-crm-cluster-geo-init">
   <title>Setting up the first site of a &geo; cluster</title>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -293,21 +293,23 @@
  </sect1>
 
   <sect1 xml:id="sec-ha-inst-quick-installation">
-    <title>Installing the &productname;</title>
+    <title>Installing the &ha; packages</title>
     <para>
       The packages for configuring and managing a cluster
       are included in the <literal>&ha;</literal> installation pattern.
-      This pattern is only available after the &productname; has been installed.
-      For information on how to install extensions, see the
-      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/article-modules.html#sec-modules-install">
-      &modulesquick;</link>.
+      This pattern is only available after the &productname; is installed.
     </para>
-
+    <para>
+     You can register to the &scc; and install the &hasi; while installing &sles;,
+     or after installation. For more information, see the
+     <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-register-sle.html">
+     &deploy;</link> for &sles;.
+    </para>
     <procedure xml:id="pro-ha-inst-quick-pattern">
-      <title>Installing the <literal>&ha;</literal> pattern</title>
+      <title>Installing the &ha; pattern</title>
       <step>
        <para>
-        Install the &ha; pattern via command line using Zypper:</para>
+        Install the &ha; pattern from the command line:</para>
 <screen>&prompt.root;<command>zypper install -t pattern ha_sles</command></screen>
       </step>
       <step>
@@ -316,20 +318,13 @@
           will be part of your cluster.
        </para>
        <note>
-        <title>Installing software packages on all parties</title>
+        <title>Installing software packages on all nodes</title>
         <para>
-         For an automated installation of &sls; &productnumber; and &productname;
-         &productnumber;, use &ay; to clone existing nodes. For more
+         For an automated installation of &sls; &productnumber; and the &hasi;,
+         use &ay; to clone existing nodes. For more
          information, see <xref linkend="sec-ha-installation-autoyast"/>.
         </para>
        </note>
-      </step>
-      <step>
-       <para>
-         Register the machines at the &scc;. Find more information in the <link
-          xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-upgrade-offline.html#sec-update-registersystem">
-         &upgrade_guide; for &sls; &productnumber;</link>.
-       </para>
       </step>
     </procedure>
   </sect1>


### PR DESCRIPTION
### PR creator: Description

Updated the installation section of the Geo quickstart to be more like the same section of the regular quickstart, and ended up improving the regular quickstart while I was at it. 


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-836


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
