### PR TITLE
Clarify and improve STONITH requirement

### DIFF
--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -112,7 +112,7 @@
       <itemizedlist>
        <listitem>
         <para>
-         A shared storage device. For information on setting up shared storage, see the
+         A shared storage device. For information on setting up shared storage, see
          <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
          &storage_guide; for &sls;</link>. If you only need basic shared storage for testing
          purposes, see <xref linkend="ha-iscsi-for-sbd"/>.

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -113,8 +113,9 @@
        <listitem>
         <para>
          A shared storage device. For information on setting up shared storage, see the
-       <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
-       &storage_guide; for &sls;</link>.
+         <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
+         &storage_guide; for &sls;</link>. If you only need basic shared storage for testing
+         purposes, see <xref linkend="ha-iscsi-for-sbd"/>.
         </para>
        </listitem>
        <listitem>
@@ -846,5 +847,6 @@ INFO: Node "&node2;" was successfully fenced by "&node1;"</screen>
       &admin;</link>.
     </para>
    </sect1>
+ <xi:include href="ha_iscsi_for_sbd.xml"/>
  <xi:include href="common_legal.xml"/>
 </article>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -55,7 +55,7 @@
     </listitem>
     <listitem>
      <para>A shared storage device, used as SBD fencing mechanism.
-      This avoids split brain scenarios.
+      This avoids split-brain scenarios.
      </para>
     </listitem>
     <listitem>
@@ -68,8 +68,8 @@
    <para>
     You can use the two-node cluster for testing purposes or as a minimal
     cluster configuration that you can extend later on. Before using the
-    cluster in a production environment, modify it according to your
-    requirements.
+    cluster in a production environment, see <xref linkend="book-administration"/>
+    to modify the cluster according to your requirements.
    </para>
   </sect1>
 
@@ -105,10 +105,10 @@
       <para>
        A node fencing (&stonith;) device to avoid split-brain scenarios. This can
        be either a physical device (a power switch) or a mechanism like SBD
-       (&stonith; by disk) in combination with a watchdog.
+       (&stonith; by disk) in combination with a watchdog. SBD can be used either
+       with shared storage or in diskless mode. This document describes using SBD
+       with shared storage. The following requirements must be met:
       </para>
-      <para>This document describes using SBD for node fencing. To use SBD, the
-       following requirements must be met:</para>
       <itemizedlist>
        <listitem>
         <para>
@@ -706,7 +706,7 @@ softdog           16384  1</screen>
       <term><option>--split-brain-iptables</option></term>
       <listitem>
        <para>
-        Simulates a split brain scenario by blocking the &corosync; port.
+        Simulates a split-brain scenario by blocking the &corosync; port.
         Checks whether one node can be fenced as expected.
        </para>
       </listitem>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -100,7 +100,7 @@
   <title>Installing a basic two-node cluster</title>
   <para>
    Before you proceed, install and set up a basic two-node cluster. This task is
-   described in the &haquick;. The &haquick; describes
+   described in <xref linkend="article-installation"/>. The &haquick; describes
    how to use the &crmshell; to set up a
    cluster with minimal effort.
   </para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -39,7 +39,7 @@
   <title>Usage scenario</title>
   <para>
    This document will help you set up a highly available NFS server.
-   The cluster used to for the highly available NFS storage has the
+   The cluster used for the highly available NFS storage has the
    following properties:
   </para>
 

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -65,8 +65,9 @@
     </para>
    </listitem>
    <listitem>
-    <para>A shared storage device, used as an SBD fencing mechanism.
-     This avoids split brain scenarios.
+    <para>
+     SBD used as a &stonith; fencing device to avoid split-brain scenarios.
+     &stonith; is mandatory for the HA cluster.
     </para>
    </listitem>
    <listitem>

