### PR TITLE
Consolidate remaining config into basics chapter

### DIFF
--- a/xml/book_administration.xml
+++ b/xml/book_administration.xml
@@ -54,8 +54,6 @@
   <title>Configuration and administration</title>
   <info/>
   <xi:include href="ha_config_basics.xml"/>
-  <xi:include href="ha_config_hawk2.xml"/>
-  <xi:include href="ha_config_cli.xml"/>
   <xi:include href="ha_configuring_resources.xml"/>
   <xi:include href="ha_resource_constraints.xml"/>
   <xi:include href="ha_managing_resources.xml"/>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -18,8 +18,8 @@
     irrelevant to the cluster.
    </para>
         <para>
-    In this chapter, we will introduce some basic concepts you need to know
-    when configuring resources and administering your cluster. The following
+    This chapter introduces some basic concepts you need to know
+    when administering your cluster. The following
     chapters show you how to execute the main configuration and
     administration tasks with each of the management tools the &hasi;
     provides.
@@ -109,113 +109,6 @@
      </listitem>
     </varlistentry>
    </variablelist>
-
-  <!-- ************* -->
-<!--   <variablelist os="hide">
-    <title>Use cases of two two-node clusters in different locations</title>
-    <varlistentry><!-\- 1.2 -\->
-     <term>Two-node cluster in one location (alternative)</term>
-     <listitem>
-      <formalpara>
-       <title>Configuration:</title>
-       <para>DRBD storage and layer 2 network.</para>
-      </formalpara>
-      <formalpara>
-       <title>Usage scenario:</title>
-       <para>Embedded clusters which focus on service high
-       availability and local data redundancy for data replication.
-       Such a setup is used for radio stations or assembly line controllers,
-       for example.</para>
-      </formalpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry><!-\- 1.3 -\->
-     <term>Three or more node cluster in one location</term>
-     <listitem>
-      <formalpara>
-       <title>Configuration:</title>
-       <para>FC SAN or similar storage, layer 2 network.</para>
-      </formalpara>
-      <formalpara>
-       <title>Usage scenario:</title>
-       <para>SAP BWA, SAP HANA scale-out without system replication, and
-        small XEN/KVM infrastructure.</para>
-      </formalpara>
-     </listitem>
-    </varlistentry>
-
-    <varlistentry><!-\- 2.2 -\->
-     <term>Two two-node clusters in two locations (alternative 1)</term>
-     <listitem>
-      <formalpara>
-       <title>Configuration:</title>
-       <para>Symmetrical stretched cluster and FC SAN across two locations.
-       No layer 2 network.</para>
-      </formalpara>
-      <formalpara>
-       <title>Usage scenario:</title>
-       <para>Classical stretched clusters. For databases and enterprise
-        resource planning. This setup is rarely used.
-       </para>
-      </formalpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry><!-\- 2.3 -\->
-     <term>Two two-node clusters in two locations (alternative 2)</term>
-     <listitem>
-      <formalpara>
-       <title>Configuration:</title>
-       <para>Symmetrical stretched cluster, no FC SAN, no layer 2 network.</para>
-      </formalpara>
-      <formalpara>
-       <title>Usage scenario:</title>
-       <para>alternative of <xref linkend="vl-2x2node-2locs"/> inside a
-        public cloud.
-       </para>
-      </formalpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-
-   <variablelist>
-    <title>Use cases of an odd number of two-node clusters in different locations</title>
-
-    <varlistentry><!-\- 3.2 -\->
-     <term>Odd number of nodes in three locations (alternative 1)</term>
-     <listitem>
-      <formalpara>
-       <title>Configuration:</title>
-       <para>2&times;N+1 nodes, no FC SAN across locations and no layer 2
-        network. Auxiliary third site which acts as a majority maker.
-       </para>
-      </formalpara>
-      <formalpara>
-       <title>Usage scenario:</title>
-       <para>
-        Variant of <xref linkend="vl-n-nodes-3locs"/>. For example, for HANA
-        scale-out system replication. Rarely used.
-       </para>
-      </formalpara>
-     </listitem>
-    </varlistentry>
-    <varlistentry><!-\- 3.3 -\->
-     <term>Odd number of nodes in three locations (alternative 1)</term>
-     <listitem>
-      <formalpara>
-       <title>Configuration:</title>
-       <para>2&times;N+1 nodes, FC SAN and layer 2 network across all locations.
-       </para>
-      </formalpara>
-      <formalpara>
-       <title>Usage scenario:</title>
-       <para>
-        Variant of <xref linkend="vl-n-nodes-3locs"/>. Rarely used.
-       </para>
-      </formalpara>
-     </listitem>
-    </varlistentry>
-   </variablelist>
--->
   </sect1>
 
   <sect1 xml:id="sec-ha-config-basics-global">
