### PR TITLE
Restructure maintenance chapter

### DIFF
--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -255,10 +255,10 @@
   </warning>
    <para>
     To put the cluster in maintenance mode on the &crmshell;, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> configure property maintenance-mode=true</screen>
+<screen>&prompt.root;<command>crm configure property maintenance-mode=true</command></screen>
   <para>
     To put the cluster back to normal mode after your maintenance work is done, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> configure property maintenance-mode=false</screen>
+<screen>&prompt.root;<command>crm configure property maintenance-mode=false</command></screen>
 
 <procedure xml:id="pro-ha-maint-mode-cluster-hawk2">
    <title>Putting the cluster in maintenance mode with &hawk2;</title>
@@ -305,12 +305,12 @@
  <para>
   To stop the cluster services on all nodes at once, use the following command:
  </para>
-<screen>&prompt.root;<command>crm</command> cluster stop --all</screen>
+<screen>&prompt.root;<command>crm cluster stop --all</command></screen>
  <para>
   To start the cluster services again after your maintenance work is done, use
   the following command:
  </para>
-<screen>&prompt.root;<command>crm</command> cluster start --all</screen>
+<screen>&prompt.root;<command>crm cluster start --all</command></screen>
  <warning>
   <title>Graceful shutdown not guaranteed</title>
   <para>
@@ -326,10 +326,10 @@
   <title>Putting a node in maintenance mode</title>
    <para>
     To put a node in maintenance mode on the &crmshell;, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> node maintenance <replaceable>NODENAME</replaceable></screen>
+<screen>&prompt.root;<command>crm node maintenance <replaceable>NODENAME</replaceable></command></screen>
   <para>
     To put the node back to normal mode after your maintenance work is done, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> node ready <replaceable>NODENAME</replaceable></screen>
+<screen>&prompt.root;<command>crm node ready <replaceable>NODENAME</replaceable></command></screen>
 
   <procedure xml:id="pro-ha-maint-mode-nodes-hawk2">
    <title>Putting a node in maintenance mode with &hawk2;</title>
@@ -363,10 +363,10 @@
   <title>Putting a node in standby mode</title>
    <para>
     To put a node in standby mode on the &crmshell;, use the following command:</para>
-<screen>&prompt.root;crm node standby <replaceable>NODENAME</replaceable></screen>
+<screen>&prompt.root;<command>crm node standby <replaceable>NODENAME</replaceable></command></screen>
   <para>
     To bring the node back online after your maintenance work is done, use the following command:</para>
-<screen>&prompt.root;crm node online <replaceable>NODENAME</replaceable></screen>
+<screen>&prompt.root;<command>crm node online <replaceable>NODENAME</replaceable></command></screen>
 
 <procedure xml:id="pro-ha-maint-node-standby-hawk2">
   <title>Putting a node in standby mode with &hawk2;</title>
@@ -419,7 +419,7 @@
    <para>
     Put the node into <literal>standby</literal> mode:
    </para>
-<screen>&prompt.root;crm -w node standby</screen>
+<screen>&prompt.root;<command>crm -w node standby</command></screen>
    <para>
     That way, services can migrate off the node without being limited by the
     shutdown timeout of the cluster services.
@@ -429,7 +429,7 @@
    <para>
     Check the cluster status:
    </para>
-<screen>&prompt.root;crm status</screen>
+<screen>&prompt.root;<command>crm status</command></screen>
    <para>
     It shows the respective node in <literal>standby</literal> mode:
    </para>
@@ -441,7 +441,7 @@ Node <replaceable>&node2;</replaceable>: standby
    <para>
     Stop the cluster services on that node:
    </para>
-<screen>&prompt.root;crm cluster stop</screen>
+<screen>&prompt.root;<command>crm cluster stop</command></screen>
   </step>
   <step>
    <para>
@@ -464,17 +464,17 @@ Node <replaceable>&node2;</replaceable>: standby
    <para>
     Check if the cluster services have started:
    </para>
-<screen>&prompt.root;crm cluster status</screen>
+<screen>&prompt.root;<command>crm cluster status</command></screen>
    <para>
     If not, start them:
    </para>
-<screen>&prompt.root;crm cluster start</screen>
+<screen>&prompt.root;<command>crm cluster start</command></screen>
   </step>
   <step>
    <para>
     Check the cluster status:
    </para>