--- a/xml/ha_iscsi_for_sbd.xml
+++ b/xml/ha_iscsi_for_sbd.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook51-profile.xsl"
+ type="text/xml"
+ title="Profiling step"?>
+<!DOCTYPE appendix
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<appendix xml:id="ha-iscsi-for-sbd" xml:lang="en"
+ xmlns="http://docbook.org/ns/docbook" version="5.1"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Basic &iscsi; storage for SBD</title>
+ <info>
+  <abstract>
+   <para>
+    Use the following procedures to configure basic &iscsi; storage to use with SBD.
+    These procedures are only recommended for testing purposes. Before using &iscsi; in a
+    production environment, see the
+    <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-iscsi.html">
+    &storage_guide; for &sles;</link>.
+   </para>
+  </abstract>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+ <itemizedlist>
+  <title>Requirements</title>
+  <listitem>
+   <para>
+    A &sles; virtual machine to act as the &iscsi; target. This VM is not
+    part of the cluster.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Two virtual storage devices on the VM: a 20&nbsp;GB device for the system,
+    and a 1&nbsp;GB device for SBD.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Two &sles; nodes that have not been added to a &ha; cluster yet.
+   </para>
+  </listitem>
+ </itemizedlist>
+
+ <para>
+  First, set up an &iscsi; target on the virtual machine:
+ </para>
+
+ <procedure xml:id="pro-iscsi-for-sbd-target">
+  <title>Configuring an &iscsi; target</title>
+  <step>
+   <para>
+    Install the package <package>yast2-iscsi-lio-server</package>:
+   </para>
+<screen>&prompt.root;<command>zypper install yast2-iscsi-lio-server</command></screen>
+  </step>
+  <step>
+   <para>
+    Start the <literal>iscsi-lio-server</literal> module in &yast;:
+   </para>
+<screen>&prompt.root;<command>yast2 iscsi-lio-server</command></screen>
+  </step>
+  <step>
+   <para>
+    In the <guimenu>Service</guimenu> tab, under <guimenu>After reboot</guimenu>, select
+    <guimenu>Start on boot</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Activate <guimenu>Open Port in Firewall</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    In the <guimenu>Discovery</guimenu> tab, activate <guimenu>Discovery Authentication</guimenu>.
+    </para>
+   </step>
+  <step>
+   <para>
+    Under <guimenu>Authentication by Targets</guimenu>, enter a <guimenu>Username</guimenu>
+    and <guimenu>Password</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Under <guimenu>Authentication by Initiators</guimenu>, enter a
+    <guimenu>Mutual Username</guimenu> and <guimenu>Mutual Password</guimenu>.
+    This password must be different from the <guimenu>Authentication by Targets</guimenu> password.
+   </para>
+  </step>
+  <step>
+   <para>
+    In the <guimenu>Target</guimenu> tab, select <guimenu>Add</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Change the <guimenu>Target</guimenu> name by replacing <literal>.com.example</literal>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Add the <guimenu>IP Address</guimenu> of the server.
+   </para>
+  </step>
+  <step>
+   <para>
+    Select <guimenu>Add</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    In the <guimenu>LUN Details</guimenu> window, enter the <guimenu>LUN Path</guimenu> to the 1&nbsp;GB storage device (for example, <filename>/dev/vbd</filename>).
+   </para>
+  </step>
+  <step>
+   <para>
+    Select <guimenu>Ok</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Select <guimenu>Next</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Select <guimenu>Finish</guimenu> to close &yast;.
+   </para>
+  </step>
+  <step>
+   <para>
+    To check the target setup, switch to the target CLI:
+   </para>
+<screen>&prompt.root;<command>targetcli</command></screen>
+   <para>
+    Show the configuration:
+   </para>
+<screen><prompt>/> </prompt><command>ls</command></screen>
+  </step>
+ </procedure>
+
+ <para>
+  Next, set up &iscsi; initiators on the nodes. Repeat this procedure on both nodes:
+ </para>
+
+ <procedure xml:id="pro-iscsi-for-sbd-clients">
+  <title>Configuring an &iscsi; initiator</title>
+  <step>
+   <para>
+    Install the package <package>yast2-iscsi-client</package>:
+   </para>
+<screen>&prompt.root;<command>zypper install yast2-iscsi-client</command></screen>
+  </step>
+  <step>
+   <para>
+    Start the <literal>iscsid</literal> service:
+   </para>
+<screen>&prompt.root;<command>systemctl start iscsid</command></screen>
+  </step>
+  <step>
+   <para>
+    Open the <literal>iscsi-client</literal> module in &yast;:
+   </para>
+<screen>&prompt.root;<command>yast2 iscsi-client</command></screen>
+  </step>
+  <step>
+   <para>
+    In the <guimenu>Discovered Targets</guimenu> tab, select <guimenu>Discovery</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Enter the IP address of the &iscsi; target.
+   </para>
+  </step>
+  <step>
+   <para>
+    Clear <guimenu>No Discovery Authentication</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Under <guimenu>Authentication by Initiator</guimenu>, enter the initiator
+    <guimenu>Username</guimenu> and <guimenu>Password</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Under <guimenu>Authentication by Targets</guimenu>, enter the target
+    <guimenu>Username</guimenu> and <guimenu>Password</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Select <guimenu>Next</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    After &yast; discovers the &iscsi; target, select <guimenu>Connect</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Under <guimenu>Startup</guimenu>, select <guimenu>onboot</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Select <guimenu>Next</guimenu>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Select <guimenu>Ok</guimenu> to close &yast;.
+   </para>
+  </step>
+  <step>
+   <para>
+    Check the &iscsi; initiator:
+   </para>
+<screen>&prompt.root;<command>lsscsi</command>
+[0:0:1:0] cd/dvd QEMU QEMU DVD-ROM 2.5+ /dev/sr0
+[2:0:0:0] disk LIO-ORG IBLOCK 4.0 /dev/sda</screen>
+   <para>
+    Look for a line with <literal>IBLOCK</literal>. In this example,
+    the &iscsi; device is <literal>/dev/sda</literal>.
+   </para>
+  </step>
+  <step>
+   <para>
+    Check the status of the <literal>iscsid</literal> service:
+   </para>
+<screen>&prompt.root;<command>systemctl status iscsid</command></screen>
+  </step>
+ </procedure>
+
+ <para>
+  You can find the stable device name in <filename>/dev/disk/by-id/</filename>.
+  Usually, an &iscsi; device starts with <literal>scsi-SLIO-ORG_IBLOCK</literal>.
+ </para>
+ <para>
+  When you configure the cluster, specify the stable device name using one of these methods:
+ </para>
+ <itemizedlist>
+  <listitem>
+   <para>
+    When you run <command>crm cluster init</command>, enter the stable device name when prompted.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Before running <command>crm cluster init</command>, add the stable device name
+    to <filename>/etc/sysconfig/sbd</filename>:
+   </para>
+<screen>SBD_DEVICE=/dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_<replaceable>DEVICE_ID_STRING</replaceable></screen>
+   <para>
+    When you run <command>crm cluster init</command>, answer <literal>n</literal>
+    for this question:
+   </para>
+<screen>SBD is already configured to use /dev/disk/by-id/scsi-SLIO-ORG_IBLOCK_... - overwrite (y/n)?</screen>
+  </listitem>
+ </itemizedlist>
+</appendix>

--- a/xml/ha_iscsi_for_sbd.xml
+++ b/xml/ha_iscsi_for_sbd.xml
@@ -18,7 +18,7 @@
    <para>
     Use the following procedures to configure basic &iscsi; storage to use with SBD.
     These procedures are only recommended for testing purposes. Before using &iscsi; in a
-    production environment, see the
+    production environment, see
     <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-iscsi.html">
     &storage_guide; for &sles;</link>.
    </para>


### PR DESCRIPTION
### PR creator: Description

I've addressed two JIRA issues in this PR: 

**DOCTEAM-144**
* Clarified the STONITH item in the NFS quick start guide. This section is a usage scenario rather than a list of requirements, so not an appropriate place to go into a lot of detail.
* Added more detail to the STONITH requirement in the Installation quick start guide.

**DOCTEAM-107**
* Added an appendix with simple procedures to add iSCSI storage for use with SBD. I've tried to clearly mark it as just a simple option for testing purposes, but I think it's really useful to include as an easy way to get SBD for testing out an HA cluster, even if you know nothing about shared storage. 

### PR creator: Are there any relevant issues/feature requests?

* bsc#1158162
* jsc#DOCTEAM-144
* jsc#DOCTEAM-107


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