@@ -230,10 +123,7 @@
    Quorum is a requirement for fencing.
    </para>
    <para>
-   Quorum calculation has changed between &productname;&nbsp;11 and
-   &productname;&nbsp;15. For &productname;&nbsp;11, quorum was calculated by
-   &pace;.
-   Starting with &productname;&nbsp;12, &corosync; can handle quorum for
+   Quorum is usually calculated by &pace;. However, &corosync; can handle quorum for
    two-node clusters directly without changing the &pace; configuration.
   </para>
 
@@ -272,135 +162,6 @@ C = number of cluster nodes</screen>
     </varlistentry>
    </variablelist>
 
-  <sect2 xml:id="sec-ha-config-basics-global-options">
-   <title>Global cluster options</title>
-   <para> Global cluster options control how the cluster behaves when
-    confronted with certain situations. They are grouped into sets and can be
-    viewed and modified with the cluster management tools like &hawk2; and
-    the <command>crm</command> shell. </para>
-   <para> The predefined values can usually be kept. However, to make key
-    functions of your cluster work correctly, you need to adjust the
-    following parameters after basic cluster setup:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      <xref linkend="sec-ha-config-basics-global-quorum" xrefstyle="select:title"/>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <xref linkend="sec-ha-config-basics-global-stonith" xrefstyle="select:title"/>
-     </para>
-    </listitem>
-   </itemizedlist>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-config-basics-global-quorum">
-   <title>Global option <literal>no-quorum-policy</literal></title>
-   <para>
-    This global option defines what to do when a cluster partition does not
-    have quorum (no majority of nodes is part of the partition).
-   </para>
-   <para>
-    Allowed values are:
-   </para>
-   <variablelist>
-    <varlistentry>
-     <term><literal>ignore</literal>
-     </term>
-     <listitem>
-      <para></para>
-      <para>
-       Setting <literal>no-quorum-policy</literal> to <literal>ignore</literal> makes
-       the cluster behave like it has quorum. Resource management is
-       continued.
-      </para>
-      <para>
-       On &slsa;&nbsp;11 this was the recommended setting for a two-node cluster.
-       Starting with &slsa;&nbsp;12, this option is obsolete.
-       Based on configuration and conditions, &corosync; gives cluster nodes
-       or a single node <quote>quorum</quote>&mdash;or not.
-      </para>
-      <para>
-      For two-node clusters the only meaningful behavior is to always
-      react in case of quorum loss. The first step should always be
-      to try to fence the lost node.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>freeze</literal>
-     </term>
-     <listitem>
-      <para>
-       If quorum is lost, the cluster partition freezes. Resource management
-       is continued: running resources are not stopped (but possibly
-       restarted in response to monitor events), but no further resources
-       are started within the affected partition.
-      </para>
-      <para>
-       This setting is recommended for clusters where certain resources
-       depend on communication with other nodes (for example, OCFS2 mounts).
-       In this case, the default setting
-       <literal>no-quorum-policy=stop</literal> is not useful, as it would
-       lead to the following scenario: Stopping those resources would not be
-       possible while the peer nodes are unreachable. Instead, an attempt to
-       stop them would eventually time out and cause a <literal>stop
-       failure</literal>, triggering escalated recovery and fencing.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>stop</literal> (default value)</term>
-     <listitem>
-      <para>
-       If quorum is lost, all resources in the affected cluster partition
-       are stopped in an orderly fashion.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>suicide</literal>
-     </term>
-     <listitem>
-      <para>
-       If quorum is lost, all nodes in the affected cluster partition are
-       fenced. This option works only in combination with SBD, see
-       <xref linkend="cha-ha-storage-protect"/>.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-config-basics-global-stonith">
-   <title>Global option <literal>stonith-enabled</literal></title>
-   <para>
-    This global option defines whether to apply fencing, allowing &stonith;
-    devices to shoot failed nodes and nodes with resources that cannot be
-    stopped. By default, this global option is set to
-    <literal>true</literal>, because for normal cluster operation it is
-    necessary to use &stonith; devices. According to the default value,
-    the cluster will refuse to start any resources if no &stonith;
-    resources have been defined.
-   </para>
-   <para>
-    If you need to disable fencing for any reasons, set
-    <literal>stonith-enabled</literal> to <literal>false</literal>, but be
-    aware that this has impact on the support status for your product.
-    Furthermore, with <literal>stonith-enabled="false"</literal>, resources
-    like the Distributed Lock Manager (DLM) and all services depending on
-    DLM (such as lvmlockd, GFS2, and OCFS2) will fail to start.
-   </para>
-   <important>
-    <title>No support without &stonith;</title>
-    <para>
-     A cluster without &stonith; is not supported.
-    </para>
-   </important>
-  </sect2>
-
   <sect2 xml:id="sec-ha-config-basics-corosync-2-node">
    <title>&corosync; configuration for two-node clusters</title>
    <para>
