### PR TITLE
Add defragfs.ocfs2

### DIFF
--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -158,7 +158,15 @@
     <term>debugfs.ocfs2</term>
     <listitem>
      <para>
-      Examines the state of the OCFS file system for debugging.
+      Examines the state of the &ocfs; file system for debugging.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>defragfs.ocfs2</term>
+    <listitem>
+     <para>
+      Reduces fragmentation of the &ocfs; file system.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
### PR creator: Description

Added the defragfs.ocfs2 tool.  Will also be added to 15 SP4 and 15 SP3 but not until later in the 15 SP5 cycle. 

Engineering ticket is still in progress, but the tool is in the latest snapshot, so I think it's safe to add it now as the doc change is very small and not likely to change based on further testing/QA.  


### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-921

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4 (later)
  - [x] 15 SP3 (later)
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
