### PR TITLE
Change deprecated ms to clone

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -1165,20 +1165,16 @@ Illegal request, Invalid opcode</screen>
     op monitor interval=60 timeout=60</command></screen>
     </step>
     <step>
-     <para> Add the <literal>sg_persist</literal> primitive to a master-slave
-      group: <remark>taroth 2018-03-05: ygao, should 'master-max' be replaced
-       with 'promoted-max' or does the screen below need more changes? - ygao
-       2018-03-13: the new names are not explicitly promoted in crmsh
-       yet</remark>
+     <para> Create a promotable clone of the <literal>sg_persist</literal> primitive:
      </para>
-     <screen>&prompt.crm.conf;<command>ms ms-sg sg \
-    meta master-max=1 notify=true</command></screen>
+     <screen>&prompt.crm.conf;<command>clone clone-sg sg \
+    meta promotable=true promoted-max=1 notify=true</command></screen>
     </step>
     <step>
-     <para> Do some tests. When the resource is in master/slave status, you can
+     <para> Do some tests. When the resource is promoted, you can
       mount and write on <filename>/dev/sdc1</filename> on the cluster node where
-      the master instance is running, while you cannot write on the cluster node
-      where the slave instance is running.</para>
+      the primary instance is running, while you cannot write on the cluster node
+      where the secondary instance is running.</para>
     </step>
     <step>
      <para> Add a file system primitive for Ext4: </para>
@@ -1187,9 +1183,9 @@ Illegal request, Invalid opcode</screen>
     </step>
     <step>
      <para> Add the following order relationship plus a collocation between the
-      <literal>sg_persist</literal> master and the file system resource: </para>
-     <screen>&prompt.crm.conf;<command>order o-ms-sg-before-ext4 Mandatory: ms-sg:promote ext4:start</command>
-&prompt.crm.conf;<command>colocation col-ext4-with-sg-persist inf: ext4 ms-sg:Master</command></screen>
+      <literal>sg_persist</literal> clone and the file system resource: </para>
+     <screen>&prompt.crm.conf;<command>order o-ms-sg-before-ext4 Mandatory: clone-sg:promote ext4:start</command>
+&prompt.crm.conf;<command>colocation col-ext4-with-sg-persist inf: ext4 clone-sg:Promoted</command></screen>
     </step>
     <step>
      <para> Check all your changes with the <command>show changed</command> command.


### PR DESCRIPTION
### PR creator: Description

There was still one instance of `ms` instead of `clone`. I changed it based on how I changed all the previous instances. Also, based on those previous changes, this only goes back as far as 15 SP4.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1207389
* jsc#DOCTEAM-883


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