@@ -418,14 +179,7 @@ C = number of cluster nodes</screen>
 }</screen>
    </example>
    <para>
-    As opposed to &sle;&nbsp;11, the votequorum subsystem in &sle;&nbsp;12 and later
-    is powered by &corosync; version 2.x. This means that the
-    <literal>no-quorum-policy=ignore</literal> option must not be used.
-   </para>
-   <para>
-    <!--Normally you do not need to change this. Do not set
-    <literal>no-quorum-policy=ignore</literal> and <literal>two_node: 1</literal>
-    together. -->By default, when <literal>two_node: 1</literal> is set, the
+    By default, when <literal>two_node: 1</literal> is set, the
     <literal>wait_for_all</literal> option is automatically enabled.
     If <literal>wait_for_all</literal> is not enabled, the cluster should be
     started on both nodes in parallel. Otherwise the first node will perform
@@ -485,6 +239,140 @@ C = number of cluster nodes</screen>
   </sect2>
  </sect1>
 
+ <sect1 xml:id="sec-ha-config-basics-global-options">
+  <title>Global cluster options</title>
+  <para> Global cluster options control how the cluster behaves when
+   confronted with certain situations. They are grouped into sets and can be
+   viewed and modified with the cluster management tools like &hawk2; and
+   the <command>crm</command> shell. </para>
+  <para> The predefined values can usually be kept. However, to make key
+   functions of your cluster work correctly, you need to adjust the
+   following parameters after basic cluster setup:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     <xref linkend="sec-ha-config-basics-global-quorum" xrefstyle="select:title"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref linkend="sec-ha-config-basics-global-stonith" xrefstyle="select:title"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+
+ <sect2 xml:id="sec-ha-config-basics-global-quorum">
+  <title>Global option <literal>no-quorum-policy</literal></title>
+  <para>
+   This global option defines what to do when a cluster partition does not
+   have quorum (no majority of nodes is part of the partition).
+  </para>
+  <para>
+   Allowed values are:
+  </para>
+  <variablelist>
+   <varlistentry>
+    <term><literal>ignore</literal>
+    </term>
+    <listitem>
+     <para></para>
+     <para>
+      Setting <literal>no-quorum-policy</literal> to <literal>ignore</literal> makes
+      the cluster behave like it has quorum. Resource management is
+      continued.
+     </para>
+     <para>
+      On &slsa;&nbsp;11 this was the recommended setting for a two-node cluster.
+      Starting with &slsa;&nbsp;12, this option is obsolete.
+      Based on configuration and conditions, &corosync; gives cluster nodes
+      or a single node <quote>quorum</quote>&mdash;or not.
+     </para>
+     <para>
+     For two-node clusters the only meaningful behavior is to always
+     react in case of quorum loss. The first step should always be
+     to try to fence the lost node.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>freeze</literal>
+    </term>
+    <listitem>
+     <para>
+      If quorum is lost, the cluster partition freezes. Resource management
+      is continued: running resources are not stopped (but possibly
+      restarted in response to monitor events), but no further resources
+      are started within the affected partition.
+     </para>
+     <para>
+      This setting is recommended for clusters where certain resources
+      depend on communication with other nodes (for example, OCFS2 mounts).
+      In this case, the default setting
+      <literal>no-quorum-policy=stop</literal> is not useful, as it would
+      lead to the following scenario: Stopping those resources would not be
+      possible while the peer nodes are unreachable. Instead, an attempt to
+      stop them would eventually time out and cause a <literal>stop
+      failure</literal>, triggering escalated recovery and fencing.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>stop</literal> (default value)</term>
+    <listitem>
+     <para>
+      If quorum is lost, all resources in the affected cluster partition
+      are stopped in an orderly fashion.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>suicide</literal>
+    </term>
+    <listitem>
+     <para>
+      If quorum is lost, all nodes in the affected cluster partition are
+      fenced. This option works only in combination with SBD, see
+      <xref linkend="cha-ha-storage-protect"/>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect2>
+
+ <sect2 xml:id="sec-ha-config-basics-global-stonith">
+  <title>Global option <literal>stonith-enabled</literal></title>
+  <para>
+   This global option defines whether to apply fencing, allowing &stonith;
+   devices to shoot failed nodes and nodes with resources that cannot be
+   stopped. By default, this global option is set to
+   <literal>true</literal>, because for normal cluster operation it is
+   necessary to use &stonith; devices. According to the default value,
+   the cluster will refuse to start any resources if no &stonith;
+   resources have been defined.
+  </para>
+  <para>
+   If you need to disable fencing for any reasons, set
+   <literal>stonith-enabled</literal> to <literal>false</literal>, but be
+   aware that this has impact on the support status for your product.
+   Furthermore, with <literal>stonith-enabled="false"</literal>, resources
+   like the Distributed Lock Manager (DLM) and all services depending on
+   DLM (such as lvmlockd, GFS2, and OCFS2) will fail to start.
+  </para>
+  <important>
+   <title>No support without &stonith;</title>
+   <para>
+    A cluster without &stonith; is not supported.
+   </para>
+  </important>
+  </sect2>
+ </sect1>
+
+
+ <xi:include href="ha_config_hawk2.xml"/>
+ <xi:include href="ha_config_cli.xml"/>
+
+
  <sect1 xml:id="sec-ha-config-basics-more">
   <title>For more information</title>
 
