### PR TITLE
Fix qdevice-hostname -> qnetd-hostname

### DIFF
--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -325,7 +325,7 @@ Heuristics COMMAND to run with absolute path; For multiple commands, use ";" to 
          one of your cluster nodes as follows:
       </para>
       <screen>&prompt.root;<command>crm</command
-> cluster init qdevice --qdevice-hostname=&node3; \
+> cluster init qdevice --qnetd-hostname=&node3; \
      --qdevice-heuristics=/usr/sbin/my-script.sh  \
      --qdevice-heuristics-mode=on</screen>
       <para>


### PR DESCRIPTION
### PR creator: Description

`--qdevice-hostname` should be `--qnetd-hostname`.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1206498
* jsc#DOCTEAM-867

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
