### PR TITLE
Clarify SBD STONITH resource step

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -796,7 +796,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     Configure the SBD &stonith; resource. You do not need to clone this resource.
    </para>
    <para>
-    For a two-node cluster, in case of split-brain, there will be fencing issued from
+    For a two-node cluster, in case of split brain, there will be fencing issued from
     each node to the other as expected. To prevent both nodes from being reset at practically
     the same time, it is recommended to apply the following fencing
     delays to help one of the nodes, or even the preferred node, win the fencing match.

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -752,27 +752,6 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
 
 <procedure xml:id="pro-ha-storage-protect-fencing">
  <title>Configuring the cluster to use SBD</title>
-   <para>
-    To configure the use of SBD in the cluster, you need to do the following in
-    the cluster configuration:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-       Set the <parameter>stonith-timeout</parameter> parameter to a value that
-       matches your setting.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Configure the SBD &stonith; resource. You do not need to clone this resource.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-     For the calculation of the <parameter>stonith-timeout</parameter> refer to
-     <xref linkend="sec-ha-storage-protect-watchdog-timings"/>.
-   </para>
    <step>
     <para>
      Start a shell and log in as &rootuser; or equivalent.
@@ -804,6 +783,8 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
      </callout>
      <callout arearefs="co-ha-sbd-st-timeout">
       <para>
+       To calculate the <parameter>stonith-timeout</parameter>, refer to
+       <xref linkend="sec-ha-storage-protect-watchdog-timings"/>.
        A <systemitem>stonith-timeout</systemitem> value of <literal>40</literal>
        would be appropriate if the <literal>msgwait</literal> timeout value for
        SBD was set to <literal>30</literal> seconds.</para>
@@ -811,6 +792,9 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
    </calloutlist>
   </step>
   <step xml:id="st-ha-storage-protect-fencing-static-random">
+   <para>
+    Configure the SBD &stonith; resource. You do not need to clone this resource.
+   </para>
    <para>
     For a two-node cluster, in case of split-brain, there will be fencing issued from
     each node to the other as expected. To prevent both nodes from being reset at practically


### PR DESCRIPTION
### PR creator: Description

Per DOCTEAM-834, step 4 was a little confusing as there's a lot of info there and it's not immediately obvious that this is the step where you configure the resource (at least until you scroll past and see that there's nothing else after it). 

I thought the fix would be more complex, but actually all I ended up doing was moving the context from the start of the procedure to the appropriate steps. It's still not an ideal structure for a step in a procedure, but for the purposes of this issue (making clear what the step actually is), this fix does the trick. 


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-834


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