@@ -539,13 +427,6 @@ C = number of cluster nodes</screen>
         for reference.
        </para>
       </listitem>
-     <!--taroth 2015-05-06: commenting for now since it is a little bit outdated
-       (clones are still used in stonith configuration examples)<listitem>
-       <para>
-        <citetitle>Configuring Fencing with crmsh</citetitle>: How to
-        configure and use &stonith; devices.
-       </para>
-      </listitem>-->
       <listitem>
        <para>
         <citetitle>Colocation Explained</citetitle>

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -1,48 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter
+<!DOCTYPE section
 [
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
-<!--
 
- Future TODOs:
- * Correct IDs
- * FATE 304867 Multilevel administration rights for CIB
-   => 2010-02-23: According to Lars, not fully functionaly yet
-
- http://www.clusterlabs.org/wiki/Example_configurations
--->
-<chapter xml:id="cha-ha-manual-config" version="5.0"
+<sect1 xml:id="cha-ha-manual-config" version="5.0"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-<!--<sect1 id="sec-ha-manual-config-adminrights">
-  <title>Setting multilevel administration rights</title>
-  <remark>FATE#304867 Multilevel administration rights for CIB</remark>
-  <para></para>
- </sect1>-->
-<!-- FATE#309125 -->
-<!-- FATE#310358, #310174, #310172 -->
- <title>Configuring and managing cluster resources (command line)</title>
+ <title>Introduction to &crmsh;</title>
  <info>
-      <abstract>
-        <para>
-    To configure and manage cluster resources, either use the &crmshell;
-    (&crmsh;) command line utility or &hawk2;, a Web-based
-    user interface.
-   </para>
-        <para>
-    This chapter introduces <command>crm</command>, the command line tool
-    and covers an overview of this tool, how to use templates, and mainly
-    configuring and managing cluster resources: creating basic and advanced
-    types of resources (groups and clones), configuring constraints,
-    specifying failover nodes and failback nodes, configuring resource
-    monitoring, starting, cleaning up or removing resources, and migrating
-    resources manually.
-   </para>
-      </abstract>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:maintainer/>
         <dm:status>editing</dm:status>
@@ -54,6 +23,23 @@
         <dm:repository/>
       </dm:docmanager>
     </info>
+
+   <para>
+    To configure and manage cluster resources, either use the &crmshell;
+    (&crmsh;) command line utility or &hawk2;, a Web-based
+    user interface.
+   </para>
+        <para>
+    This section introduces the command line tool <command>crm</command>.
+    The <command>crm</command> command has several subcommands which manage
+   resources, CIBs, nodes, resource agents, and others. It offers a thorough
+   help system with embedded examples. All examples follow a naming
+   convention described in
+   <xref linkend="app-naming" xrefstyle="select:label"/>.
+   </para>
+     <para>
+   Events are logged to <filename>/var/log/crmsh/crmsh.log</filename>.
+  </para>
     <note>
   <title>User privileges</title>
   <para>
@@ -76,19 +62,6 @@
    <command>sudo</command> does not ask for a password.
   </para>
  </note>
- <sect1 xml:id="sec-ha-manual-config-crm">
-  <title>&crmsh;&mdash;overview</title>
-
-  <para>
-   The <command>crm</command> command has several subcommands which manage
-   resources, CIBs, nodes, resource agents, and others. It offers a thorough
-   help system with embedded examples. All examples follow a naming
-   convention described in
-   <xref linkend="app-naming" xrefstyle="select:label"/>.
-  </para>
-  <para>
-   Events are logged to <filename>/var/log/crmsh/crmsh.log</filename>.
-  </para>
 
 
 <!-- toms 2014-02-27:
@@ -824,8 +797,8 @@ primitive fence-&node2; stonith:apcsmart \
    </para>
 <screen>&prompt.root;<command>crm configure graph dot config.svg svg</command></screen>
   </sect2>
- </sect1>
- <sect1 xml:id="sec-ha-manual-config-crm-corosync">
+
+ <sect2 xml:id="sec-ha-manual-config-crm-corosync">
   <title>Managing &corosync; configuration</title>
 
   <para>
@@ -887,13 +860,13 @@ Membership information
    For more details, see
    <link xlink:href="http://crmsh.nongnu.org/crm.8.html#cmdhelp_corosync"/>.
   </para>
- </sect1>
+ </sect2>
 
- <sect1 xml:id="sec-ha-config-crm-setpwd">
+ <sect2 xml:id="sec-ha-config-crm-setpwd">
   <title>Setting passwords independent of <filename>cib.xml</filename></title>
 
   <para>
-   In case your cluster configuration contains sensitive information, such
+   If your cluster configuration contains sensitive information, such
    as passwords, it should be stored in local files. That way, these
    parameters will never be logged or leaked in support reports.
   </para>
@@ -928,28 +901,5 @@ linux</screen>
    <command>crm resource secret</command> command will take care of that. We
    highly recommend to only use this command to manage secret parameters.
   </para>
- </sect1>
-
- <sect1 xml:id="sec-ha-config-crm-more">
-  <title>For more information</title>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-     The crm man page.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Visit the upstream project documentation at
-     <link xlink:href="http://crmsh.github.io/documentation"/>.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     See <xref linkend="article-nfs-storage"/> for an exhaustive example.
-    </para>
-   </listitem>
-  </itemizedlist>
- </sect1>
-</chapter>
+ </sect2>
+</sect1>

--- a/xml/ha_config_hawk2.xml
+++ b/xml/ha_config_hawk2.xml
@@ -1,31 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter
+<!DOCTYPE section
 [
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
-<chapter xml:id="cha-conf-hawk2"
+<sect1 xml:id="cha-conf-hawk2"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
- <title>Configuring and managing cluster resources with &hawk2;</title>
+ <title>Introduction to &hawk2;</title>
  <info>
-  <abstract>
-   <para>
-    To configure and manage cluster resources, either use &hawk2;, or
-    the &crmshell; (&crmsh;) command line utility. If you upgrade from an
-    earlier version of &productnamereg; where &hawk; was installed, the package
-    will be replaced with the current version, &hawk2;.
-   </para>
-
-   <para>
-    &hawk2;'s user-friendly Web interface allows you to monitor and administer
-    your &ha; clusters from Linux or non-Linux machines alike. &hawk2; can be
-    accessed from any machine inside or outside of the cluster by using a
-    (graphical) Web browser.
-   </para>
-  </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:maintainer/>
    <dm:status>editing</dm:status>
@@ -37,7 +22,20 @@
    <dm:repository/>
   </dm:docmanager>
  </info>
- <sect1 xml:id="sec-conf-hawk2-req">
+
+   <para>
+    To configure and manage cluster resources, either use &hawk2;, or
+    the &crmshell; (&crmsh;) command line utility.
+   </para>
+
+   <para>
+    &hawk2;'s user-friendly Web interface allows you to monitor and administer
+    your &ha; clusters from Linux or non-Linux machines alike. &hawk2; can be
+    accessed from any machine inside or outside of the cluster by using a
+    (graphical) Web browser.
+   </para>
+
+ <sect2 xml:id="sec-conf-hawk2-req">
   <title>&hawk2; requirements</title>
 
   <para>
@@ -150,8 +148,8 @@
 <screen>&prompt.root;<command>systemctl enable hawk</command></screen>
    </step>
   </procedure>
- </sect1>
- <sect1 xml:id="sec-conf-hawk2-login">
+ </sect2>
+ <sect2 xml:id="sec-conf-hawk2-login">
   <title>Logging in</title>
 
   <para>
@@ -225,8 +223,8 @@
     </para>
    </step>
   </procedure>
- </sect1>
- <sect1 xml:id="sec-conf-hawk2-overview">
+ </sect2>
+ <sect2 xml:id="sec-conf-hawk2-overview">
   <title>&hawk2; overview: main elements</title>
 
   <para>
@@ -252,7 +250,7 @@
    </para>
   </note>
 
-  <sect2 xml:id="sec-conf-hawk2-overview-leftnav">
+  <sect3 xml:id="sec-conf-hawk2-overview-leftnav">
    <title>Left navigation bar</title>
    <variablelist>
     <varlistentry>
@@ -370,9 +368,9 @@
      </listitem>
     </varlistentry>
    </variablelist>
-  </sect2>
+  </sect3>
 
-  <sect2 xml:id="sec-conf-hawk2-overview-toprow">
+  <sect3 xml:id="sec-conf-hawk2-overview-toprow">
    <title>Top-level row</title>
    <para>
     &hawk2;'s top-level row shows the following entries:
@@ -404,9 +402,9 @@
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
- </sect1>
- <sect1 xml:id="sec-conf-hawk2-cluster-config">
+  </sect3>
+ </sect2>
+ <sect2 xml:id="sec-conf-hawk2-cluster-config">
   <title>Configuring global cluster options</title>
 
   <para>
@@ -549,9 +547,9 @@
     </para>
    </step>
   </procedure>
- </sect1>
+ </sect2>
 
- <sect1 xml:id="sec-conf-hawk2-rsc-show">
+ <sect2 xml:id="sec-conf-hawk2-rsc-show">
   <title>Showing the current cluster configuration (CIB)</title>
   <para>
    Sometimes a cluster administrator needs to know the cluster configuration.
@@ -564,9 +562,9 @@
    representation of the nodes and resources configured in the CIB. It also
    shows the relationships between resources.
   </para>
- </sect1>
+ </sect2>
 
- <sect1 xml:id="sec-conf-hawk2-rsc-wizard">
+ <sect2 xml:id="sec-conf-hawk2-rsc-wizard">
   <title>Adding resources with the wizard</title>
   <para>
    The &hawk2; wizard is a convenient way of setting up simple resources like a
@@ -623,7 +621,7 @@
   <para>
    For more information, see <xref linkend="sec-ha-config-basics-resources"/>.
   </para>
- </sect1>
+ </sect2>
 
  <xi:include href="ha_hawk2_batch_i.xml"/>
-</chapter>
+</sect1>

--- a/xml/ha_hawk2_batch_i.xml
+++ b/xml/ha_hawk2_batch_i.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE sect1
+<!DOCTYPE sect2
 [
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
-<sect1 xmlns="http://docbook.org/ns/docbook"
+<sect2 xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink"
  version="5.0" xml:id="sec-conf-hawk2-batch">
@@ -385,4 +385,4 @@
    </para>
   </step>
  </procedure>
-</sect1>
+</sect2>


### PR DESCRIPTION
### PR creator: Description

Final PR for DOCTEAM-106. Consolidates the remaining sections into the Basics chapter. Not too much shuffling required for this one, and I didn't need to create any new files, so I should be able to cherry-pick this one back to SP1. 


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-106


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