-<screen>&prompt.root;crm status</screen>
+<screen>&prompt.root;<command>crm status</command></screen>
    <para>
     It should show the node coming online again.
    </para>
@@ -486,10 +486,10 @@ Node <replaceable>&node2;</replaceable>: standby
   <title>Putting a resource into maintenance mode</title>
    <para>
     To put a resource into maintenance mode on the &crmshell;, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> resource maintenance <replaceable>RESOURCE_ID</replaceable> true</screen>
+<screen>&prompt.root;<command>crm resource maintenance <replaceable>RESOURCE_ID</replaceable> true</command></screen>
   <para>
     To put the resource back into normal mode after your maintenance work is done, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> resource maintenance <replaceable>RESOURCE_ID</replaceable> false</screen>
+<screen>&prompt.root;<command>crm resource maintenance <replaceable>RESOURCE_ID</replaceable> false</command></screen>
 
 <procedure xml:id="pro-ha-maint-mode-rsc-hawk2">
    <title>Putting a resource into maintenance mode with &hawk2;</title>
@@ -551,10 +551,10 @@ Node <replaceable>&node2;</replaceable>: standby
   <title>Putting a resource into unmanaged mode</title>
    <para>
     To put a resource into unmanaged mode on the &crmshell;, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> resource unmanage <replaceable>RESOURCE_ID</replaceable></screen>
+<screen>&prompt.root;<command>crm resource unmanage <replaceable>RESOURCE_ID</replaceable></command></screen>
   <para>
     To put it into managed mode again after your maintenance work is done, use the following command:</para>
-<screen>&prompt.root;<command>crm</command> resource manage <replaceable>RESOURCE_ID</replaceable></screen>
+<screen>&prompt.root;<command>crm resource manage <replaceable>RESOURCE_ID</replaceable></command></screen>
 
  <procedure xml:id="pro-ha-maint-rsc-unmanaged-hawk2">
    <title>Putting a resource into unmanaged mode with &hawk2;</title>
@@ -643,7 +643,7 @@ Node <replaceable>&node2;</replaceable>: standby
      If you have a DLM resource (or other resources depending on DLM), make
      sure to explicitly stop those resources before stopping the cluster services:
     </para>
-<screen>&prompt.crm.res;stop <replaceable>RESOURCE_ID</replaceable></screen>
+<screen>&prompt.crm.res;<command>stop <replaceable>RESOURCE_ID</replaceable></command></screen>
     <para>
      The reason is that stopping &pace; also stops the &corosync; service, on
      whose membership and messaging services DLM depends. If &corosync; stops,
@@ -655,7 +655,7 @@ Node <replaceable>&node2;</replaceable>: standby
     <para>
      Stop the cluster services on that node:
     </para>
-<screen>&prompt.root;crm cluster stop</screen>
+<screen>&prompt.root;<command>crm cluster stop</command></screen>
    </step>
    <step>
     <para>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -35,58 +35,45 @@
    <dm:repository/>
   </dm:docmanager>
  </info>
- <sect1 xml:id="sec-ha-maint-shutdown-node">
-  <title>Implications of taking down a cluster node</title>
-  <para>
-   In &sls; &hasi; 15 SP2, the way cluster services were started and
-   stopped has changed. &suse; recommends using the &crmshell;. The
-   old commands with <command>systemctl</command> are still available, but
-   are recommended for experienced users only.
-   For details, refer to the &suse; blog article <link
-    xlink:href="https://www.suse.com/c/suse-high-availability-cluster-services-how-to-stop-start-or-view-the-status/"
-   />.
-  </para>
-  <para>
-   The recommended way to start, stop, or view the status is:
-  </para>
 
+ <sect1 xml:id="sec-ha-maint-outline">
+  <title>Preparing and finishing maintenance work</title>
+  <para>
+   Use the following commands to start, stop, or view the status of the cluster:
+  </para>
   <variablelist>
    <varlistentry>
-    <term><command>crm cluster start</command></term>
+    <term><command>crm cluster start [--all]</command></term>
     <listitem>
-     <para>Start cluster services on one node</para>
+     <para>Start the cluster services on one node or all nodes</para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><command>crm cluster stop</command></term>
+    <term><command>crm cluster stop [--all]</command></term>
     <listitem>
-     <para>Stop cluster services on one node</para>
+     <para>Stop the cluster services on one node or all nodes</para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><command>crm cluster restart</command></term>
+    <term><command>crm cluster restart [--all]</command></term>
     <listitem>
-     <para>Restart cluster services on one node</para>
+     <para>Restart the cluster services on one node or all nodes</para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term><command>crm cluster status</command></term>
     <listitem>
-     <para>View status of the cluster stack on one node</para>
+     <para>View the status of the cluster stack</para>
     </listitem>
    </varlistentry>
   </variablelist>
-
   <para>
-   Execute the above commands as user &rootuser; or as a user who
-   has the required privileges.
+   Execute the above commands as user &rootuser;, or as a user with the required privileges.
   </para>
-
   <para>
    When you shut down or reboot a cluster node (or stop the cluster services on a
    node), the following processes will be triggered:
   </para>
-
   <itemizedlist>
    <listitem>
     <para>
@@ -96,97 +83,52 @@
    </listitem>
    <listitem>
     <para>
-     If stopping the resources should fail or time out, the &stonith; mechanism
+     If stopping a resource fails or times out, the &stonith; mechanism
      will fence the node and shut it down.
     </para>
    </listitem>
   </itemizedlist>
-
-  <procedure xml:id="pro-ha-maint-shutdown-node">
-   <title>Manually rebooting a cluster node</title>
+  <warning>
+   <title>Risk of data loss</title>
    <para>
-    If your aim is to move the services off the node in an orderly fashion
-    before shutting down or rebooting the node, proceed as follows:
+    If you need to do testing or maintenance work, follow the general steps
+    below.
    </para>
+   <para>
+    Otherwise you risk unwanted side effects, like resources not starting in an
+    orderly fashion, unsynchronized CIBs across the cluster nodes, or even data loss.
+   </para>
+   <procedure>
    <step>
     <para>
-     On the node you want to reboot or shut down, log in as &rootuser; or
-     equivalent.
+     Before you start, choose the appropriate option from <xref linkend="sec-ha-maint-overview"/>.
     </para>
    </step>
    <step>
     <para>
-     Put the node into <literal>standby</literal> mode:
-    </para>
-<screen>&prompt.root;crm -w node standby</screen>
-    <para>
-     That way, services can migrate off the node without being limited by the
-     shutdown timeout of the cluster services.
+     Apply this option with &hawk2; or &crmsh;.
     </para>
    </step>
    <step>
     <para>
-     Check the cluster status with:
+     Execute your maintenance task or tests.
     </para>
-<screen>&prompt.root;crm status</screen>
-    <para>
-     It shows the respective node in <literal>standby</literal> mode:
-    </para>
-<screen>[...]
-Node <replaceable>&node2;</replaceable>: standby
-[...]</screen>
    </step>
    <step>
     <para>
-     Stop the cluster services on that node:
-    </para>
-<screen>&prompt.root;crm cluster stop</screen>
-   </step>
-   <step>
-    <para>
-     Reboot the node.
+     After you have finished, put the resource, node or cluster back to
+     <quote>normal</quote> operation.
     </para>
    </step>
   </procedure>
-
-  <para>
-   To check if the node joins the cluster again:
-  </para>
-
-  <procedure>
-   <step>
-    <para>
-     Log in to the node as &rootuser; or equivalent.
-    </para>
-   </step>
-   <step>
-    <para>
-     Check if the cluster services have started:
-    </para>
-<screen>&prompt.root;crm cluster status</screen>
-   </step>
-   <step>
-    <para>
-     If not, start it:
-    </para>
-<screen>&prompt.root;crm cluster start</screen>
-   </step>
-   <step>
-    <para>
-     Check the cluster status with:
-    </para>
-<screen>&prompt.root;crm status</screen>
-    <para>
-     It should show the node coming online again.
-    </para>
-   </step>
-  </procedure>
+ </warning>
  </sect1>
+
  <sect1 xml:id="sec-ha-maint-overview">
   <title>Different options for maintenance tasks</title>
 
   <para>
-   &pace; offers a variety of options for performing system maintenance:
+   &pace; offers the following options for performing system maintenance:
   </para>
 
   <variablelist>
@@ -234,7 +176,7 @@ Node <replaceable>&node2;</replaceable>: standby
     <listitem>
      <para>
       A node that is in standby mode can no longer run resources. Any resources
-      running on the node will be moved away or stopped (in case no other node
+      running on the node will be moved away or stopped (if no other node
       is eligible to run the resource). Also, all monitoring operations will be
       stopped on the node (except for those with
       <literal>role="Stopped"</literal>).
@@ -242,6 +184,18 @@ Node <replaceable>&node2;</replaceable>: standby
      <para>
       You can use this option if you need to stop a node in a cluster while
       continuing to provide the services running on another node.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry xml:id="vle-ha-maint-shutdown-node">
+    <!--<term>Stopping the cluster services on a node</term>-->
+    <term><xref linkend="sec-ha-maint-shutdown-node" xrefstyle="select:title"/></term>
+    <listitem>
+     <para>
+      This option stops all of the cluster services on a single node. Any resources
+      running on the node will be moved away or stopped (if no other node is
+      eligible to run the resource). If stopping a resource fails or times out,
+      the node will be fenced.
      </para>
     </listitem>
    </varlistentry>
@@ -282,47 +236,6 @@ Node <replaceable>&node2;</replaceable>: standby
    </varlistentry>
 
   </variablelist>
- </sect1>
-
- <sect1 xml:id="sec-ha-maint-outline">
-  <title>Preparing and finishing maintenance work</title>
-
-  <warning>
-   <title>Risk of data loss</title>
-   <para>
-    If you need to do testing or maintenance work, follow the general steps
-    below.
-   </para>
-   <para>
-    Otherwise you risk unwanted side effects, like resources not starting in an
-    orderly fashion, unsynchronized CIBs across the cluster nodes, or even data loss.
-   </para>
-   <procedure>
-   <step>
-    <para>
-     Before you start, choose which of the options outlined in
-     <xref linkend="sec-ha-maint-overview" xrefstyle="select:label"
-     /> is appropriate for your situation.
-    </para>
-   </step>
-   <step>
-    <para>
-     Apply this option with &hawk2; or &crmsh;.
-    </para>
-   </step>
-   <step>
-    <para>
-     Execute your maintenance task or tests.
-    </para>
-   </step>
-   <step>
-    <para>
-     After you have finished, put the resource, node or cluster back to
-     <quote>normal</quote> operation.
-    </para>
-   </step>
-  </procedure>
- </warning>
  </sect1>
 
  <sect1 xml:id="sec-ha-maint-mode-cluster">
@@ -486,6 +399,87 @@ Node <replaceable>&node2;</replaceable>: standby
     </para>
    </step>
   </procedure>
+</sect1>
+
+<sect1 xml:id="sec-ha-maint-shutdown-node">
+ <title>Stopping the cluster services on a node</title>
+ <para>
+  To move the services off the node in an orderly fashion
+  before shutting down or rebooting the node, proceed as follows:
+ </para>
+ <procedure xml:id="pro-ha-maint-shutdown-node">
+  <title>Manually rebooting a cluster node</title>
+  <step>
+   <para>
+    On the node you want to reboot or shut down, log in as &rootuser; or
+    equivalent.
+   </para>
+  </step>
+  <step>
+   <para>
+    Put the node into <literal>standby</literal> mode:
+   </para>
+<screen>&prompt.root;crm -w node standby</screen>
+   <para>
+    That way, services can migrate off the node without being limited by the
+    shutdown timeout of the cluster services.
+   </para>
+  </step>
+  <step>
+   <para>
+    Check the cluster status:
+   </para>
+<screen>&prompt.root;crm status</screen>
+   <para>
+    It shows the respective node in <literal>standby</literal> mode:
+   </para>
+<screen>[...]
+Node <replaceable>&node2;</replaceable>: standby
+[...]</screen>
+  </step>
+  <step>
+   <para>
+    Stop the cluster services on that node:
+   </para>
+<screen>&prompt.root;crm cluster stop</screen>
+  </step>
+  <step>
+   <para>
+    Reboot the node.
+   </para>
+  </step>
+ </procedure>
+
+ <para>
+  To check if the node joins the cluster again:
+ </para>
+
+ <procedure>
+  <step>
+   <para>
+    Log in to the node as &rootuser; or equivalent.
+   </para>
+  </step>
+  <step>
+   <para>
+    Check if the cluster services have started:
+   </para>
+<screen>&prompt.root;crm cluster status</screen>
+   <para>
+    If not, start them:
+   </para>
+<screen>&prompt.root;crm cluster start</screen>
+  </step>
+  <step>
+   <para>
+    Check the cluster status:
+   </para>
+<screen>&prompt.root;crm status</screen>
+   <para>
+    It should show the node coming online again.
+   </para>
+  </step>
+ </procedure>
 </sect1>
 
  <sect1 xml:id="sec-ha-maint-mode-rsc">

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -95,7 +95,7 @@
     below.
    </para>
    <para>
-    Otherwise you risk unwanted side effects, like resources not starting in an
+    Otherwise, you risk unwanted side effects, like resources not starting in an
     orderly fashion, unsynchronized CIBs across the cluster nodes, or even data loss.
    </para>
    <procedure>
@@ -239,7 +239,7 @@
  </sect1>
 
  <sect1 xml:id="sec-ha-maint-mode-cluster">
-  <title>Putting the cluster in maintenance mode</title>
+  <title>Putting the cluster into maintenance mode</title>
   <warning>
    <title>Maintenance mode only disables &pace;</title>
    <para>
@@ -254,14 +254,15 @@
    </para>
   </warning>
    <para>
-    To put the cluster in maintenance mode on the &crmshell;, use the following command:</para>
+    To put the cluster into maintenance mode on the &crmshell;, use the
+    following command:</para>
 <screen>&prompt.root;<command>crm configure property maintenance-mode=true</command></screen>
   <para>
     To put the cluster back to normal mode after your maintenance work is done, use the following command:</para>
 <screen>&prompt.root;<command>crm configure property maintenance-mode=false</command></screen>
 
 <procedure xml:id="pro-ha-maint-mode-cluster-hawk2">
-   <title>Putting the cluster in maintenance mode with &hawk2;</title>
+   <title>Putting the cluster into maintenance mode with &hawk2;</title>
    <step>
     <para>
      Start a Web browser and log in to the cluster as described in
@@ -323,16 +324,17 @@
 </sect1>
 
  <sect1 xml:id="sec-ha-maint-mode-node">
-  <title>Putting a node in maintenance mode</title>
+  <title>Putting a node into maintenance mode</title>
    <para>
-    To put a node in maintenance mode on the &crmshell;, use the following command:</para>
+    To put a node into maintenance mode on the &crmshell;, use the
+    following command:</para>
 <screen>&prompt.root;<command>crm node maintenance <replaceable>NODENAME</replaceable></command></screen>
   <para>
     To put the node back to normal mode after your maintenance work is done, use the following command:</para>
 <screen>&prompt.root;<command>crm node ready <replaceable>NODENAME</replaceable></command></screen>
 
   <procedure xml:id="pro-ha-maint-mode-nodes-hawk2">
-   <title>Putting a node in maintenance mode with &hawk2;</title>
+   <title>Putting a node into maintenance mode with &hawk2;</title>
    <step>
     <para>
      Start a Web browser and log in to the cluster as described in
@@ -360,16 +362,17 @@
  </sect1>
 
  <sect1 xml:id="sec-ha-maint-node-standby">
-  <title>Putting a node in standby mode</title>
+  <title>Putting a node into standby mode</title>
    <para>
-    To put a node in standby mode on the &crmshell;, use the following command:</para>
+    To put a node into standby mode on the &crmshell;, use the
+    following command:</para>
 <screen>&prompt.root;<command>crm node standby <replaceable>NODENAME</replaceable></command></screen>
   <para>
     To bring the node back online after your maintenance work is done, use the following command:</para>
 <screen>&prompt.root;<command>crm node online <replaceable>NODENAME</replaceable></command></screen>
 
 <procedure xml:id="pro-ha-maint-node-standby-hawk2">
-  <title>Putting a node in standby mode with &hawk2;</title>
+  <title>Putting a node into standby mode with &hawk2;</title>
    <step>
     <para>
      Start a Web browser and log in to the cluster as described in
@@ -645,7 +648,7 @@ Node <replaceable>&node2;</replaceable>: standby
     </para>
 <screen>&prompt.crm.res;<command>stop <replaceable>RESOURCE_ID</replaceable></command></screen>
     <para>
-     The reason is that stopping &pace; also stops the &corosync; service, on
+     The reason is that stopping &pace; also stops the &corosync; service on
      whose membership and messaging services DLM depends. If &corosync; stops,
      the DLM resource will assume a split brain scenario and trigger a fencing
      operation.

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -245,7 +245,7 @@
    <para>
     When putting a cluster into maintenance mode, only the resource management
     by &pace; is disabled. &corosync; and SBD are still functional. Depending
-    on your maintainence tasks, this might lead to fence operations.
+    on your maintenance tasks, this might lead to fence operations.
    </para>
    <para>
     Use maintenance mode for any tasks involving cluster resources. For any tasks
@@ -254,11 +254,13 @@
    </para>
   </warning>
    <para>
-    To put the cluster into maintenance mode on the &crmshell;, use the
-    following command:</para>
+    To put the cluster into maintenance mode on the &crmshell;, use the following command:
+   </para>
 <screen>&prompt.root;<command>crm configure property maintenance-mode=true</command></screen>
-  <para>
-    To put the cluster back to normal mode after your maintenance work is done, use the following command:</para>
+   <para>
+    To put the cluster back to normal mode after your maintenance work is done, use
+    the following command:
+   </para>
 <screen>&prompt.root;<command>crm configure property maintenance-mode=false</command></screen>
 
 <procedure xml:id="pro-ha-maint-mode-cluster-hawk2">
@@ -326,11 +328,13 @@
  <sect1 xml:id="sec-ha-maint-mode-node">
   <title>Putting a node into maintenance mode</title>
    <para>
-    To put a node into maintenance mode on the &crmshell;, use the
-    following command:</para>
+    To put a node into maintenance mode on the &crmshell;, use the following command:
+   </para>
 <screen>&prompt.root;<command>crm node maintenance <replaceable>NODENAME</replaceable></command></screen>
-  <para>
-    To put the node back to normal mode after your maintenance work is done, use the following command:</para>
+   <para>
+    To put the node back to normal mode after your maintenance work is done, use
+    the following command:
+   </para>
 <screen>&prompt.root;<command>crm node ready <replaceable>NODENAME</replaceable></command></screen>
 
   <procedure xml:id="pro-ha-maint-mode-nodes-hawk2">
@@ -364,11 +368,12 @@
  <sect1 xml:id="sec-ha-maint-node-standby">
   <title>Putting a node into standby mode</title>
    <para>
-    To put a node into standby mode on the &crmshell;, use the
-    following command:</para>
+    To put a node into standby mode on the &crmshell;, use the following command:
+   </para>
 <screen>&prompt.root;<command>crm node standby <replaceable>NODENAME</replaceable></command></screen>
-  <para>
-    To bring the node back online after your maintenance work is done, use the following command:</para>
+   <para>
+    To bring the node back online after your maintenance work is done, use the following command:
+   </para>
 <screen>&prompt.root;<command>crm node online <replaceable>NODENAME</replaceable></command></screen>
 
 <procedure xml:id="pro-ha-maint-node-standby-hawk2">
@@ -490,8 +495,10 @@ Node <replaceable>&node2;</replaceable>: standby
    <para>
     To put a resource into maintenance mode on the &crmshell;, use the following command:</para>
 <screen>&prompt.root;<command>crm resource maintenance <replaceable>RESOURCE_ID</replaceable> true</command></screen>
-  <para>
-    To put the resource back into normal mode after your maintenance work is done, use the following command:</para>
+   <para>
+    To put the resource back into normal mode after your maintenance work is done, use
+    the following command:
+   </para>
 <screen>&prompt.root;<command>crm resource maintenance <replaceable>RESOURCE_ID</replaceable> false</command></screen>
 
 <procedure xml:id="pro-ha-maint-mode-rsc-hawk2">
@@ -555,8 +562,10 @@ Node <replaceable>&node2;</replaceable>: standby
    <para>
     To put a resource into unmanaged mode on the &crmshell;, use the following command:</para>
 <screen>&prompt.root;<command>crm resource unmanage <replaceable>RESOURCE_ID</replaceable></command></screen>
-  <para>
-    To put it into managed mode again after your maintenance work is done, use the following command:</para>
+   <para>
+    To put it into managed mode again after your maintenance work is done, use the
+    following command:
+   </para>
 <screen>&prompt.root;<command>crm resource manage <replaceable>RESOURCE_ID</replaceable></command></screen>
 
  <procedure xml:id="pro-ha-maint-rsc-unmanaged-hawk2">


### PR DESCRIPTION
### PR creator: Description

I restructured the Maintenance chapter to hopefully be a bit more straightforward. I mostly just moved content to new locations, but I did a little editing as well.

Original chapter: https://documentation.suse.com/sle-ha/15-SP4/html/SLE-HA-all/cha-ha-maintenance.html

New chapter: [cha-ha-maintenance_color_en.pdf](https://github.com/SUSE/doc-sleha/files/10256945/cha-ha-maintenance_color_en.pdf)

### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-831


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
  - [x] 15
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
