### PR TITLE
Overhaul HA NFS guide

### DIFF
--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -48,7 +48,7 @@
     </listitem>
     <listitem>
      <para>
-      A floating, virtual IP address (<systemitem class="ipaddress">&subnetII;.1</systemitem>)
+      A floating, virtual IP address (<systemitem class="ipaddress">&subnetI;.10</systemitem>)
       that allows clients to connect to the service no matter which node it is running on.
       This IP address is used to connect to the graphical management tool &hawk2;.
      </para>
@@ -445,7 +445,7 @@ softdog           16384  1</screen>
       virtual IP address.</para></step>
      <step>
       <para>Enter an unused IP address that you want to use as administration IP
-       for &hawk2;: <literal>&subnetII;.1</literal>
+       for &hawk2;: <literal>&subnetI;.10</literal>
       </para>
       <para>Instead of logging in to an individual cluster node with &hawk2;,
        you can connect to the virtual IP address.</para>
@@ -478,7 +478,7 @@ softdog           16384  1</screen>
    </step>
    <step>
     <para>As URL, enter the virtual IP address that you configured with the bootstrap script:</para>
-    <screen>https://192.168.2.1:7630/</screen>
+    <screen>https://&subnetI;.10:7630/</screen>
     <note>
      <title>Certificate warning</title>
      <para> If a certificate warning appears when you try to access the URL for
@@ -632,10 +632,10 @@ softdog           16384  1</screen>
     <title>Testing resource failover</title>
     <step>
      <para>
-      Open a terminal and ping <systemitem>&subnetII;.1</systemitem>,
+      Open a terminal and ping <systemitem>&subnetI;.10</systemitem>,
       your virtual IP address:
      </para>
-     <screen>&prompt.root;<command>ping &subnetII;.1</command></screen>
+     <screen>&prompt.root;<command>ping &subnetI;.10</command></screen>
     </step>
     <step>
      <para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -146,10 +146,10 @@
   </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-drbd-device">
-   <title>Creating a DRBD device</title>
+   <title>Creating DRBD devices</title>
    <para>
-    This section describes how to set up a DRBD device on top of LVM. The
-    configuration of LVM as a back-end of DRBD has some benefits:
+    This section describes how to set up DRBD devices on top of LVM.
+    Using LVM as a back-end of DRBD has some benefits:
    </para>
   <itemizedlist>
    <listitem>
@@ -162,44 +162,40 @@
    </listitem>
   </itemizedlist>
   <para>
-    As the LVM volume group is named <literal>nfs</literal>, the
-    DRBD resource uses the same name.
+    The following procedures will result in two DRBD devices: one device
+    for the NFS file system, and a second device to share the NFS file states.
    </para>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-config">
-    <title>Creating DRBD configuration</title>
+    <title>Creating DRBD configurations</title>
     <para>
      For consistency reasons, it is highly recommended to follow this advice:
     </para>
-
     <itemizedlist>
      <listitem>
       <para>Use the directory <filename>/etc/drbd.d/</filename> for your
-      configuration.</para>
+      configurations.</para>
      </listitem>
      <listitem>
-      <para>Name the file according to the purpose of the resource.
+      <para>Name the files according to the purpose of the resources.
       </para>
      </listitem>
      <listitem>
-      <para>Put your resource configuration in a file with a <filename
-       class="extension">.res</filename> extension. In the following
-        examples, the file <filename>/etc/drbd.d/nfs.res</filename> is
-        used.
+      <para>Put your resource configurations in files with a <filename
+       class="extension">.res</filename> extension.
       </para>
      </listitem>
     </itemizedlist>
-
     <procedure>
-     <title>Creating a DRBD configuration</title>
+     <title>Creating DRBD configurations</title>
      <step>
       <para>
-       Create the file <filename>/etc/drbd.d/nfs.res</filename> with the
+       Create the file <filename>/etc/drbd.d/nfs_exportfs.res</filename> with the
         following contents:
       </para>
-<screen>resource nfs {
-   device /dev/drbd0; <co xml:id="co-ha-quick-nfs-drbd-device"/>
-   disk   /dev/nfs/work; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
+<screen>resource nfs_exportfs {
+   device /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
+   disk   /dev/nfs/exportfs; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
    meta-disk internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
 
    net {
@@ -273,6 +269,16 @@
      </step>
      <step>
       <para>
+       Create the file <filename>/etc/drbd.d/nfs_state.res</filename> with the
+       same contents as <filename>/etc/drbd.d/nfs_exportfs.res</filename>, but
+       change the following lines:
+      </para>
+<screen>resource nfs_<emphasis role="bold">state</emphasis> {
+   device /dev/drbd<emphasis role="bold">2</emphasis> minor <emphasis role="bold">2</emphasis>;
+   disk   /dev/nfs/<emphasis role="bold">state</emphasis>;</screen>
+     </step>
+     <step>
+      <para>
        Open <filename>/etc/csync2/csync2.cfg</filename> and check whether the
        following two lines exist:
       </para>
@@ -296,25 +302,27 @@ include /etc/drbd.d/*.res;</screen>
    </sect2>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-activate">
-    <title>Activating the DRBD device</title>
+    <title>Activating the DRBD devices</title>
     <para>
-     After you have prepared your DRBD configuration, proceed as follows:
+     After preparing the DRBD configurations, activate the devices:
     </para>
-
     <procedure>
+     <title>Activating DRBD devices</title>
      <step>
-      <para> If you use a firewall in your cluster, open port
-              <systemitem>&drbd.port;</systemitem> in your firewall configuration. </para>
+      <para>
+       If you use a firewall in your cluster, open port
+       <systemitem>&drbd.port;</systemitem> in your firewall configuration.
+      </para>
      </step>
      <step>
       <para>The first time you do this, execute the following
         commands on <emphasis>both</emphasis> nodes (in our example, <systemitem>&node1;</systemitem>
         and <systemitem>&node2;</systemitem>):
       </para>
-<screen>&prompt.root;<command>drbdadm create-md nfs</command>
-&prompt.root;<command>drbdadm up nfs</command></screen>
-      <para> This initializes the metadata storage and creates the
-              <filename>/dev/drbd0</filename> device.
+<screen>&prompt.root;<command>drbdadm create-md nfs_exportfs</command>
+&prompt.root;<command>drbdadm up nfs_exportfs</command></screen>
+      <para>
+       This initializes the metadata storage and creates the DRBD device.
       </para>
      </step>
      <step>
@@ -322,37 +330,44 @@ include /etc/drbd.d/*.res;</screen>
        If the DRBD devices on all nodes have the same data, skip
        the initial resynchronization. Use the following command:
       </para>
-      <screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/0</command></screen>
+      <screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs_exportfs/0</command></screen>
      </step>
      <step>
        <para>Make <systemitem>&node1;</systemitem> primary:</para>
-       <screen>&prompt.root;<command>drbdadm primary --force nfs</command></screen>
+       <screen>&prompt.root;<command>drbdadm primary --force nfs_exportfs</command></screen>
      </step>
       <step>
        <para>Check the DRBD status:</para>
-       <screen>&prompt.root;<command>drbdadm status nfs</command></screen>
+       <screen>&prompt.root;<command>drbdadm status nfs_exportfs</command></screen>
        <para>This returns the following message:</para>
-          <screen>nfs role:Primary
+          <screen>nfs_exportfs role:Primary
   disk:UpToDate
   &node1; role:Secondary
     peer-disk:UpToDate</screen>
      </step>
+     <step>
+      <para>
+       Repeat these steps for the <literal>nfs_state</literal> configuration.
+      </para>
+     </step>
     </procedure>
     <para>
-     After the synchronization is complete, you can access the DRBD resource
-     on the block device <filename>/dev/drbd0</filename>. Use this device
-     for creating your file system.
-     Find more information about DRBD in <xref linkend="cha-ha-drbd"/>.
+     You can access the DRBD resources on the block devices
+     <filename>/dev/drbd1</filename> and <filename>/dev/drbd2</filename>.
+
+     </para>
+     <para>
+      For more information about DRBD, refer to <xref linkend="cha-ha-drbd"/>.
      </para>
    </sect2>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-createfs">
     <title>Creating the file system</title>
-    <para>After you have finished <xref
-      linkend="sec-ha-quick-nfs-drbd-activate"/>,
-    you should see a DRBD device on <filename>/dev/drbd0</filename>:
+    <para>
+     After activating the DRBD devices, create the NFS file system on
+     <filename>/dev/drbd1</filename>:
     </para>
-    <screen>&prompt.root;<command>mkfs.ext3 /dev/drbd0</command></screen>
+    <screen>&prompt.root;<command>mkfs.ext3 /dev/drbd1</command></screen>
    </sect2>
   </sect1>
 
@@ -376,7 +391,7 @@ include /etc/drbd.d/*.res;</screen>
  </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-resources">
-  <title>Creating cluster resources<!-- for an HA NFS Server--></title>
+  <title>Creating cluster resources</title>
   <para>The following sections cover the configuration of
     the required resources for a highly available NFS cluster.
     The configuration steps use the &crmshell;.
@@ -389,7 +404,7 @@ include /etc/drbd.d/*.res;</screen>
     <listitem>
      <para>
       These resources are used to replicate data. The promotable clone resource
-      is switched from and to the Primary and Secondary roles as deemed
+      is switched to and from the Primary and Secondary roles as deemed
       necessary by the cluster resource manager.
      </para>
     </listitem>
@@ -423,15 +438,22 @@ include /etc/drbd.d/*.res;</screen>
     </listitem>
     <listitem>
         <para>The service exports data served from
-         <literal>/srv/nfs/work</literal>. </para>
+         <literal>/srv/nfs/exportfs</literal>. </para>
     </listitem>
     <listitem>
         <para>Into this export directory, the cluster will mount
             <literal>ext3</literal> file systems from the DRBD device
-         <filename>/dev/drbd0</filename>.
-         This DRBD device sits on top of an LVM logical volume with the name
-         <literal>nfs</literal>.
+         <filename>/dev/drbd1</filename>.
+         This DRBD device sits on top of an LVM logical volume named
+         <literal>/dev/nfs/exportfs</literal>.
         </para>
+    </listitem>
+    <listitem>
+     <para>
+      A second DRBD device, <literal>/dev/drbd2</literal>, is used to share the
+      NFS file states from <filename>/var/lib/nfs</filename>. This DRBD device
+      sits on top of an LVM logical volume named <literal>/dev/nfs/state</literal>.
+     </para>
     </listitem>
   </itemizedlist>
 

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -367,7 +367,7 @@ include /etc/drbd.d/*.res;</screen>
      After activating the DRBD devices, create the NFS file system on
      <filename>/dev/drbd1</filename>:
     </para>
-    <screen>&prompt.root;<command>mkfs.ext3 /dev/drbd1</command></screen>
+    <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
    </sect2>
   </sect1>
 
@@ -392,20 +392,27 @@ include /etc/drbd.d/*.res;</screen>
 
  <sect1 xml:id="sec-ha-quick-nfs-resources">
   <title>Creating cluster resources</title>
-  <para>The following sections cover the configuration of
-    the required resources for a highly available NFS cluster.
-    The configuration steps use the &crmshell;.
-    The following list shows the necessary cluster resources:
+  <para>
+   The following procedures describe how to configure the resources required
+   for a highly available NFS cluster.
   </para>
-  <variablelist xml:id="vl-ha-quick-nfs-overview-cluster-res">
+  <variablelist>
    <title>Overview of cluster resources</title>
    <varlistentry>
     <term>DRBD primitive and promotable clone resources</term>
     <listitem>
      <para>
       These resources are used to replicate data. The promotable clone resource
-      is switched to and from the Primary and Secondary roles as deemed
-      necessary by the cluster resource manager.
+      is switched to and from the primary and secondary roles as deemed necessary
+      by the cluster resource manager.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>File system resources</term>
+    <listitem>
+     <para>
+      These resources manage the NFS file system and file states.
      </para>
     </listitem>
    </varlistentry>
@@ -413,8 +420,7 @@ include /etc/drbd.d/*.res;</screen>
     <term>NFS kernel server resource</term>
     <listitem>
      <para>
-      With this resource, Pacemaker ensures that the NFS server daemons are
-      always available.
+      This resource manages the NFS server daemon.
      </para>
     </listitem>
    </varlistentry>
@@ -422,12 +428,22 @@ include /etc/drbd.d/*.res;</screen>
     <term>NFS exports</term>
     <listitem>
      <para>
-      One or more NFS exports, typically corresponding to the file system.
+      This resource is used to export the <filename>/srv/nfs/exportfs</filename>
+      directory to clients.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Virtual IP address</term>
+    <listitem>
+     <para>
+      The initial installation creates an administrative virtual IP address for &hawk2;.
+      Create another virtual IP address exclusively for NFS exports. This makes it
+      easier to apply security restrictions later.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
-
   <itemizedlist>
     <title>Example NFS scenario</title>
     <listitem>
@@ -441,8 +457,8 @@ include /etc/drbd.d/*.res;</screen>
          <literal>/srv/nfs/exportfs</literal>. </para>
     </listitem>
     <listitem>
-        <para>Into this export directory, the cluster will mount
-            <literal>ext3</literal> file systems from the DRBD device
+        <para>Into this export directory, the cluster mounts
+            <literal>ext4</literal> file systems from the DRBD device
          <filename>/dev/drbd1</filename>.
          This DRBD device sits on top of an LVM logical volume named
          <literal>/dev/nfs/exportfs</literal>.
@@ -458,167 +474,207 @@ include /etc/drbd.d/*.res;</screen>
   </itemizedlist>
 
   <sect2 xml:id="sec-ha-quick-nfs-resources-drbd">
-   <title>DRBD primitive and promotable clone resource</title>
+   <title>Creating DRBD primitive and promotable clone resources</title>
    <para>
-    To configure these resources, run the following commands from the
-   &crmshell;:
+    First, create cluster resources to manage the DRBD devices, and promotable
+    clones to allow these resources to run on both nodes.
    </para>
-<screen>&prompt.root;<command>crm configure</command>
-&prompt.crm.conf;<command>primitive drbd_nfs ocf:linbit:drbd \
-    params drbd_resource="nfs" \
+   <procedure>
+    <title>Creating DRBD resources for NFS</title>
+    <step>
+     <para>
+      Log in as &rootuser; and start the <command>crm</command> interactive shell:
+     </para>
+<screen>&prompt.root;<command>crm configure</command></screen>
+    </step>
+    <step>
+     <para>
+      Create a primitive for the DRBD resource <literal>nfs_exportfs</literal>:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive drbd-nfs_exportfs ocf:linbit:drbd \
+  params drbd_resource="nfs_exportfs" \
   op monitor interval="15" role="Promoted" \
-  op monitor interval="30" role="Unpromoted"</command>
-&prompt.crm.conf;<command>clone clone-drbd_nfs drbd_nfs \
-  meta promotable="true" promoted-max="1" promoted-node-max="1" clone-max="2" \
-  clone-node-max="1" notify="true"</command>
-&prompt.crm.conf;<command>commit</command></screen>
-   <para>
-    This will create a Pacemaker promotable clone resource corresponding to the
-    DRBD resource <literal>nfs</literal>. Pacemaker should now activate your
-    DRBD resource on both nodes and promote it to the primary role on one of
-    them.
-   </para>
-   <para>
-    Check the state of the cluster with the <command>crm status</command>
-     command, or run <command>drbdadm status</command>.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-quick-nfs-resources-nfsserver">
-   <title>NFS kernel server resource</title>
-   <para>
-    In the &crmshell;, the resource for the NFS server
-    daemons must be configured as a <emphasis>clone</emphasis> of a
-    <literal>systemd</literal> resource type.
-   </para>
-<screen>&prompt.crm.conf;<command>primitive nfsserver \
-  systemd:nfs-server \
-  op monitor interval="30s"</command>
-&prompt.crm.conf;<command>clone cl-nfsserver nfsserver \
-   meta interleave=true</command>
-&prompt.crm.conf;<command>commit</command></screen>
-   <para>
-    After you have committed this configuration, Pacemaker should start the
-    NFS Kernel server processes on both nodes.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-quick-nfs-resources-lvm">
-   <title>File system resource</title>
-   <orderedlist>
-    <listitem>
+  op monitor interval="30" role="Unpromoted"</command></screen>
+    </step>
+    <step>
      <para>
-      Configure the file system type resource as follows (but
-      <emphasis>do not</emphasis> commit this configuration yet):
+      Create a primitive for the DRBD resource <literal>nfs_state</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive fs_work \
-  ocf:heartbeat:Filesystem \
-  params device=/dev/drbd0 \
-    directory=/srv/nfs/work \
-    fstype=ext3 \
-  op monitor interval="10s"</command></screen>
-    </listitem>
-    <listitem>
+<screen>&prompt.crm.conf;<command>primitive drbd-nfs_state ocf:linbit:drbd \
+  params drbd_resource="nfs_state" \
+  op monitor interval="15" role="Promoted" \
+  op monitor interval="30" role="Unpromoted"</command></screen>
+    </step>
+    <step>
      <para>
-      Combine these resources into a Pacemaker resource
-      <emphasis>group</emphasis>:
+      Create a promotable clone for the <literal>drbd-nfs_exportfs</literal>
+      primitive:
      </para>
-<screen>&prompt.crm.conf;<command>group g-nfs fs_work</command></screen>
-    </listitem>
-    <listitem>
+<screen>&prompt.crm.conf;<command>clone cl-nfs_exportfs drbd-nfs_exportfs \
+  meta promotable="true" promoted-max="1" promoted-node-max="1" \
+  clone-max="2" clone-node-max="1" notify="true"</command></screen>
+    </step>
+    <step>
      <para>
-      Add the following constraints to make sure that the group is started
-      on the same node on which the DRBD promotable clone resource is in the
-      primary role:
+      Create a promotable clone for the <literal>drbd-nfs_state</literal>
+      primitive:
      </para>
-<screen>&prompt.crm.conf;<command>order o-drbd_before_nfs Mandatory: \
-  clone-drbd_nfs:promote g-nfs:start</command>
-&prompt.crm.conf;<command>colocation col-nfs_on_drbd inf: \
-  g-nfs clone-drbd_nfs:Promoted</command></screen>
-    </listitem>
-    <listitem>
+<screen>&prompt.crm.conf;<command>clone cl-nfs_state drbd-nfs_state \
+  meta promotable="true" promoted-max="1" promoted-node-max="1" \
+  clone-max="2" clone-node-max="1" notify="true"</command></screen>
+    </step>
+    <step>
      <para>
       Commit this configuration:
      </para>
 <screen>&prompt.crm.conf;<command>commit</command></screen>
-    </listitem>
-   </orderedlist>
+    </step>
+   </procedure>
    <para>
-    After these changes have been committed, Pacemaker mounts the DRBD device
-    to <filename>/srv/nfs/work</filename> on the same node. Confirm this with
-    <command>mount</command> (or by looking at <filename
-     >/proc/mounts</filename>).
+    Pacemaker activates the DRBD resources on both nodes and promotes
+    them to the primary role on one of the nodes. Check the state of the
+    cluster with the <command>crm status</command> command, or run
+    <command>drbdadm status</command>.
    </para>
   </sect2>
 
-  <sect2 xml:id="sec-ha-quick-nfs-resources-nfsexport">
-   <title>NFS export resources</title>
+  <sect2 xml:id="sec-ha-quick-nfs-resources-lvm">
+   <title>Creating NFS file system resources</title>
    <para>
-    When your DRBD, LVM, and file system resources are working properly,
-    continue with the resources managing your NFS exports. To create highly
-    available NFS export resources, use the <literal>exportfs</literal>
-    resource type.
+    Next, create cluster resources to manage the NFS file system and file states.
+    <emphasis>Do not</emphasis> commit this configuration until after you add
+    the colocation and order constraints.
    </para>
-
-    <para>
-     To export the <filename>/srv/nfs/work</filename> directory to clients,
-     use the following primitive:
-    </para>
-    <orderedlist>
-     <listitem>
-      <para>
-       Create NFS exports with the following commands:
-      </para>
-<screen>&prompt.crm.conf;<command>primitive exportfs_work \
-  ocf:heartbeat:exportfs \
-    params directory="/srv/nfs/work" \
-      options="rw,mountpoint" \
-      clientspec="&nfs-clientspec;" \
-      wait_for_leasetime_on_stop=true \
-      fsid=100 \
+   <procedure>
+    <title>Creating file system resources for NFS</title>
+    <step>
+     <para>
+      Create a file system type resource for the NFS file system on
+      <literal>/dev/drbd1</literal>:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive fs-nfs_exportfs Filesystem \
+  params device=/dev/drbd1 directory=/srv/nfs/exportfs fstype=ext4 \
   op monitor interval="30s"</command></screen>
-     </listitem>
-     <listitem>
-      <para>
-       After you have created these resources, append them to the existing
-       <literal>g-nfs</literal> resource group:
-      </para>
-<screen>&prompt.crm.conf;<command>modgroup g-nfs add exportfs_work</command></screen>
-     </listitem>
-     <listitem>
-      <para>
-       Commit this configuration:
-      </para>
+    </step>
+    <step>
+     <para>
+      Create a file system type resource for the NFS file states on
+      <literal>/dev/drbd2</literal>:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive fs-nfs_state Filesystem \
+  params device=/dev/drbd2 directory=/var/lib/nfs fstype=ext4 \
+  op monitor interval="30s"</command></screen>
+    </step>
+    <step>
+     <para>
+      Add a colocation constraint to make sure that the two resources
+      always start on the same node:
+     </para>
+<screen>&prompt.crm.conf;<command>colocation co-nfs_exportfs-with-nfs_state \
+  inf: fs-nfs_exportfs fs-nfs_state</command></screen>
+    </step>
+    <step>
+     <para>
+      Add colocation constraints to make sure that each resource always starts
+      on the node where the related DRBD promotable clone is in the primary role:
+     </para>
+<screen>&prompt.crm.conf;<command>colocation co-nfs_exportfs-on-drbd \
+  inf: fs-nfs_exportfs cl-nfs_exportfs:Promoted</command>
+&prompt.crm.conf;<command>colocation co-nfs_state-on-drbd \
+  inf: fs-nfs_state cl-nfs_state:Promoted</command></screen>
+    </step>
+    <step>
+     <para>
+      Add order constraints to make sure the DRBD promotable clones always start
+      before the file system resources:
+     </para>
+<screen>&prompt.crm.conf;<command>order o-drbd-before-nfs_exportfs \
+  Mandatory: cl-nfs_exportfs:promote fs-nfs_exportfs:start</command>
+&prompt.crm.conf;<command>order o-drbd-before-nfs_state \
+  Mandatory: cl-nfs_state:promote fs-nfs_state:start</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
 <screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+   </procedure>
+   <para>
+    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/srv/nfs/exportfs</filename>,
+    and <literal>/dev/drbd2</literal> to <filename>/var/lib/nfs</filename>. Confirm this
+    with <command>mount</command>, or by looking at <filename >/proc/mounts</filename>.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-ha-quick-nfs-resources-nffserver-exportfs-vip">
+   <title>Creating NFS supporting resources</title>
+   <para>
+    Finally, create cluster resources for the NFS server daemon, the NFS exports,
+    and the virtual IP address. <emphasis>Do not</emphasis> commit this configuration
+    until after you add the colocation and order constraints.
+   </para>
+   <procedure>
+    <title>Creating supporting resources for NFS</title>
+    <step>
+     <para>
+      Create a primitive to manage the NFS server daemon:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive p-nfsserver nfsserver \
+  params nfs_server_scope=SUSE \
+  op monitor interval=10s timeout=20s \
+  meta target-role=Started</command></screen>
+    </step>
+     <step>
       <para>
-       Pacemaker will export the NFS virtual file system root and the two
-       other exports.
+       Create a primitive for the NFS exports:
       </para>
-     </listitem>
-     <listitem>
+<screen>&prompt.crm.conf;<command>primitive p-nfs_exportfs exportfs \
+  params directory="/srv/nfs/exportfs" \
+  options="rw,mountpoint" clientspec="*" fsid=100 \
+  op monitor interval=30s \
+  meta target-role=Started</command></screen>
+     </step>
+     <step>
       <para>
        Confirm that the NFS exports are set up properly:
       </para>
 <screen>&prompt.root;<command>exportfs -v</command>
-/srv/nfs/work   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
-     </listitem>
-    </orderedlist>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-quick-nfs-resources-vip">
-   <title>Virtual IP address for NFS exports</title>
-   <para>
-    The initial installation creates an administrative virtual IP address for
-    &hawk2;. Although you could use this IP address for your NFS exports too,
-    create another one exclusively for NFS exports. This makes it easier to
-    apply security restrictions later. Use the following commands in the
-    &crmshell;:
-   </para>
-   <screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 \
-   params ip=&nfs-vip-exports; cidr_netmask=24 \
-   op monitor interval=10 timeout=20</command>
-&prompt.crm.conf;<command>modgroup g-nfs add vip_nfs</command>
-&prompt.crm.conf;<command>commit</command></screen>
+/srv/nfs/exportfs   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
+     </step>
+    <step>
+     <para>
+      Create a primitive for the virtual IP address:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 \
+  params ip=&nfs-vip-exports; \
+  op monitor interval=10 timeout=20 \
+  meta target-role=Started</command></screen>
+    </step>
+    <step>
+     <para>
+      Add a colocation constraint to make sure that the NFS server daemon,
+      the NFS exports, and the virtual IP address all start on the same node
+      as the NFS file system resources:
+     </para>
+<screen>&prompt.crm.conf;<command>colocation co-nfs_resources-with-filesystem \
+  inf: vip_nfs p-nfs_exportfs p-nfsserver ( fs-nfs_exportfs fs-nfs_state )</command></screen>
+    </step>
+    <step>
+     <para>
+      Add an order constraint to make sure that the file system resources always start
+      before the NFS server daemon, the NFS exports, and finally the virtual IP address:
+     </para>
+<screen>&prompt.crm.conf;<command>order o-filesystem-before-nfs_resources \
+  Mandatory: ( fs-nfs_exportfs fs-nfs_state ) p-nfsserver p-nfs_exportfs vip_nfs</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit these changes:
+     </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+   </procedure>
   </sect2>
  </sect1>
 

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -92,13 +92,26 @@
  </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-installation">
-  <title>Installing a basic two-node cluster</title>
+  <title>Preparing a two-node cluster for NFS storage</title>
   <para>
-   Before you proceed, install and set up a basic two-node cluster. This task is
-   described in <xref linkend="article-installation"/>. The &haquick; describes
-   how to use the &crmshell; to set up a
-   cluster with minimal effort.
+   Before you can set up highly available NFS storage, you must prepare a &ha; cluster:
   </para>
+  <procedure>
+   <title>Preparing a two-node cluster for NFS storage</title>
+   <step>
+    <para>
+     Install and set up a basic two-node cluster as described in
+     <link xlink:href="&doc-url;/html/SLE-HA-all/article-installation.html">&haquick;</link>.
+<!--trichardson 2023-05-17: using doc-url because this link needs to be version-specific, not generic-->
+    </para>
+   </step>
+   <step>
+    <para>
+     On <emphasis>both</emphasis> nodes, install the package <package>nfs-kernel-server</package>:
+    </para>
+<screen>&prompt.root;<command>zypper install nfs-kernel-server</command></screen>
+   </step>
+  </procedure>
  </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-lvm">
@@ -279,7 +292,7 @@
        following two lines exist:
       </para>
 <screen>include /etc/drbd.conf;
-include /etc/drbd.d/*.res;</screen>
+include /etc/drbd.d;</screen>
       <para>
        If not, add them to the file.
       </para>
@@ -571,10 +584,6 @@ include /etc/drbd.d/*.res;</screen>
    <title>Creating an NFS kernel server resource</title>
    <para>
     Create a cluster resource to manage the NFS server daemon.
-   </para>
-   <para>
-    Make sure the package <package>nfs-kernel-server</package> is installed on
-    both nodes before performing this procedure.
    </para>
    <procedure>
     <title>Creating an NFS kernel server resource</title>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -53,8 +53,8 @@
      Two floating, virtual IP addresses (<systemitem class="ipaddress"
       >&nfs-vip-hawk;</systemitem> and <systemitem class="ipaddress"
       >&nfs-vip-exports;</systemitem>), allowing clients to connect to
-     the service no matter which physical node it is running on.
-     One IP address is used for cluster administration with &hawk2;, the other
+     a service no matter which physical node it is running on.
+     One IP address is used for cluster administration with &hawk2;, and the other
      IP address is used exclusively for the NFS exports.
     </para>
    </listitem>
@@ -104,8 +104,8 @@
  <sect1 xml:id="sec-ha-quick-nfs-lvm">
    <title>Creating LVM devices</title>
    <para>
-    LVM (Logical Volume Manager) enables flexible distribution of hard disk space
-    over several file systems.
+    LVM (Logical Volume Manager) enables flexible distribution of storage space
+    across several file systems.
    </para>
    <para>
     Use <command>crm cluster run</command> to create the LVM devices on both nodes at once.
@@ -180,23 +180,11 @@
    <sect2 xml:id="sec-ha-quick-nfs-drbd-config">
     <title>Creating the DRBD configuration</title>
     <para>
-     For consistency reasons, it is highly recommended to follow this advice:
+     DRBD configuration files are kept in the <filename>/etc/drbd.d/</filename>
+     directory, and must end with a <filename class="extension">.res</filename>
+     extension. In this procedure, the configuration file is named
+     <filename>/etc/drbd.d/nfs.res</filename>.
     </para>
-    <itemizedlist>
-     <listitem>
-      <para>Use the directory <filename>/etc/drbd.d/</filename> for your
-      configuration.</para>
-     </listitem>
-     <listitem>
-      <para>Name the file according to the purpose of the resource.
-      </para>
-     </listitem>
-     <listitem>
-      <para>Put your resource configuration in a file with a
-       <filename class="extension">.res</filename> extension.
-      </para>
-     </listitem>
-    </itemizedlist>
     <procedure>
      <title>Creating a DRBD configuration</title>
      <step>
@@ -252,16 +240,16 @@
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-metadisk">
-        <para>Where the metadata format is stored. Using
+        <para>Where the metadata is stored. Using
          <literal>internal</literal>, the metadata is stored together with
          the user data on the same device. See the man page for further
          information.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-protocol">
-        <para>The specified protocol to be used for this connection. For protocol
-         <literal>C</literal>, a write is considered to be complete when
-         it has reached all disks, be they local or remote.
+        <para>The protocol to use for this connection. Protocol <literal>C</literal>
+         provides better data availability, and does not consider a write to be
+         complete until it has reached all local and remote disks.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-fencing-policy">
@@ -274,9 +262,7 @@
         <para>
          Enables resource-level fencing. If the DRBD replication link
          becomes disconnected, &pace; tries to promote the DRBD resource
-         to another node. During this process, the scripts were called.
-         See <xref linkend="sec-ha-drbd-fencing"/> for more
-         information.
+         to another node. For more information, refer to <xref linkend="sec-ha-drbd-fencing"/>.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-connectionmesh">
@@ -598,6 +584,12 @@ include /etc/drbd.d/*.res;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>primitive p_nfsserver nfsserver \
   params nfs_server_scope=SUSE nfs_shared_infodir="/var/lib/nfs"</command></screen>
+     <para>
+      The <literal>nfs_server_scope</literal> must be the same on all nodes in the
+      cluster that run the NFS server, but this is not set by default. All clusters
+      using &suse; software can use the same scope, so we recommend setting the value
+      to <literal>SUSE</literal>.
+     </para>
      <warning>
       <title>Low lease time can cause loss of file state</title>
       <para>
@@ -641,14 +633,23 @@ include /etc/drbd.d/*.res;</screen>
       </para>
 <screen>&prompt.crm.conf;<command>primitive p_exportfs exportfs \
   params directory="/srv/nfs/share" \
-  options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=101 \
-  op monitor interval=30s timeout=90s</command></screen>
-      <para>
-       The value of <literal>op monitor timeout</literal> must be higher
-       than the value of <literal>stonith-timeout</literal>. To find the
-       <literal>stonith-timeout</literal> value, run <command>crm configure show</command>
-       and look under the <literal>property</literal> section.
-      </para>
+  options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=101 \</command><co xml:id="co-exportfs-fsid"/>
+  <command>op monitor interval=30s timeout=90s</command><co xml:id="co-exportfs-monitor-timeout"/></screen>
+      <calloutlist>
+       <callout arearefs="co-exportfs-fsid">
+        <para>
+         The <literal>fsid</literal> must be unique for each NFS export resource.
+        </para>
+       </callout>
+       <callout arearefs="co-exportfs-monitor-timeout">
+        <para>
+         The value of <literal>op monitor timeout</literal> must be higher
+         than the value of <literal>stonith-timeout</literal>. To find the
+         <literal>stonith-timeout</literal> value, run <command>crm configure show</command>
+         and look under the <literal>property</literal> section.
+        </para>
+       </callout>
+      </calloutlist>
       <important>
        <title>Do not set <literal>wait_for_leasetime_on_stop=true</literal></title>
        <para>
@@ -696,8 +697,7 @@ include /etc/drbd.d/*.res;</screen>
      <para>
       Create a primitive for the virtual IP address:
      </para>
-<screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 \
-  params ip=&nfs-vip-exports;</command></screen>
+<screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 params ip=&nfs-vip-exports;</command></screen>
     </step>
     <step>
      <para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -121,17 +121,17 @@
     </step>
     <step>
       <para>
-       Create a logical volume named <systemitem>exportfs</systemitem> in the
+       Create a logical volume named <systemitem>share</systemitem> in the
        volume group <systemitem>nfs</systemitem>:
       </para>
-      <screen>&prompt.root;<command>lvcreate -n exportfs -L 20G nfs</command></screen>
+      <screen>&prompt.root;<command>lvcreate -n share -L 20G nfs</command></screen>
      </step>
      <step>
       <para>
        Create a second logical volume, named <systemitem>state</systemitem>,
        in the volume group <systemitem>nfs</systemitem>:
       </para>
-      <screen>&prompt.root;<command>lvcreate -n state -L 20G nfs</command></screen>
+      <screen>&prompt.root;<command>lvcreate -n state -L 4G nfs</command></screen>
      </step>
      <step>
       <para>
@@ -141,7 +141,7 @@
    </procedure>
    <para>
     You should now see the following devices on the system:
-    <filename>/dev/nfs/exportfs</filename> and <filename>/dev/nfs/state</filename>.
+    <filename>/dev/nfs/share</filename> and <filename>/dev/nfs/state</filename>.
    </para>
   </sect1>
 
@@ -162,12 +162,13 @@
    </listitem>
   </itemizedlist>
   <para>
-    The following procedures will result in two DRBD devices: one device
-    for the NFS file system, and a second device to share the NFS file states.
+    The following procedures will result in two DRBD devices: one device for the
+    <literal>ext4</literal> file system that will be exported, and a second device
+    to track the NFS client states.
    </para>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-config">
-    <title>Creating DRBD configurations</title>
+    <title>Creating the DRBD configurations</title>
     <para>
      For consistency reasons, it is highly recommended to follow this advice:
     </para>
@@ -190,12 +191,12 @@
      <title>Creating DRBD configurations</title>
      <step>
       <para>
-       Create the file <filename>/etc/drbd.d/nfs-exportfs.res</filename> with the
+       Create the file <filename>/etc/drbd.d/nfs-share.res</filename> with the
         following contents:
       </para>
-<screen>resource nfs-exportfs {
+<screen>resource nfs-share {
    device /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
-   disk   /dev/nfs/exportfs; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
+   disk   /dev/nfs/share; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
    meta-disk internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
 
    net {
@@ -270,7 +271,7 @@
      <step>
       <para>
        Create the file <filename>/etc/drbd.d/nfs-state.res</filename> with the
-       same contents as <filename>/etc/drbd.d/nfs-exportfs.res</filename>, but
+       same contents as <filename>/etc/drbd.d/nfs-share.res</filename>, but
        change the following lines:
       </para>
 <screen>resource nfs_<emphasis role="bold">state</emphasis> {
@@ -319,7 +320,7 @@ include /etc/drbd.d/*.res;</screen>
        Initialize the metadata storage. Run these commands on
        <emphasis>both</emphasis> nodes:
       </para>
-<screen>&prompt.root;<command>drbdadm create-md nfs-exportfs</command>
+<screen>&prompt.root;<command>drbdadm create-md nfs-share</command>
 &prompt.root;<command>drbdadm create-md nfs-state</command></screen>
      </step>
      <step>
@@ -327,7 +328,7 @@ include /etc/drbd.d/*.res;</screen>
        Create the DRBD devices. Run these commands on
        <emphasis>both</emphasis> nodes:
       </para>
-<screen>&prompt.root;<command>drbdadm up nfs-exportfs</command>
+<screen>&prompt.root;<command>drbdadm up nfs-share</command>
 &prompt.root;<command>drbdadm up nfs-state</command></screen>
      </step>
      <step>
@@ -335,19 +336,19 @@ include /etc/drbd.d/*.res;</screen>
        The devices do not have data yet, so
        you can run these commands to skip the initial synchronization:
       </para>
-<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-exportfs/1</command>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-share/1</command>
 &prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-state/2</command></screen>
      </step>
      <step>
        <para>Make <systemitem>&node1;</systemitem> primary:</para>
-<screen>&prompt.root;<command>drbdadm primary --force nfs-exportfs</command>
+<screen>&prompt.root;<command>drbdadm primary --force nfs-share</command>
 &prompt.root;<command>drbdadm primary --force nfs-state</command></screen>
      </step>
       <step>
-       <para>Check the DRBD status of <literal>nfs-exportfs</literal>:</para>
-<screen>&prompt.root;<command>drbdadm status nfs-exportfs</command></screen>
+       <para>Check the DRBD status of <literal>nfs-share</literal>:</para>
+<screen>&prompt.root;<command>drbdadm status nfs-share</command></screen>
        <para>This returns the following message:</para>
-<screen>nfs-exportfs role:Primary
+<screen>nfs-share role:Primary
   disk:UpToDate
   &node1; role:Secondary
     peer-disk:UpToDate</screen>
@@ -363,33 +364,42 @@ include /etc/drbd.d/*.res;</screen>
    </sect2>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-createfs">
-    <title>Creating the file system</title>
+    <title>Creating the file systems</title>
     <para>
-     After activating the DRBD devices, create the NFS file system on
-     <filename>/dev/drbd1</filename>:
+     After activating the DRBD devices, create file systems on them:
+
     </para>
-    <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
+    <procedure>
+     <title>Creating file systems for DRBD</title>
+     <step>
+      <para>
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd1</filename>:
+      </para>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
+     </step>
+     <step>
+      <para>
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd2</filename>:
+      </para>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
+     </step>
+    </procedure>
+    <warning>
+     <title>Low lease time can cause loss of file state</title>
+     <para>
+      NFS clients regularly renew their state with the NFS server. If the lease time
+      is too low, operating system or network delays can cause the timer to expire
+      before the renewal is complete, leading to loss of file state and I/O errors.
+     </para>
+     <para>
+      <literal>NFSV4LEASETIME</literal> is set on the NFS server in the file
+      <filename>/etc/sysconfig/nfs</filename>. The default is 90 seconds.
+      If lowering the lease time is necessary, we recommend a value of 60 or
+      higher. We strongly discourage values lower than 30.
+     </para>
+    </warning>
    </sect2>
   </sect1>
-
- <sect1 xml:id="sec-ha-quick-nfs-initial-pacemaker">
-  <title>Adjusting Pacemaker's configuration</title>
-  &failback-nodes;
-  <para>
-    To adjust the option, open the &crmshell; as &rootuser; (or any
-    non-&rootuser; user that is part of the
-    <systemitem class="groupname">haclient</systemitem> group) and run the
-    following commands:
-   </para>
-   <screen>&prompt.root;<command>crm configure</command>
-&prompt.crm.conf;<command>rsc_defaults resource-stickiness="200"</command>
-&prompt.crm.conf;<command>commit</command></screen>
-
-   <para>
-    For more information about global cluster options, refer to
-    <xref linkend="sec-ha-config-basics-global-options"/>.
-   </para>
- </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-resources">
   <title>Creating cluster resources</title>
@@ -413,7 +423,8 @@ include /etc/drbd.d/*.res;</screen>
     <term>File system resources</term>
     <listitem>
      <para>
-      These resources manage the NFS file system and file states.
+      These resources manage the file system that will be exported, and the
+      file system that will track NFS client states.
      </para>
     </listitem>
    </varlistentry>
@@ -429,7 +440,7 @@ include /etc/drbd.d/*.res;</screen>
     <term>NFS exports</term>
     <listitem>
      <para>
-      This resource is used to export the directory <filename>/srv/nfs/exportfs</filename>
+      This resource is used to export the directory <filename>/srv/nfs/share</filename>
       to clients.
      </para>
     </listitem>
@@ -455,20 +466,20 @@ include /etc/drbd.d/*.res;</screen>
     </listitem>
     <listitem>
         <para>The service exports data served from
-         <literal>/srv/nfs/exportfs</literal>. </para>
+         <literal>/srv/nfs/share</literal>. </para>
     </listitem>
     <listitem>
-        <para>Into this export directory, the cluster mounts
-            <literal>ext4</literal> file systems from the DRBD device
+        <para>Into this export directory, the cluster mounts an
+            <literal>ext4</literal> file system from the DRBD device
          <filename>/dev/drbd1</filename>.
          This DRBD device sits on top of an LVM logical volume named
-         <literal>/dev/nfs/exportfs</literal>.
+         <literal>/dev/nfs/share</literal>.
         </para>
     </listitem>
     <listitem>
      <para>
       A second DRBD device, <literal>/dev/drbd2</literal>, is used to share the
-      NFS file states from <filename>/var/lib/nfs</filename>. This DRBD device
+      NFS client states from <filename>/var/lib/nfs</filename>. This DRBD device
       sits on top of an LVM logical volume named <literal>/dev/nfs/state</literal>.
      </para>
     </listitem>
@@ -490,10 +501,10 @@ include /etc/drbd.d/*.res;</screen>
     </step>
     <step>
      <para>
-      Create a primitive for the DRBD device <literal>nfs-exportfs</literal>:
+      Create a primitive for the DRBD device <literal>nfs-share</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive drbd_nfs-exportfs ocf:linbit:drbd \
-  params drbd_resource="nfs-exportfs" \
+<screen>&prompt.crm.conf;<command>primitive drbd_nfs-share ocf:linbit:drbd \
+  params drbd_resource="nfs-share" \
   op monitor interval="15" role="Promoted" \
   op monitor interval="30" role="Unpromoted"</command></screen>
     </step>
@@ -508,10 +519,10 @@ include /etc/drbd.d/*.res;</screen>
     </step>
     <step>
      <para>
-      Create a promotable clone for the <literal>drbd_nfs-exportfs</literal>
+      Create a promotable clone for the <literal>drbd_nfs-share</literal>
       primitive:
      </para>
-<screen>&prompt.crm.conf;<command>clone cl_nfs-exportfs drbd_nfs-exportfs \
+<screen>&prompt.crm.conf;<command>clone cl_nfs-share drbd_nfs-share \
   meta promotable="true" promoted-max="1" promoted-node-max="1" \
   clone-max="2" clone-node-max="1" notify="true"</command></screen>
     </step>
@@ -540,27 +551,26 @@ include /etc/drbd.d/*.res;</screen>
   </sect2>
 
   <sect2 xml:id="sec-ha-quick-nfs-resources-lvm">
-   <title>Creating NFS file system resources</title>
+   <title>Creating file system resources</title>
    <para>
-    Next, create cluster resources to manage the NFS file system and file states.
-    <emphasis>Do not</emphasis> commit this configuration until after you add
-    the colocation and order constraints.
+    Next, create cluster resources to manage the file systems for export and
+    state tracking. <emphasis>Do not</emphasis> commit this configuration until
+    after you add the colocation and order constraints.
    </para>
    <procedure>
     <title>Creating file system resources for NFS</title>
     <step>
      <para>
-      Create a file system type resource for the NFS file system on
+      Create a primitive for the file system to be exported on
       <literal>/dev/drbd1</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive fs_nfs-exportfs Filesystem \
-  params device=/dev/drbd1 directory=/srv/nfs/exportfs fstype=ext4 \
+<screen>&prompt.crm.conf;<command>primitive fs_nfs-share Filesystem \
+  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4 \
   op monitor interval="30s"</command></screen>
     </step>
     <step>
      <para>
-      Create a file system type resource for the NFS file states on
-      <literal>/dev/drbd2</literal>:
+      Create a primitive for the NFS client states on <literal>/dev/drbd2</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-state Filesystem \
   params device=/dev/drbd2 directory=/var/lib/nfs fstype=ext4 \
@@ -571,16 +581,16 @@ include /etc/drbd.d/*.res;</screen>
       Add a colocation constraint to make sure that the two resources
       always start on the same node:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co_nfs-exportfs-with-nfs-state \
-  inf: fs_nfs-exportfs fs_nfs-state</command></screen>
+<screen>&prompt.crm.conf;<command>colocation co_nfs-share-with-nfs-state \
+  inf: fs_nfs-share fs_nfs-state</command></screen>
     </step>
     <step>
      <para>
       Add colocation constraints to make sure that each resource always starts
       on the node where the related DRBD promotable clone is in the primary role:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co_nfs-exportfs-on-drbd \
-  inf: fs_nfs-exportfs cl_nfs-exportfs:Promoted</command>
+<screen>&prompt.crm.conf;<command>colocation co_nfs-share-on-drbd \
+  inf: fs_nfs-share cl_nfs-share:Promoted</command>
 &prompt.crm.conf;<command>colocation co_nfs-state-on-drbd \
   inf: fs_nfs-state cl_nfs-state:Promoted</command></screen>
     </step>
@@ -589,8 +599,8 @@ include /etc/drbd.d/*.res;</screen>
       Add order constraints to make sure the DRBD promotable clones always start
       before the file system resources:
      </para>
-<screen>&prompt.crm.conf;<command>order o_drbd-before-nfs-exportfs \
-  Mandatory: cl_nfs-exportfs:promote fs_nfs-exportfs:start</command>
+<screen>&prompt.crm.conf;<command>order o_drbd-before-nfs-share \
+  Mandatory: cl_nfs-share:promote fs_nfs-share:start</command>
 &prompt.crm.conf;<command>order o_drbd-before-nfs-state \
   Mandatory: cl_nfs-state:promote fs_nfs-state:start</command></screen>
     </step>
@@ -602,7 +612,7 @@ include /etc/drbd.d/*.res;</screen>
     </step>
    </procedure>
    <para>
-    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/srv/nfs/exportfs</filename>,
+    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/srv/nfs/share</filename>,
     and <literal>/dev/drbd2</literal> to <filename>/var/lib/nfs</filename>. Confirm this
     with <command>mount</command>, or by looking at <filename >/proc/mounts</filename>.
    </para>
@@ -623,25 +633,36 @@ include /etc/drbd.d/*.res;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>primitive p_nfsserver nfsserver \
   params nfs_server_scope=SUSE \
-  op monitor interval=10s timeout=20s \
-  meta target-role=Started</command></screen>
+  op monitor interval=10s timeout=20s</command></screen>
     </step>
      <step>
       <para>
        Create a primitive for the NFS exports:
       </para>
 <screen>&prompt.crm.conf;<command>primitive p_exportfs exportfs \
-  params directory="/srv/nfs/exportfs" \
+  params directory="/srv/nfs/share" \
   options="rw,mountpoint" clientspec="*" fsid=100 \
-  op monitor interval=30s \
-  meta target-role=Started</command></screen>
+  op monitor interval=30s</command></screen>
+      <important>
+       <title>Do not set <literal>wait_for_leasetime_on_stop=true</literal></title>
+       <para>
+        Setting this option to <literal>true</literal>
+        in a highly available NFS setup can cause unnecessary delays and loss of locks.
+       </para>
+       <para>
+        The default value for <literal>wait_for_leasetime_on_stop</literal> is
+        <literal>false</literal>. There is no need to set it to <literal>true</literal>
+        when <filename>/var/lib/nfs</filename> and <literal>p_nfsserver</literal>
+        are configured as described in this guide.
+       </para>
+      </important>
      </step>
      <step>
       <para>
        Confirm that the NFS exports are set up properly:
       </para>
 <screen>&prompt.root;<command>exportfs -v</command>
-/srv/nfs/exportfs   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
+/srv/nfs/share   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
      </step>
     <step>
      <para>
@@ -649,17 +670,16 @@ include /etc/drbd.d/*.res;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 \
   params ip=&nfs-vip-exports; \
-  op monitor interval=10 timeout=20 \
-  meta target-role=Started</command></screen>
+  op monitor interval=10 timeout=20</command></screen>
     </step>
     <step>
      <para>
       Add a colocation constraint to make sure that the NFS server daemon,
       the NFS exports, and the virtual IP address all start on the same node
-      as the NFS file system resources:
+      as the file system resources:
      </para>
 <screen>&prompt.crm.conf;<command>colocation co_nfs-resources-with-filesystem \
-  inf: vip_nfs p_exportfs p_nfsserver ( fs_nfs-exportfs fs_nfs-state )</command></screen>
+  inf: vip_nfs p_exportfs p_nfsserver ( fs_nfs-share fs_nfs-state )</command></screen>
     </step>
     <step>
      <para>
@@ -667,7 +687,7 @@ include /etc/drbd.d/*.res;</screen>
       before the NFS server daemon, the NFS exports, and finally the virtual IP address:
      </para>
 <screen>&prompt.crm.conf;<command>order o_filesystem-before-nfs-resources \
-  Mandatory: ( fs_nfs-exportfs fs_nfs-state ) p_nfsserver p_exportfs vip_nfs</command></screen>
+  Mandatory: ( fs_nfs-share fs_nfs-state ) p_nfsserver p_exportfs vip_nfs</command></screen>
     </step>
     <step>
      <para>
@@ -691,38 +711,32 @@ include /etc/drbd.d/*.res;</screen>
    configured on one of the cluster nodes' network interfaces. For compatibility
    reasons, use the <emphasis>full</emphasis> path of the NFS export on the server.
   </para>
-
-  <para>In its simplest form, the command to mount the NFS export looks like
-   this:</para>
-  <screen>&prompt.root;<command>mount -t nfs &nfs-vip-exports;:/srv/nfs/exportfs /home/exportfs</command></screen>
   <para>
-   To configure a specific transport protocol (<option>proto</option>)
-   and maximum read and write request sizes (<option>rsize</option> and
-    <option>wsize</option>), use:
+   The command to mount the NFS export looks like this:
   </para>
-  <screen>&prompt.root;<command>mount -o rsize=32768,wsize=32768 \
-    &nfs-vip-exports;:/srv/nfs/exportfs /home/exportfs</command></screen>
+<screen>&prompt.root;<command>mount &nfs-vip-exports;:/srv/nfs/share /home/share</command></screen>
   <para>
-   If you need to be compatible with NFS version&nbsp;3, include the value
-   <option>vers=3</option> after the <option>-o</option> option.
+   If you need to configure other mount options, such as a specific transport protocol
+   (<option>proto</option>), maximum read and write request sizes (<option>rsize</option>
+   and <option>wsize</option>), or a specific NFS version (<option>vers</option>),
+   use the <option>-o</option> option.
   </para>
+  <para>
+   For example:
+  </para>
+<screen>&prompt.root;<command>mount -o proto=tcp,rsize=32768,wsize=32768,vers=3 \
+&nfs-vip-exports;:/srv/nfs/share /home/share</command></screen>
   <para>
    For further NFS mount options, refer to the <command>nfs</command> man page.
   </para>
-  <warning>
-   <title>Low lease time can cause loss of file state</title>
+  <note>
+   <title>Loopback mounts</title>
    <para>
-    NFS clients regularly renew their state with the NFS server. If the lease time
-    is too low, operating system or network delays can cause the timer to expire
-    before the renewal is complete, leading to loss of file state and I/O errors.
+    Loopback mounts are only supported for NFS version 3, <emphasis>not</emphasis>
+    NFS version 4. For more information, refer to
+    <link xlink:href="https://www.suse.com/support/kb/doc/?id=000018709"/>.
    </para>
-   <para>
-    <literal>NFSV4LEASETIME</literal> is set on the NFS server in the file
-    <filename>/etc/sysconfig/nfs</filename>. The default is 90 seconds.
-    If lowering the lease time is necessary, we recommend a value of 60 or
-    higher. We strongly discourage values lower than 30.
-   </para>
-  </warning>
+  </note>
  </sect1>
  <sect1 xml:id="sec-ha-quick-nfs-more-info">
   <title>For more information</title>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -190,10 +190,10 @@
      <title>Creating DRBD configurations</title>
      <step>
       <para>
-       Create the file <filename>/etc/drbd.d/nfs_exportfs.res</filename> with the
+       Create the file <filename>/etc/drbd.d/nfs-exportfs.res</filename> with the
         following contents:
       </para>
-<screen>resource nfs_exportfs {
+<screen>resource nfs-exportfs {
    device /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
    disk   /dev/nfs/exportfs; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
    meta-disk internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
@@ -269,8 +269,8 @@
      </step>
      <step>
       <para>
-       Create the file <filename>/etc/drbd.d/nfs_state.res</filename> with the
-       same contents as <filename>/etc/drbd.d/nfs_exportfs.res</filename>, but
+       Create the file <filename>/etc/drbd.d/nfs-state.res</filename> with the
+       same contents as <filename>/etc/drbd.d/nfs-exportfs.res</filename>, but
        change the following lines:
       </para>
 <screen>resource nfs_<emphasis role="bold">state</emphasis> {
@@ -315,49 +315,50 @@ include /etc/drbd.d/*.res;</screen>
       </para>
      </step>
      <step>
-      <para>The first time you do this, execute the following
-        commands on <emphasis>both</emphasis> nodes (in our example, <systemitem>&node1;</systemitem>
-        and <systemitem>&node2;</systemitem>):
-      </para>
-<screen>&prompt.root;<command>drbdadm create-md nfs_exportfs</command>
-&prompt.root;<command>drbdadm up nfs_exportfs</command></screen>
       <para>
-       This initializes the metadata storage and creates the DRBD device.
+       Initialize the metadata storage. Run these commands on
+       <emphasis>both</emphasis> nodes:
       </para>
+<screen>&prompt.root;<command>drbdadm create-md nfs-exportfs</command>
+&prompt.root;<command>drbdadm create-md nfs-state</command></screen>
      </step>
      <step>
       <para>
-       If the DRBD devices on all nodes have the same data, skip
-       the initial resynchronization. Use the following command:
+       Create the DRBD devices. Run these commands on
+       <emphasis>both</emphasis> nodes:
       </para>
-      <screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs_exportfs/0</command></screen>
+<screen>&prompt.root;<command>drbdadm up nfs-exportfs</command>
+&prompt.root;<command>drbdadm up nfs-state</command></screen>
+     </step>
+     <step>
+      <para>
+       The devices do not have data yet, so
+       you can run these commands to skip the initial synchronization:
+      </para>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-exportfs/1</command>
+&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-state/2</command></screen>
      </step>
      <step>
        <para>Make <systemitem>&node1;</systemitem> primary:</para>
-       <screen>&prompt.root;<command>drbdadm primary --force nfs_exportfs</command></screen>
+<screen>&prompt.root;<command>drbdadm primary --force nfs-exportfs</command>
+&prompt.root;<command>drbdadm primary --force nfs-state</command></screen>
      </step>
       <step>
-       <para>Check the DRBD status:</para>
-       <screen>&prompt.root;<command>drbdadm status nfs_exportfs</command></screen>
+       <para>Check the DRBD status of <literal>nfs-exportfs</literal>:</para>
+<screen>&prompt.root;<command>drbdadm status nfs-exportfs</command></screen>
        <para>This returns the following message:</para>
-          <screen>nfs_exportfs role:Primary
+<screen>nfs-exportfs role:Primary
   disk:UpToDate
   &node1; role:Secondary
     peer-disk:UpToDate</screen>
-     </step>
-     <step>
-      <para>
-       Repeat these steps for the <literal>nfs_state</literal> configuration.
-      </para>
+     <para>
+      Checking the status of <literal>nfs-state</literal> should return the same message.
+     </para>
      </step>
     </procedure>
     <para>
      You can access the DRBD resources on the block devices
      <filename>/dev/drbd1</filename> and <filename>/dev/drbd2</filename>.
-
-     </para>
-     <para>
-      For more information about DRBD, refer to <xref linkend="cha-ha-drbd"/>.
      </para>
    </sect2>
 
@@ -428,8 +429,8 @@ include /etc/drbd.d/*.res;</screen>
     <term>NFS exports</term>
     <listitem>
      <para>
-      This resource is used to export the <filename>/srv/nfs/exportfs</filename>
-      directory to clients.
+      This resource is used to export the directory <filename>/srv/nfs/exportfs</filename>
+      to clients.
      </para>
     </listitem>
    </varlistentry>
@@ -489,37 +490,37 @@ include /etc/drbd.d/*.res;</screen>
     </step>
     <step>
      <para>
-      Create a primitive for the DRBD resource <literal>nfs_exportfs</literal>:
+      Create a primitive for the DRBD device <literal>nfs-exportfs</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive drbd-nfs_exportfs ocf:linbit:drbd \
-  params drbd_resource="nfs_exportfs" \
+<screen>&prompt.crm.conf;<command>primitive drbd_nfs-exportfs ocf:linbit:drbd \
+  params drbd_resource="nfs-exportfs" \
   op monitor interval="15" role="Promoted" \
   op monitor interval="30" role="Unpromoted"</command></screen>
     </step>
     <step>
      <para>
-      Create a primitive for the DRBD resource <literal>nfs_state</literal>:
+      Create a primitive for the DRBD device <literal>nfs-state</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive drbd-nfs_state ocf:linbit:drbd \
-  params drbd_resource="nfs_state" \
+<screen>&prompt.crm.conf;<command>primitive drbd_nfs-state ocf:linbit:drbd \
+  params drbd_resource="nfs-state" \
   op monitor interval="15" role="Promoted" \
   op monitor interval="30" role="Unpromoted"</command></screen>
     </step>
     <step>
      <para>
-      Create a promotable clone for the <literal>drbd-nfs_exportfs</literal>
+      Create a promotable clone for the <literal>drbd_nfs-exportfs</literal>
       primitive:
      </para>
-<screen>&prompt.crm.conf;<command>clone cl-nfs_exportfs drbd-nfs_exportfs \
+<screen>&prompt.crm.conf;<command>clone cl_nfs-exportfs drbd_nfs-exportfs \
   meta promotable="true" promoted-max="1" promoted-node-max="1" \
   clone-max="2" clone-node-max="1" notify="true"</command></screen>
     </step>
     <step>
      <para>
-      Create a promotable clone for the <literal>drbd-nfs_state</literal>
+      Create a promotable clone for the <literal>drbd_nfs-state</literal>
       primitive:
      </para>
-<screen>&prompt.crm.conf;<command>clone cl-nfs_state drbd-nfs_state \
+<screen>&prompt.crm.conf;<command>clone cl_nfs-state drbd_nfs-state \
   meta promotable="true" promoted-max="1" promoted-node-max="1" \
   clone-max="2" clone-node-max="1" notify="true"</command></screen>
     </step>
@@ -552,7 +553,7 @@ include /etc/drbd.d/*.res;</screen>
       Create a file system type resource for the NFS file system on
       <literal>/dev/drbd1</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive fs-nfs_exportfs Filesystem \
+<screen>&prompt.crm.conf;<command>primitive fs_nfs-exportfs Filesystem \
   params device=/dev/drbd1 directory=/srv/nfs/exportfs fstype=ext4 \
   op monitor interval="30s"</command></screen>
     </step>
@@ -561,7 +562,7 @@ include /etc/drbd.d/*.res;</screen>
       Create a file system type resource for the NFS file states on
       <literal>/dev/drbd2</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive fs-nfs_state Filesystem \
+<screen>&prompt.crm.conf;<command>primitive fs_nfs-state Filesystem \
   params device=/dev/drbd2 directory=/var/lib/nfs fstype=ext4 \
   op monitor interval="30s"</command></screen>
     </step>
@@ -570,28 +571,28 @@ include /etc/drbd.d/*.res;</screen>
       Add a colocation constraint to make sure that the two resources
       always start on the same node:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co-nfs_exportfs-with-nfs_state \
-  inf: fs-nfs_exportfs fs-nfs_state</command></screen>
+<screen>&prompt.crm.conf;<command>colocation co_nfs-exportfs-with-nfs-state \
+  inf: fs_nfs-exportfs fs_nfs-state</command></screen>
     </step>
     <step>
      <para>
       Add colocation constraints to make sure that each resource always starts
       on the node where the related DRBD promotable clone is in the primary role:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co-nfs_exportfs-on-drbd \
-  inf: fs-nfs_exportfs cl-nfs_exportfs:Promoted</command>
-&prompt.crm.conf;<command>colocation co-nfs_state-on-drbd \
-  inf: fs-nfs_state cl-nfs_state:Promoted</command></screen>
+<screen>&prompt.crm.conf;<command>colocation co_nfs-exportfs-on-drbd \
+  inf: fs_nfs-exportfs cl_nfs-exportfs:Promoted</command>
+&prompt.crm.conf;<command>colocation co_nfs-state-on-drbd \
+  inf: fs_nfs-state cl_nfs-state:Promoted</command></screen>
     </step>
     <step>
      <para>
       Add order constraints to make sure the DRBD promotable clones always start
       before the file system resources:
      </para>
-<screen>&prompt.crm.conf;<command>order o-drbd-before-nfs_exportfs \
-  Mandatory: cl-nfs_exportfs:promote fs-nfs_exportfs:start</command>
-&prompt.crm.conf;<command>order o-drbd-before-nfs_state \
-  Mandatory: cl-nfs_state:promote fs-nfs_state:start</command></screen>
+<screen>&prompt.crm.conf;<command>order o_drbd-before-nfs-exportfs \
+  Mandatory: cl_nfs-exportfs:promote fs_nfs-exportfs:start</command>
+&prompt.crm.conf;<command>order o_drbd-before-nfs-state \
+  Mandatory: cl_nfs-state:promote fs_nfs-state:start</command></screen>
     </step>
     <step>
      <para>
@@ -620,7 +621,7 @@ include /etc/drbd.d/*.res;</screen>
      <para>
       Create a primitive to manage the NFS server daemon:
      </para>
-<screen>&prompt.crm.conf;<command>primitive p-nfsserver nfsserver \
+<screen>&prompt.crm.conf;<command>primitive p_nfsserver nfsserver \
   params nfs_server_scope=SUSE \
   op monitor interval=10s timeout=20s \
   meta target-role=Started</command></screen>
@@ -629,7 +630,7 @@ include /etc/drbd.d/*.res;</screen>
       <para>
        Create a primitive for the NFS exports:
       </para>
-<screen>&prompt.crm.conf;<command>primitive p-nfs_exportfs exportfs \
+<screen>&prompt.crm.conf;<command>primitive p_exportfs exportfs \
   params directory="/srv/nfs/exportfs" \
   options="rw,mountpoint" clientspec="*" fsid=100 \
   op monitor interval=30s \
@@ -657,20 +658,20 @@ include /etc/drbd.d/*.res;</screen>
       the NFS exports, and the virtual IP address all start on the same node
       as the NFS file system resources:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co-nfs_resources-with-filesystem \
-  inf: vip_nfs p-nfs_exportfs p-nfsserver ( fs-nfs_exportfs fs-nfs_state )</command></screen>
+<screen>&prompt.crm.conf;<command>colocation co_nfs-resources-with-filesystem \
+  inf: vip_nfs p_exportfs p_nfsserver ( fs_nfs-exportfs fs_nfs-state )</command></screen>
     </step>
     <step>
      <para>
       Add an order constraint to make sure that the file system resources always start
       before the NFS server daemon, the NFS exports, and finally the virtual IP address:
      </para>
-<screen>&prompt.crm.conf;<command>order o-filesystem-before-nfs_resources \
-  Mandatory: ( fs-nfs_exportfs fs-nfs_state ) p-nfsserver p-nfs_exportfs vip_nfs</command></screen>
+<screen>&prompt.crm.conf;<command>order o_filesystem-before-nfs-resources \
+  Mandatory: ( fs_nfs-exportfs fs_nfs-state ) p_nfsserver p_exportfs vip_nfs</command></screen>
     </step>
     <step>
      <para>
-      Commit these changes:
+      Commit this configuration:
      </para>
 <screen>&prompt.crm.conf;<command>commit</command></screen>
     </step>
@@ -693,21 +694,58 @@ include /etc/drbd.d/*.res;</screen>
 
   <para>In its simplest form, the command to mount the NFS export looks like
    this:</para>
-  <screen>&prompt.root;<command>mount -t nfs &nfs-vip-exports;:/srv/nfs/work /home/work</command></screen>
+  <screen>&prompt.root;<command>mount -t nfs &nfs-vip-exports;:/srv/nfs/exportfs /home/exportfs</command></screen>
   <para>
    To configure a specific transport protocol (<option>proto</option>)
    and maximum read and write request sizes (<option>rsize</option> and
     <option>wsize</option>), use:
   </para>
   <screen>&prompt.root;<command>mount -o rsize=32768,wsize=32768 \
-    &nfs-vip-exports;:/srv/nfs/work /home/work</command></screen>
+    &nfs-vip-exports;:/srv/nfs/exportfs /home/exportfs</command></screen>
   <para>
    If you need to be compatible with NFS version&nbsp;3, include the value
    <option>vers=3</option> after the <option>-o</option> option.
   </para>
   <para>
-   For further NFS mount options, consult the <command>nfs</command> man page.
+   For further NFS mount options, refer to the <command>nfs</command> man page.
   </para>
+  <warning>
+   <title>Low lease time can cause loss of file state</title>
+   <para>
+    NFS clients regularly renew their state with the NFS server. If the lease time
+    is too low, operating system or network delays can cause the timer to expire
+    before the renewal is complete, leading to loss of file state and I/O errors.
+   </para>
+   <para>
+    <literal>NFSV4LEASETIME</literal> is set on the NFS server in the file
+    <filename>/etc/sysconfig/nfs</filename>. The default is 90 seconds.
+    If lowering the lease time is necessary, we recommend a value of 60 or
+    higher. We strongly discourage values lower than 30.
+   </para>
+  </warning>
+ </sect1>
+ <sect1 xml:id="sec-ha-quick-nfs-more-info">
+  <title>For more information</title>
+  <itemizedlist>
+   <listitem>
+    <para>
+     For more details about the steps in this guide, refer to
+     <link xlink:href="https://www.suse.com/support/kb/doc/?id=000020396"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     For more information about NFS and LVM, refer to
+     <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
+     &storage_guide; for &sles;</link>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     For more information about DRBD, refer to <xref linkend="cha-ha-drbd"/>.
+    </para>
+   </listitem>
+  </itemizedlist>
  </sect1>
  <xi:include href="common_legal.xml"/>
  </article>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -78,7 +78,8 @@
    </listitem>
    <listitem>
     <para>
-      A file system exported through NFS.
+      A file system exported through NFS, and a separate file system used to track
+      the NFS client states.
     </para>
    </listitem>
   </itemizedlist>
@@ -102,9 +103,9 @@
 
  <sect1 xml:id="sec-ha-quick-nfs-lvm">
    <title>Creating LVM devices</title>
-   <para>LVM (<emphasis>Logical Volume Manager</emphasis>) enables
-    flexible distribution of hard disk space over several file
-    systems.
+   <para>
+    LVM (Logical Volume Manager) enables flexible distribution of hard disk space
+    over several file systems.
    </para>
    <para>
     Use <command>crm cluster run</command> to create the LVM devices on both nodes at once.
@@ -113,7 +114,7 @@
     <title>Creating LVM devices for DRBD</title>
     <step>
      <para>
-      Create an LVM physical volume and replace <filename>/dev/sdb1</filename>
+      Create an LVM physical volume, replacing <filename>/dev/sdb1</filename>
       with your corresponding device for LVM:</para>
      <screen>&prompt.root;<command>crm cluster run "pvcreate /dev/sdb1"</command></screen>
     </step>
@@ -128,13 +129,20 @@
        volume group <systemitem>nfs</systemitem>:
       </para>
       <screen>&prompt.root;<command>crm cluster run "lvcreate -n share -L 20G nfs"</command></screen>
+      <para>
+       This volume will be used for the NFS exports.
+      </para>
      </step>
      <step>
       <para>
-       Create a second logical volume, named <systemitem>state</systemitem>,
-       in the volume group <systemitem>nfs</systemitem>:
+       Create a logical volume named <systemitem>state</systemitem> in the
+       volume group <systemitem>nfs</systemitem>:
       </para>
-      <screen>&prompt.root;<command>crm cluster run "lvcreate -n state -L 4G nfs"</command></screen>
+      <screen>&prompt.root;<command>crm cluster run "lvcreate -n state -L 8G nfs"</command></screen>
+      <para>
+       This volume will be used for the NFS client states. The 8 GB volume size
+       used in this example should support several thousand concurrent NFS clients.
+      </para>
      </step>
      <step>
       <para>
@@ -166,8 +174,7 @@
   </itemizedlist>
   <para>
     The following procedures will result in two DRBD devices: one device for the
-    <literal>ext4</literal> file system that will be exported, and a second device
-    to track the NFS client states.
+    NFS exports, and a second device to track the NFS client states.
    </para>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-config">
@@ -199,12 +206,12 @@
       </para>
 <screen>resource nfs {
    volume 0 { <co xml:id="co-ha-quick-nfs-drbd-volume"/>
-      device           /dev/drbd0 minor 0; <co xml:id="co-ha-quick-nfs-drbd-device"/>
+      device           /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
       disk             /dev/nfs/state; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
       meta-disk        internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
    }
    volume 1 {
-      device           /dev/drbd1 minor 1;
+      device           /dev/drbd2 minor 2;
       disk             /dev/nfs/share;
       meta-disk        internal;
    }
@@ -355,7 +362,7 @@ include /etc/drbd.d/*.res;</screen>
     </procedure>
     <para>
      You can access the DRBD resources on the block devices
-     <filename>/dev/drbd0</filename> and <filename>/dev/drbd1</filename>.
+     <filename>/dev/drbd1</filename> and <filename>/dev/drbd2</filename>.
      </para>
    </sect2>
 
@@ -369,15 +376,15 @@ include /etc/drbd.d/*.res;</screen>
      <title>Creating file systems for DRBD</title>
      <step>
       <para>
-       Create an <literal>ext4</literal> file system on <filename>/dev/drbd0</filename>:
-      </para>
-      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd0</command></screen>
-     </step>
-     <step>
-      <para>
        Create an <literal>ext4</literal> file system on <filename>/dev/drbd1</filename>:
       </para>
       <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
+     </step>
+     <step>
+      <para>
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd2</filename>:
+      </para>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
      </step>
     </procedure>
    </sect2>
@@ -453,14 +460,14 @@ include /etc/drbd.d/*.res;</screen>
     <listitem>
         <para>Into this export directory, the cluster mounts an
             <literal>ext4</literal> file system from the DRBD device
-         <filename>/dev/drbd1</filename>.
+         <filename>/dev/drbd2</filename>.
          This DRBD device sits on top of an LVM logical volume named
          <literal>/dev/nfs/share</literal>.
         </para>
     </listitem>
     <listitem>
      <para>
-      The DRBD device <literal>/dev/drbd0</literal> is used to share the
+      The DRBD device <literal>/dev/drbd1</literal> is used to share the
       NFS client states from <filename>/var/lib/nfs</filename>. This DRBD device
       sits on top of an LVM logical volume named <literal>/dev/nfs/state</literal>.
      </para>
@@ -531,7 +538,7 @@ include /etc/drbd.d/*.res;</screen>
       Create a primitive for the NFS client states on <literal>/dev/drbd1</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-state Filesystem \
-  params device=/dev/drbd0 directory=/var/lib/nfs fstype=ext4 \
+  params device=/dev/drbd1 directory=/var/lib/nfs fstype=ext4 \
   op monitor interval=30s timeout=40s \
   op start timeout=60s interval=0s \
   op stop timeout=60s interval=0s</command></screen>
@@ -542,7 +549,7 @@ include /etc/drbd.d/*.res;</screen>
       <literal>/dev/drbd2</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-share Filesystem \
-  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4 \
+  params device=/dev/drbd2 directory=/srv/nfs/share fstype=ext4 \
   op monitor interval=30s timeout=40s \
   op start timeout=60s interval=0s \
   op stop timeout=60s interval=0s</command></screen>
@@ -578,8 +585,8 @@ include /etc/drbd.d/*.res;</screen>
     </step>
    </procedure>
    <para>
-    Pacemaker mounts <literal>/dev/drbd0</literal> to <filename>/var/lib/nfs</filename>,
-    and <literal>/dev/drbd1</literal> to <filename>srv/nfs/share</filename>. Confirm this
+    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/var/lib/nfs</filename>,
+    and <literal>/dev/drbd2</literal> to <filename>srv/nfs/share</filename>. Confirm this
     with <command>mount</command>, or by looking at <filename >/proc/mounts</filename>.
    </para>
   </sect2>
@@ -730,15 +737,13 @@ include /etc/drbd.d/*.res;</screen>
     </step>
     <step>
      <para>
-      Check the state of the cluster:
+      Check the status of the cluster. The resources in the <literal>g_nfs</literal>
+      group should appear in the following order:
      </para>
   <screen>&prompt.root;<command>crm status</command>
   [...]
   Full List of Resources
     [...]
-    * Clone Set: cl_nfs [drbd_nfs] (promotable):
-      * Masters: [ &node1; ]
-      * Slaves: [ &node2; ]
     * Resource Group: g_nfs:
       * fs_nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
       * fs_nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
@@ -797,7 +802,7 @@ include /etc/drbd.d/*.res;</screen>
   to the cluster.
  </para>
  <para>
-  In this example, a new DRBD device named <literal>/dev/drbd2</literal> sits
+  In this example, a new DRBD device named <literal>/dev/drbd3</literal> sits
   on top of an LVM logical volume named <literal>/dev/nfs/share2</literal>.
  </para>
  <procedure>
@@ -814,7 +819,7 @@ include /etc/drbd.d/*.res;</screen>
     under the existing volumes:
    </para>
 <screen>   volume 2 {
-      device           /dev/drbd2;
+      device           /dev/drbd3;
       disk             /dev/nfs/share2;
       meta-disk        internal;
    }</screen>
@@ -853,9 +858,9 @@ include /etc/drbd.d/*.res;</screen>
   <step>
    <para>
     On the node that is in the <literal>Primary</literal> role, create an
-    <literal>ext4</literal> file system on <literal>/dev/drbd2</literal>:
+    <literal>ext4</literal> file system on <literal>/dev/drbd3</literal>:
    </para>
-<screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
+<screen>&prompt.root;<command>mkfs.ext4 /dev/drbd3</command></screen>
   </step>
   <step>
    <para>
@@ -865,10 +870,10 @@ include /etc/drbd.d/*.res;</screen>
   </step>
   <step>
    <para>
-    Create a primitive for the file system to be exported on <literal>/dev/drbd2</literal>:
+    Create a primitive for the file system to be exported on <literal>/dev/drbd3</literal>:
    </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-share2 Filesystem \
-  params device="/dev/drbd2" directory="/srv/nfs/share2" fstype=ext4 \
+  params device="/dev/drbd3" directory="/srv/nfs/share2" fstype=ext4 \
   op monitor interval=30s timeout=40s \
   op start timeout=60s interval=0s \
   op stop timeout=60s interval=0s</command></screen>
@@ -912,7 +917,8 @@ include /etc/drbd.d/*.res;</screen>
   </step>
   <step>
    <para>
-    Check the state of the cluster:
+    Check the status of the cluster. The resources in the <literal>g_nfs</literal>
+    group should appear in the following order:
    </para>
 <screen>&prompt.root;<command>crm status</command>
 [...]

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -96,7 +96,7 @@
   <para>
    Before you can set up highly available NFS storage, you must prepare a &ha; cluster:
   </para>
-  <procedure>
+  <procedure xml:id="pro-ha-nfs-prepare-cluster">
    <title>Preparing a two-node cluster for NFS storage</title>
    <step>
     <para>
@@ -123,7 +123,7 @@
    <para>
     Use <command>crm cluster run</command> to run these commands on both nodes at once.
    </para>
-   <procedure>
+   <procedure xml:id="pro-ha-nfs-create-lvm-devices">
     <title>Creating LVM devices for DRBD</title>
     <step>
      <para>
@@ -198,7 +198,7 @@
      extension. In this procedure, the configuration file is named
      <filename>/etc/drbd.d/nfs.res</filename>.
     </para>
-    <procedure>
+    <procedure xml:id="pro-ha-nfs-create-drbd-config">
      <title>Creating a DRBD configuration</title>
      <step>
       <para>
@@ -315,7 +315,7 @@ include /etc/drbd.d;</screen>
     <para>
      After preparing the DRBD configuration, activate the devices:
     </para>
-    <procedure>
+    <procedure xml:id="pro-ha-nfs-activate-drbd-devices">
      <title>Activating DRBD devices</title>
      <step>
       <para>
@@ -371,7 +371,7 @@ include /etc/drbd.d;</screen>
      After activating the DRBD devices, create file systems on them:
 
     </para>
-    <procedure>
+    <procedure xml:id="pro-ha-nfs-create-drbd-file-systems">
      <title>Creating file systems for DRBD</title>
      <step>
       <para>
@@ -479,7 +479,7 @@ include /etc/drbd.d;</screen>
     Create a cluster resource to manage the DRBD devices, and a promotable
     clone to allow this resource to run on both nodes.
    </para>
-   <procedure>
+   <procedure xml:id="pro-ha-nfs-create-drbd-resource">
     <title>Creating a DRBD resource for NFS</title>
     <step>
      <para>
@@ -526,7 +526,7 @@ include /etc/drbd.d;</screen>
     state tracking. <emphasis>Do not</emphasis> commit this configuration until
     after you add the colocation and order constraints.
    </para>
-   <procedure>
+   <procedure xml:id="pro-ha-nfs-create-fs-resource">
     <title>Creating file system resources for NFS</title>
     <step>
      <para>
@@ -585,7 +585,7 @@ include /etc/drbd.d;</screen>
    <para>
     Create a cluster resource to manage the NFS server daemon.
    </para>
-   <procedure>
+   <procedure xml:id="pro-ha-nfs-create-nfs-server-resource">
     <title>Creating an NFS kernel server resource</title>
     <step>
      <para>
@@ -634,7 +634,7 @@ include /etc/drbd.d;</screen>
    <para>
     Create a cluster resource to manage the NFS exports.
    </para>
-   <procedure>
+   <procedure xml:id="pro-ha-nfs-create-nfs-export-resource">
     <title>Creating an NFS export resource</title>
      <step>
       <para>
@@ -700,7 +700,7 @@ include /etc/drbd.d;</screen>
    <para>
     Create a cluster resource to manage the virtual IP address for the NFS exports.
    </para>
-   <procedure>
+   <procedure xml:id="pro-ha-nfs-create-vip-resource">
     <title>Creating virtual IP address for NFS exports</title>
     <step>
      <para>
@@ -796,7 +796,7 @@ include /etc/drbd.d;</screen>
   In this example, a new DRBD device named <literal>/dev/drbd2</literal> sits
   on top of an LVM logical volume named <literal>/dev/nfs/share2</literal>.
  </para>
- <procedure>
+ <procedure xml:id="pro-ha-nfs-add-nfs-shares">
   <title>Adding more NFS shares to the cluster</title>
   <step>
    <para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -491,16 +491,16 @@ include /etc/drbd.d;</screen>
      <para>
       Create a primitive for the DRBD configuration <literal>nfs</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive drbd_nfs ocf:linbit:drbd \
+<screen>&prompt.crm.conf;<command>primitive drbd-nfs ocf:linbit:drbd \
   params drbd_resource="nfs" \
   op monitor interval=15 role=Promoted \
   op monitor interval=30 role=Unpromoted</command></screen>
     </step>
     <step>
      <para>
-      Create a promotable clone for the <literal>drbd_nfs</literal> primitive:
+      Create a promotable clone for the <literal>drbd-nfs</literal> primitive:
      </para>
-<screen>&prompt.crm.conf;<command>clone cl_nfs drbd_nfs \
+<screen>&prompt.crm.conf;<command>clone cl-nfs drbd-nfs \
   meta promotable="true" promoted-max="1" promoted-node-max="1" \
   clone-max="2" clone-node-max="1" notify="true" interleave=true</command></screen>
     </step>
@@ -532,7 +532,7 @@ include /etc/drbd.d;</screen>
      <para>
       Create a primitive for the NFS client states on <literal>/dev/drbd0</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive fs_nfs-state Filesystem \
+<screen>&prompt.crm.conf;<command>primitive fs-nfs-state Filesystem \
   params device=/dev/drbd0 directory=/var/lib/nfs fstype=ext4</command></screen>
     </step>
     <step>
@@ -540,14 +540,14 @@ include /etc/drbd.d;</screen>
       Create a primitive for the file system to be exported on
       <literal>/dev/drbd1</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive fs_nfs-share Filesystem \
+<screen>&prompt.crm.conf;<command>primitive fs-nfs-share Filesystem \
   params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4</command></screen>
     </step>
     <step>
      <para>
-      Add both of these resources to a resource group named <literal>g_nfs</literal>:
+      Add both of these resources to a resource group named <literal>g-nfs</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>group g_nfs fs_nfs-state fs_nfs-share</command></screen>
+<screen>&prompt.crm.conf;<command>group g-nfs fs-nfs-state fs-nfs-share</command></screen>
      <para>
       Resources start in the order they are added to the group, and stop in the reverse order.
      </para>
@@ -557,14 +557,14 @@ include /etc/drbd.d;</screen>
       Add a colocation constraint to make sure that the resource group always
       starts on the node where the DRBD promotable clone is in the primary role:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co_nfs-on-drbd inf: g_nfs cl_nfs:Promoted</command></screen>
+<screen>&prompt.crm.conf;<command>colocation col-nfs-on-drbd inf: g-nfs cl-nfs:Promoted</command></screen>
     </step>
     <step>
      <para>
       Add an order constraint to make sure the DRBD promotable clone always
       starts before the resource group:
      </para>
-<screen>&prompt.crm.conf;<command>order o_drbd-before-nfs Mandatory: cl_nfs:promote g_nfs:start</command></screen>
+<screen>&prompt.crm.conf;<command>order o-drbd-before-nfs Mandatory: cl-nfs:promote g-nfs:start</command></screen>
     </step>
     <step>
      <para>
@@ -591,7 +591,7 @@ include /etc/drbd.d;</screen>
      <para>
       Create a primitive to manage the NFS server daemon:
      </para>
-<screen>&prompt.crm.conf;<command>primitive p_nfsserver nfsserver \
+<screen>&prompt.crm.conf;<command>primitive nfsserver nfsserver \
   params nfs_server_scope=SUSE nfs_shared_infodir="/var/lib/nfs"</command></screen>
      <para>
       The <literal>nfs_server_scope</literal> must be the same on all nodes in the
@@ -616,9 +616,9 @@ include /etc/drbd.d;</screen>
     </step>
     <step>
      <para>
-      Append this resource to the existing <literal>g_nfs</literal> resource group:
+      Append this resource to the existing <literal>g-nfs</literal> resource group:
      </para>
-<screen>&prompt.crm.conf;<command>modgroup g_nfs add p_nfsserver</command></screen>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add nfsserver</command></screen>
     </step>
     <step>
      <para>
@@ -640,7 +640,7 @@ include /etc/drbd.d;</screen>
       <para>
        Create a primitive for the NFS exports:
       </para>
-<screen>&prompt.crm.conf;<command>primitive p_exportfs exportfs \
+<screen>&prompt.crm.conf;<command>primitive exportfs-nfs exportfs \
   params directory="/srv/nfs/share" \
   options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=101 \</command><co xml:id="co-exportfs-fsid"/>
   <command>op monitor interval=30s timeout=90s</command><co xml:id="co-exportfs-monitor-timeout"/></screen>
@@ -668,16 +668,16 @@ include /etc/drbd.d;</screen>
        <para>
         The default value for <literal>wait_for_leasetime_on_stop</literal> is
         <literal>false</literal>. There is no need to set it to <literal>true</literal>
-        when <filename>/var/lib/nfs</filename> and <literal>p_nfsserver</literal>
+        when <filename>/var/lib/nfs</filename> and <literal>nfsserver</literal>
         are configured as described in this guide.
        </para>
       </important>
      </step>
      <step>
       <para>
-       Append this resource to the existing <literal>g_nfs</literal> resource group:
+       Append this resource to the existing <literal>g-nfs</literal> resource group:
       </para>
- <screen>&prompt.crm.conf;<command>modgroup g_nfs add p_exportfs</command></screen>
+ <screen>&prompt.crm.conf;<command>modgroup g-nfs add exportfs-nfs</command></screen>
      </step>
     <step>
      <para>
@@ -706,13 +706,13 @@ include /etc/drbd.d;</screen>
      <para>
       Create a primitive for the virtual IP address:
      </para>
-<screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 params ip=&nfs-vip-exports;</command></screen>
+<screen>&prompt.crm.conf;<command>primitive vip-nfs IPaddr2 params ip=&nfs-vip-exports;</command></screen>
     </step>
     <step>
      <para>
-      Append this resource to the existing <literal>g_nfs</literal> resource group:
+      Append this resource to the existing <literal>g-nfs</literal> resource group:
      </para>
-<screen>&prompt.crm.conf;<command>modgroup g_nfs add vip_nfs</command></screen>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add vip-nfs</command></screen>
     </step>
     <step>
      <para>
@@ -728,19 +728,19 @@ include /etc/drbd.d;</screen>
     </step>
     <step>
      <para>
-      Check the status of the cluster. The resources in the <literal>g_nfs</literal>
+      Check the status of the cluster. The resources in the <literal>g-nfs</literal>
       group should appear in the following order:
      </para>
   <screen>&prompt.root;<command>crm status</command>
   [...]
   Full List of Resources
     [...]
-    * Resource Group: g_nfs:
-      * fs_nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
-      * fs_nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
-      * p_nfsserver     (ocf:heartbeat:nfsserver):    Started &node1;
-      * p_exportfs      (ocf:heartbeat:exportfs):     Started &node1;
-      * vip_nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
+    * Resource Group: g-nfs:
+      * fs-nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
+      * fs-nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
+      * nfsserver       (ocf:heartbeat:nfsserver):    Started &node1;
+      * exportfs-nfs    (ocf:heartbeat:exportfs):     Started &node1;
+      * vip-nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
     </step>
    </procedure>
   </sect2>
@@ -863,31 +863,31 @@ include /etc/drbd.d;</screen>
    <para>
     Create a primitive for the file system to be exported on <literal>/dev/drbd2</literal>:
    </para>
-<screen>&prompt.crm.conf;<command>primitive fs_nfs-share2 Filesystem \
+<screen>&prompt.crm.conf;<command>primitive fs-nfs-share2 Filesystem \
   params device="/dev/drbd2" directory="/srv/nfs/share2" fstype=ext4</command></screen>
   </step>
   <step>
    <para>
-    Add the new file system resource to the <literal>g_nfs</literal> group
-    <emphasis>before</emphasis> the <literal>p_nfsserver</literal> resource:
+    Add the new file system resource to the <literal>g-nfs</literal> group
+    <emphasis>before</emphasis> the <literal>nfsserver</literal> resource:
    </para>
-<screen>&prompt.crm.conf;<command>modgroup g_nfs add fs_nfs-share2 before p_nfsserver</command></screen>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add fs-nfs-share2 before nfsserver</command></screen>
   </step>
   <step>
    <para>
     Create a primitive for NFS exports from the new share:
    </para>
-<screen>&prompt.crm.conf;<command>primitive p_exportfs2 exportfs \
+<screen>&prompt.crm.conf;<command>primitive exportfs-nfs2 exportfs \
   params directory="/srv/nfs/share2" \
   options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=102 \
   op monitor interval=30s timeout=90s</command></screen>
   </step>
   <step>
    <para>
-    Add the new NFS export resource to the <literal>g_nfs</literal> group
-    <emphasis>before</emphasis> the <literal>vip_nfs</literal> resource:
+    Add the new NFS export resource to the <literal>g-nfs</literal> group
+    <emphasis>before</emphasis> the <literal>vip-nfs</literal> resource:
    </para>
-<screen>&prompt.crm.conf;<command>modgroup g_nfs add p_exportfs2 before vip_nfs</command></screen>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add exportfs-nfs2 before vip-nfs</command></screen>
   </step>
   <step>
    <para>
@@ -903,21 +903,21 @@ include /etc/drbd.d;</screen>
   </step>
   <step>
    <para>
-    Check the status of the cluster. The resources in the <literal>g_nfs</literal>
+    Check the status of the cluster. The resources in the <literal>g-nfs</literal>
     group should appear in the following order:
    </para>
 <screen>&prompt.root;<command>crm status</command>
 [...]
 Full List of Resources
   [...]
-  * Resource Group: g_nfs:
-    * fs_nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
-    * fs_nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
-    * fs_nfs-share2   (ocf:heartbeat:Filesystem):   Started &node1;
-    * p_nfsserver     (ocf:heartbeat:nfsserver):    Started &node1;
-    * p_exportfs      (ocf:heartbeat:exportfs):     Started &node1;
-    * p_exportfs2     (ocf:heartbeat:exportfs):     Started &node1;
-    * vip_nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
+  * Resource Group: g-nfs:
+    * fs-nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
+    * fs-nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
+    * fs-nfs-share2   (ocf:heartbeat:Filesystem):   Started &node1;
+    * nfsserver       (ocf:heartbeat:nfsserver):    Started &node1;
+    * exportfs-nfs    (ocf:heartbeat:exportfs):     Started &node1;
+    * exportfs-nfs2   (ocf:heartbeat:exportfs):     Started &node1;
+    * vip-nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
   </step>
   <step>
    <para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -198,13 +198,13 @@
         following contents:
       </para>
 <screen>resource nfs {
-   volume 1 { <co xml:id="co-ha-quick-nfs-drbd-volume"/>
-      device           /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
+   volume 0 { <co xml:id="co-ha-quick-nfs-drbd-volume"/>
+      device           /dev/drbd0 minor 0; <co xml:id="co-ha-quick-nfs-drbd-device"/>
       disk             /dev/nfs/state; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
       meta-disk        internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
    }
    volume 1 {
-      device           /dev/drbd2 minor 2;
+      device           /dev/drbd1 minor 1;
       disk             /dev/nfs/share;
       meta-disk        internal;
    }
@@ -334,8 +334,8 @@ include /etc/drbd.d/*.res;</screen>
        The devices do not have data yet, so you can run these commands to
        skip the initial synchronization:
       </para>
-<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/1</command>
-&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/2</command></screen>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/0</command>
+&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/1</command></screen>
      </step>
      <step>
        <para>Make <systemitem>&node1;</systemitem> primary:</para>
@@ -346,16 +346,16 @@ include /etc/drbd.d/*.res;</screen>
 <screen>&prompt.root;<command>drbdadm status nfs</command></screen>
        <para>This returns the following message:</para>
 <screen>nfs role:Primary
+  volume:0 disk:UpToDate
   volume:1 disk:UpToDate
-  volume:2 disk:UpToDate
   &node2; role:Secondary
-    volume:1 peer-disk:UpToDate
-    volume:2 peer-disk:UpToDate</screen>
+    volume:0 peer-disk:UpToDate
+    volume:1 peer-disk:UpToDate</screen>
      </step>
     </procedure>
     <para>
      You can access the DRBD resources on the block devices
-     <filename>/dev/drbd1</filename> and <filename>/dev/drbd2</filename>.
+     <filename>/dev/drbd0</filename> and <filename>/dev/drbd1</filename>.
      </para>
    </sect2>
 
@@ -369,15 +369,15 @@ include /etc/drbd.d/*.res;</screen>
      <title>Creating file systems for DRBD</title>
      <step>
       <para>
-       Create an <literal>ext4</literal> file system on <filename>/dev/drbd1</filename>:
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd0</filename>:
       </para>
-      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd0</command></screen>
      </step>
      <step>
       <para>
-       Create an <literal>ext4</literal> file system on <filename>/dev/drbd2</filename>:
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd1</filename>:
       </para>
-      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
      </step>
     </procedure>
    </sect2>
@@ -453,14 +453,14 @@ include /etc/drbd.d/*.res;</screen>
     <listitem>
         <para>Into this export directory, the cluster mounts an
             <literal>ext4</literal> file system from the DRBD device
-         <filename>/dev/drbd2</filename>.
+         <filename>/dev/drbd1</filename>.
          This DRBD device sits on top of an LVM logical volume named
          <literal>/dev/nfs/share</literal>.
         </para>
     </listitem>
     <listitem>
      <para>
-      The DRBD device <literal>/dev/drbd1</literal> is used to share the
+      The DRBD device <literal>/dev/drbd0</literal> is used to share the
       NFS client states from <filename>/var/lib/nfs</filename>. This DRBD device
       sits on top of an LVM logical volume named <literal>/dev/nfs/state</literal>.
      </para>
@@ -477,7 +477,7 @@ include /etc/drbd.d/*.res;</screen>
     <title>Creating a DRBD resource for NFS</title>
     <step>
      <para>
-      Log in as &rootuser; and start the <command>crm</command> interactive shell:
+      Start the <command>crm</command> interactive shell:
      </para>
 <screen>&prompt.root;<command>crm configure</command></screen>
     </step>
@@ -531,7 +531,7 @@ include /etc/drbd.d/*.res;</screen>
       Create a primitive for the NFS client states on <literal>/dev/drbd1</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-state Filesystem \
-  params device=/dev/drbd1 directory=/var/lib/nfs fstype=ext4 \
+  params device=/dev/drbd0 directory=/var/lib/nfs fstype=ext4 \
   op monitor interval=30s timeout=40s \
   op start timeout=60s interval=0s \
   op stop timeout=60s interval=0s</command></screen>
@@ -542,7 +542,7 @@ include /etc/drbd.d/*.res;</screen>
       <literal>/dev/drbd2</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-share Filesystem \
-  params device=/dev/drbd2 directory=/srv/nfs/share fstype=ext4 \
+  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4 \
   op monitor interval=30s timeout=40s \
   op start timeout=60s interval=0s \
   op stop timeout=60s interval=0s</command></screen>
@@ -578,8 +578,8 @@ include /etc/drbd.d/*.res;</screen>
     </step>
    </procedure>
    <para>
-    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/var/lib/nfs</filename>,
-    and <literal>/dev/drbd2</literal> to <filename>srv/nfs/share</filename>. Confirm this
+    Pacemaker mounts <literal>/dev/drbd0</literal> to <filename>/var/lib/nfs</filename>,
+    and <literal>/dev/drbd1</literal> to <filename>srv/nfs/share</filename>. Confirm this
     with <command>mount</command>, or by looking at <filename >/proc/mounts</filename>.
    </para>
   </sect2>
@@ -647,7 +647,7 @@ include /etc/drbd.d/*.res;</screen>
       </para>
 <screen>&prompt.crm.conf;<command>primitive p_exportfs exportfs \
   params directory="/srv/nfs/share" \
-  options="rw,mountpoint" clientspec="*" fsid=100 \
+  options="rw,mountpoint" clientspec="*" fsid=101 \
   op monitor interval=30s timeout=90s \
   op start timeout=40s interval=0s \
   op stop timeout=120s interval=0s</command></screen>
@@ -722,6 +722,30 @@ include /etc/drbd.d/*.res;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>commit</command></screen>
     </step>
+    <step>
+     <para>
+      Leave the <command>crm</command> interactive shell:
+     </para>
+  <screen>&prompt.crm.conf;<command>quit</command></screen>
+    </step>
+    <step>
+     <para>
+      Check the state of the cluster:
+     </para>
+  <screen>&prompt.root;<command>crm status</command>
+  [...]
+  Full List of Resources
+    [...]
+    * Clone Set: cl_nfs [drbd_nfs] (promotable):
+      * Masters: [ &node1; ]
+      * Slaves: [ &node2; ]
+    * Resource Group: g_nfs:
+      * fs_nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
+      * fs_nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
+      * p_nfsserver     (ocf:heartbeat:nfsserver):    Started &node1;
+      * p_exportfs      (ocf:heartbeat:exportfs):     Started &node1;
+      * vip_nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
+    </step>
    </procedure>
   </sect2>
  </sect1>
@@ -765,6 +789,155 @@ include /etc/drbd.d/*.res;</screen>
    </para>
   </note>
  </sect1>
+
+<sect1 xml:id="sec-ha-quick-nfs-add-filesystems">
+ <title>Adding more NFS shares to the cluster</title>
+ <para>
+  If you need to increase the available storage, you can add more NFS shares
+  to the cluster.
+ </para>
+ <para>
+  In this example, a new DRBD device named <literal>/dev/drbd2</literal> sits
+  on top of an LVM logical volume named <literal>/dev/nfs/share2</literal>.
+ </para>
+ <procedure>
+  <title>Adding more NFS shares to the cluster</title>
+  <step>
+   <para>
+    Create an LVM logical volume for the new share:
+   </para>
+<screen>&prompt.root;<command>crm cluster run "lvcreate -n share2 -L 20G nfs"</command></screen>
+  </step>
+  <step>
+   <para>
+    Update the file <filename>/etc/drbd.d/nfs.res</filename> to add the new volume
+    under the existing volumes:
+   </para>
+<screen>   volume 2 {
+      device           /dev/drbd2;
+      disk             /dev/nfs/share2;
+      meta-disk        internal;
+   }</screen>
+  </step>
+  <step>
+   <para>
+    Copy the updated file to the other nodes:
+   </para>
+<screen>&prompt.root;<command>csync2 -xv</command></screen>
+  </step>
+  <step>
+   <para>
+    Initialize the metadata storage for the new volume:
+   </para>
+<screen>&prompt.root;<command>crm cluster run "drbdadm create-md nfs/2 --force"</command></screen>
+  </step>
+  <step>
+   <para>
+    Update the <literal>nfs</literal> configuration to create the new device:
+   </para>
+<screen>&prompt.root;<command>crm cluster run "drbdadm adjust nfs"</command></screen>
+  </step>
+  <step>
+   <para>
+    Skip the initial synchronization for the new device:
+   </para>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/2</command></screen>
+  </step>
+  <step>
+   <para>
+    The NFS cluster resources might have moved to another node since they were created.
+    Check the DRBD status with <command>drbdadm status nfs</command>, and make a
+    note of which node is in the <literal>Primary</literal> role.
+   </para>
+  </step>
+  <step>
+   <para>
+    On the node that is in the <literal>Primary</literal> role, create an
+    <literal>ext4</literal> file system on <literal>/dev/drbd2</literal>:
+   </para>
+<screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
+  </step>
+  <step>
+   <para>
+    Start the <command>crm</command> interactive shell:
+   </para>
+<screen>&prompt.root;<command>crm configure</command></screen>
+  </step>
+  <step>
+   <para>
+    Create a primitive for the file system to be exported on <literal>/dev/drbd2</literal>:
+   </para>
+<screen>&prompt.crm.conf;<command>primitive fs_nfs-share2 Filesystem \
+  params device="/dev/drbd2" directory="/srv/nfs/share2" fstype=ext4 \
+  op monitor interval=30s timeout=40s \
+  op start timeout=60s interval=0s \
+  op stop timeout=60s interval=0s</command></screen>
+  </step>
+  <step>
+   <para>
+    Add the new file system resource to the <literal>g_nfs</literal> group
+    <emphasis>before</emphasis> the <literal>p_nfsserver</literal> resource:
+   </para>
+<screen>&prompt.crm.conf;<command>modgroup g_nfs add fs_nfs-share2 before p_nfsserver</command></screen>
+  </step>
+  <step>
+   <para>
+    Create a primitive for NFS exports from the new share:
+   </para>
+<screen>&prompt.crm.conf;<command>primitive p_exportfs2 exportfs \
+  params directory="/srv/nfs/share2" \
+  options="rw,mountpoint" clientspec="*" fsid=102 \
+  op monitor interval=30s timeout=90s \
+  op start timeout=40s interval=0s \
+  op stop timeout=120s interval=0s</command></screen>
+  </step>
+  <step>
+   <para>
+    Add the new NFS export resource to the <literal>g_nfs</literal> group
+    <emphasis>before</emphasis> the <literal>vip_nfs</literal> resource:
+   </para>
+<screen>&prompt.crm.conf;<command>modgroup g_nfs add p_exportfs2 before vip_nfs</command></screen>
+  </step>
+  <step>
+   <para>
+    Commit this configuration:
+   </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+  </step>
+  <step>
+   <para>
+    Leave the <command>crm</command> interactive shell:
+   </para>
+<screen>&prompt.crm.conf;<command>quit</command></screen>
+  </step>
+  <step>
+   <para>
+    Check the state of the cluster:
+   </para>
+<screen>&prompt.root;<command>crm status</command>
+[...]
+Full List of Resources
+  [...]
+  * Resource Group: g_nfs:
+    * fs_nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
+    * fs_nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
+    * fs_nfs-share2   (ocf:heartbeat:Filesystem):   Started &node1;
+    * p_nfsserver     (ocf:heartbeat:nfsserver):    Started &node1;
+    * p_exportfs      (ocf:heartbeat:exportfs):     Started &node1;
+    * p_exportfs2     (ocf:heartbeat:exportfs):     Started &node1;
+    * vip_nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
+  </step>
+  <step>
+   <para>
+    Confirm that the NFS exports are set up properly:
+   </para>
+<screen>&prompt.root;<command>exportfs -v</command>
+/srv/nfs/share   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)
+/srv/nfs/share2  <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
+  </step>
+ </procedure>
+</sect1>
+
  <sect1 xml:id="sec-ha-quick-nfs-more-info">
   <title>For more information</title>
   <itemizedlist>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -108,7 +108,7 @@
     across several file systems.
    </para>
    <para>
-    Use <command>crm cluster run</command> to create the LVM devices on both nodes at once.
+    Use <command>crm cluster run</command> to run these commands on both nodes at once.
    </para>
    <procedure>
     <title>Creating LVM devices for DRBD</title>
@@ -262,7 +262,7 @@
         <para>
          Enables resource-level fencing. If the DRBD replication link
          becomes disconnected, &pace; tries to promote the DRBD resource
-         to another node. For more information, refer to <xref linkend="sec-ha-drbd-fencing"/>.
+         to another node. For more information, see <xref linkend="sec-ha-drbd-fencing"/>.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-connectionmesh">
@@ -290,7 +290,7 @@ include /etc/drbd.d/*.res;</screen>
       </para>
 <screen>&prompt.root;<command>csync2 -xv</command></screen>
       <para>
-       For information about &csync;, refer to
+       For information about &csync;, see
        <xref linkend="sec-ha-installation-setup-csync2"/>.
       </para>
      </step>
@@ -765,13 +765,13 @@ include /etc/drbd.d/*.res;</screen>
 <screen>&prompt.root;<command>mount -o proto=tcp,rsize=32768,wsize=32768,vers=3 \
 &nfs-vip-exports;:/srv/nfs/share /home/share</command></screen>
   <para>
-   For further NFS mount options, refer to the <command>nfs</command> man page.
+   For further NFS mount options, see the <command>nfs</command> man page.
   </para>
   <note>
    <title>Loopback mounts</title>
    <para>
     Loopback mounts are only supported for NFS version 3, <emphasis>not</emphasis>
-    NFS version 4. For more information, refer to
+    NFS version 4. For more information, see
     <link xlink:href="https://www.suse.com/support/kb/doc/?id=000018709"/>.
    </para>
   </note>
@@ -926,25 +926,25 @@ Full List of Resources
   <itemizedlist>
    <listitem>
     <para>
-     For more details about the steps in this guide, refer to
+     For more details about the steps in this guide, see
      <link xlink:href="https://www.suse.com/support/kb/doc/?id=000020396"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     For more information about NFS and LVM, refer to
+     For more information about NFS and LVM, see
      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
      &storage_guide; for &sles;</link>.
     </para>
    </listitem>
    <listitem>
     <para>
-     For more information about DRBD, refer to <xref linkend="cha-ha-drbd"/>.
+     For more information about DRBD, see <xref linkend="cha-ha-drbd"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     For more information about cluster resources, refer to
+     For more information about cluster resources, see
      <xref linkend="sec-ha-config-basics-resources"/>.
     </para>
    </listitem>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -92,7 +92,7 @@
  </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-installation">
-  <title>Preparing a two-node cluster for NFS storage</title>
+  <title>Preparing a two-node cluster</title>
   <para>
    Before you can set up highly available NFS storage, you must prepare a &ha; cluster:
   </para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -8,11 +8,6 @@
     %entities;
 ]>
 
-<!--
- This Quick Start should link to the "Installation and Setup Quick Start"
- which covers the installation and setup of a two-node cluster.
- Follow-on steps (DRBD, LVM & NFS) are covered here.
--->
 <article version="5.0" xml:lang="en" xml:id="article-nfs-storage"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:dm="urn:x-suse:ns:docmanager"
@@ -44,7 +39,6 @@
   </para>
 
   <itemizedlist>
-   <!-- Taken from art_sle_ha_install_quick.xml: -->
    <listitem>
     <para>
      Two nodes: <systemitem class="server">&node1;</systemitem> (IP: <systemitem
@@ -78,8 +72,8 @@
    </listitem>
    <listitem>
     <para>
-     Local storage on each host. The data is synchronized between the
-     hosts using DRBD on top of LVM.
+     Local storage on each node. The data is synchronized between the
+     nodes using DRBD on top of LVM.
     </para>
    </listitem>
    <listitem>
@@ -116,12 +110,12 @@
    <procedure>
     <step>
      <para>
-      Create an LVM volume group and replace <filename>/dev/sdb1</filename>
+      Create an LVM physical volume and replace <filename>/dev/sdb1</filename>
       with your corresponding device for LVM:</para>
      <screen>&prompt.root;<command>pvcreate /dev/sdb1</command></screen>
     </step>
     <step>
-     <para>Create an LVM Volume Group <systemitem>nfs</systemitem>
+     <para>Create an LVM volume group <systemitem>nfs</systemitem>
             that includes this physical volume: </para>
      <screen>&prompt.root;<command>vgcreate nfs /dev/sdb1</command></screen>
     </step>
@@ -135,9 +129,7 @@
      </step>
      <step>
       <para>
-       Activate the volume group<!-- and create file systems on the new logical
-       volumes. This example assumes <literal>ext3</literal> as the file
-       system type-->: </para>
+       Activate the volume group: </para>
 <screen>&prompt.root;<command>vgchange -ay nfs</command></screen>
      </step>
    </procedure>
@@ -194,9 +186,6 @@
      </listitem>
     </itemizedlist>
 
-    <para>
-     Proceed as follows:
-    </para>
     <procedure>
      <title>Creating a DRBD configuration</title>
      <step>
@@ -234,7 +223,7 @@
 }</screen>
       <calloutlist>
        <callout arearefs="co-ha-quick-nfs-drbd-device">
-        <para>The DRBD device that applications are supposed to access.</para>
+        <para>The DRBD device that applications will access.</para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-disk">
         <para>The lower-level block device used by DRBD to store the actual
@@ -308,9 +297,6 @@ include /etc/drbd.d/*.res;</screen>
      After you have prepared your DRBD configuration, proceed as follows:
     </para>
 
-    <!--
-    Taken some steps from https://github.com/SUSE/doc-sleha/commit/5bb10f7fc6
-    -->
     <procedure>
      <step>
       <para> If you use a firewall in your cluster, open port
@@ -379,19 +365,9 @@ include /etc/drbd.d/*.res;</screen>
 &prompt.crm.conf;<command>rsc_defaults resource-stickiness="200"</command>
 &prompt.crm.conf;<command>commit</command></screen>
 
-<!--
-   <formalpara>
-   <title>With &hawk2;</title>
-   <para>
-   To adjust the option in &hawk2;, click <guimenu>Cluster Configuration</guimenu>.
-   In the text field <guimenu>resource-stickiness</guimenu> enter
-   <literal>200</literal>. Confirm with <guimenu>Apply</guimenu>.
-  </para>
-  </formalpara>
--->
    <para>
     For more information about global cluster options, refer to
-    <xref linkend="sec-ha-config-basics-global"/>.
+    <xref linkend="sec-ha-config-basics-global-options"/>.
    </para>
  </sect1>
 
@@ -423,14 +399,6 @@ include /etc/drbd.d/*.res;</screen>
      </para>
     </listitem>
    </varlistentry>
-   <!--<varlistentry>
-    <term>NFSv4 virtual file system root</term>
-    <listitem>
-     <para>
-      A virtual NFS root export (only needed for NFSv4 clients).
-     </para>
-    </listitem>
-   </varlistentry>-->
    <varlistentry>
     <term>NFS exports</term>
     <listitem>
@@ -450,8 +418,7 @@ include /etc/drbd.d/*.res;</screen>
          <systemitem class="ipaddress">&subnetI;.x/24</systemitem> subnet.</para>
     </listitem>
     <listitem>
-        <para>The service <!--hosts an NFSv4 virtual file system root
-        from <literal>/srv/nfs</literal>, with--> exports data served from
+        <para>The service exports data served from
          <literal>/srv/nfs/work</literal>. </para>
     </listitem>
     <listitem>
@@ -470,9 +437,8 @@ include /etc/drbd.d/*.res;</screen>
     To configure these resources, run the following commands from the
    &crmshell;:
    </para>
-<screen>&prompt.crm;<command>configure</command>
-&prompt.crm.conf;<command>primitive drbd_nfs \
-  ocf:linbit:drbd \
+<screen>&prompt.root;<command>crm configure</command>
+&prompt.crm.conf;<command>primitive drbd_nfs ocf:linbit:drbd \
     params drbd_resource="nfs" \
   op monitor interval="15" role="Promoted" \
   op monitor interval="30" role="Unpromoted"</command>
@@ -568,66 +534,6 @@ include /etc/drbd.d/*.res;</screen>
     resource type.
    </para>
 
-<!-- According to Neal, this is can be removed completely
-
-   <sect3 xml:id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
-    <title>NFSv4 virtual file system root</title>
-    <para>
-     If clients exclusively use NFSv3 to connect to the server, you do not
-     need this resource. In this case, continue with
-     <xref linkend="sec-ha-quick-nfs-resources-nfsexport-nonroot"/>.
-    </para>
-    <orderedlist>
-     <listitem>
-      <para>
-       Create a virtual NFSv4 file system:
-      </para>
-<screen>&prompt.crm.conf;<command>primitive</command> exportfs_root \
-  ocf:heartbeat:exportfs \
-  params directory="/srv/nfs" fsid=0 \
-    options="rw,crossmnt" \
-    clientspec="&nfs-clientspec;" \<!-\- 10.9.9.0/24 -\->
-  op monitor interval="30s"
-&prompt.crm.conf;<command>clone</command> cl-exportfs_root exportfs_root</screen>
-      <remark>toms 2016-09-01: What clientspec should be used here?</remark>
-      <para>
-       This resource does not hold any actual NFS-exported data, merely the
-       empty directory (<filename>/srv/nfs</filename>) that the other NFS
-       exports are mounted into. Since there is no shared data involved
-       here, you can safely <emphasis>clone</emphasis> this resource.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Since any data should be exported only on nodes where this clone has
-       been properly started, add the following constraints to the
-       configuration:
-      </para>
-<screen>&prompt.crm.conf;<command>order</command> o-root_before_nfs Mandatory: \
-  cl-exportfs_root g-nfs:start
-&prompt.crm.conf;<command>colocation</command> c-nfs_on_root inf: \
-  g-nfs cl-exportfs_root
-&prompt.crm.conf;<command>commit</command></screen>
-      <para>
-       After this, Pacemaker should start the NFSv4 virtual file system root
-       on both nodes.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Check the output of the <command>exportfs -v</command> command to
-       verify this:
-      </para>
-      <screen>&prompt.root;<command>exportfs</command> -v
-/srv/nfs/work   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(...)
-/srv/nfs        <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(...)</screen>
-     </listitem>
-    </orderedlist>
-   </sect3>
--->
-
-<!--   <sect3 xml:id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
-    <title>NFS exports</title>-->
     <para>
      To export the <filename>/srv/nfs/work</filename> directory to clients,
      use the following primitive:
@@ -668,11 +574,9 @@ include /etc/drbd.d/*.res;</screen>
        Confirm that the NFS exports are set up properly:
       </para>
 <screen>&prompt.root;<command>exportfs -v</command>
-/srv/nfs/work   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)<!--
-/srv/nfs        <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)--></screen>
+/srv/nfs/work   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
      </listitem>
     </orderedlist>
-   <!--</sect3>-->
   </sect2>
 
   <sect2 xml:id="sec-ha-quick-nfs-resources-vip">
@@ -691,13 +595,6 @@ include /etc/drbd.d/*.res;</screen>
 &prompt.crm.conf;<command>commit</command></screen>
   </sect2>
  </sect1>
-
- <!-- toms 2015-10-23: This is an attempt to descript how to set up
-      a HA NFS cluster with cluster scripts
-
-      toms 2016-08-23: Still disabled for the time being as not really finished
-   -->
- <!--<xi:include href="nfs_quick_clusterscript.xml"/>-->
 
  <sect1 xml:id="sec-ha-quick-nfs-use">
   <title>Using the NFS service</title>
@@ -723,7 +620,7 @@ include /etc/drbd.d/*.res;</screen>
   <screen>&prompt.root;<command>mount -o rsize=32768,wsize=32768 \
     &nfs-vip-exports;:/srv/nfs/work /home/work</command></screen>
   <para>
-   In case you need to be compatible with NFS version&nbsp;3, include the value
+   If you need to be compatible with NFS version&nbsp;3, include the value
    <option>vers=3</option> after the <option>-o</option> option.
   </para>
   <para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -336,8 +336,8 @@ include /etc/drbd.d/*.res;</screen>
        The devices do not have data yet, so
        you can run these commands to skip the initial synchronization:
       </para>
-<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-share/1</command>
-&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-state/2</command></screen>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-share</command>
+&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-state</command></screen>
      </step>
      <step>
        <para>Make <systemitem>&node1;</systemitem> primary:</para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -33,7 +33,7 @@
  <sect1 xml:id="sec-ha-quick-nfs-usagescenario">
   <title>Usage scenario</title>
   <para>
-   This document will help you set up a highly available NFS server.
+   This document helps you set up a highly available NFS server.
    The cluster used for the highly available NFS storage has the
    following properties:
   </para>
@@ -143,7 +143,7 @@
       </para>
       <screen>&prompt.root;<command>crm cluster run "lvcreate -n share -L 20G nfs"</command></screen>
       <para>
-       This volume will be used for the NFS exports.
+       This volume is for the NFS exports.
       </para>
      </step>
      <step>
@@ -153,7 +153,7 @@
       </para>
       <screen>&prompt.root;<command>crm cluster run "lvcreate -n state -L 8G nfs"</command></screen>
       <para>
-       This volume will be used for the NFS client states. The 8 GB volume size
+       This volume is for the NFS client states. The 8 GB volume size
        used in this example should support several thousand concurrent NFS clients.
       </para>
      </step>
@@ -173,7 +173,7 @@
    <title>Creating DRBD devices</title>
    <para>
     This section describes how to set up DRBD devices on top of LVM.
-    Using LVM as a back-end of DRBD has some benefits:
+    Using LVM as a back-end of DRBD has the following benefits:
    </para>
   <itemizedlist>
    <listitem>
@@ -186,7 +186,7 @@
    </listitem>
   </itemizedlist>
   <para>
-    The following procedures will result in two DRBD devices: one device for the
+    The following procedures result in two DRBD devices: one device for the
     NFS exports, and a second device to track the NFS client states.
    </para>
 
@@ -477,7 +477,7 @@ include /etc/drbd.d;</screen>
    <title>Creating DRBD primitive and promotable clone resources</title>
    <para>
     Create a cluster resource to manage the DRBD devices, and a promotable
-    clone to allow this resource to run on both nodes.
+    clone to allow this resource to run on both nodes:
    </para>
    <procedure xml:id="pro-ha-nfs-create-drbd-resource">
     <title>Creating a DRBD resource for NFS</title>
@@ -522,9 +522,7 @@ include /etc/drbd.d;</screen>
   <sect2 xml:id="sec-ha-quick-nfs-resources-lvm">
    <title>Creating file system resources</title>
    <para>
-    Create cluster resources to manage the file systems for export and
-    state tracking. <emphasis>Do not</emphasis> commit this configuration until
-    after you add the colocation and order constraints.
+    Create cluster resources to manage the file systems for export and state tracking:
    </para>
    <procedure xml:id="pro-ha-nfs-create-fs-resource">
     <title>Creating file system resources for NFS</title>
@@ -542,6 +540,10 @@ include /etc/drbd.d;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs-nfs-share Filesystem \
   params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4</command></screen>
+     <para>
+      <emphasis>Do not</emphasis> commit this configuration until
+    after you add the colocation and order constraints.
+     </para>
     </step>
     <step>
      <para>
@@ -583,7 +585,7 @@ include /etc/drbd.d;</screen>
   <sect2 xml:id="sec-ha-quick-nfs-resources-nfsserver">
    <title>Creating an NFS kernel server resource</title>
    <para>
-    Create a cluster resource to manage the NFS server daemon.
+    Create a cluster resource to manage the NFS server daemon:
    </para>
    <procedure xml:id="pro-ha-nfs-create-nfs-server-resource">
     <title>Creating an NFS kernel server resource</title>
@@ -603,8 +605,8 @@ include /etc/drbd.d;</screen>
       <title>Low lease time can cause loss of file state</title>
       <para>
        NFS clients regularly renew their state with the NFS server. If the lease time
-       is too low, operating system or network delays can cause the timer to expire
-       before the renewal is complete, leading to loss of file state and I/O errors.
+       is too low, system or network delays can cause the timer to expire before the
+       renewal is complete. This can lead to I/O errors and loss of file state.
       </para>
       <para>
        <literal>NFSV4LEASETIME</literal> is set on the NFS server in the file
@@ -632,7 +634,7 @@ include /etc/drbd.d;</screen>
   <sect2 xml:id="sec-ha-quick-nfs-resources-nfsexport">
    <title>Creating an NFS export resource</title>
    <para>
-    Create a cluster resource to manage the NFS exports.
+    Create a cluster resource to manage the NFS exports:
    </para>
    <procedure xml:id="pro-ha-nfs-create-nfs-export-resource">
     <title>Creating an NFS export resource</title>
@@ -698,7 +700,7 @@ include /etc/drbd.d;</screen>
   <sect2 xml:id="sec-ha-quick-nfs-resources-vip">
    <title>Creating a virtual IP address for NFS exports</title>
    <para>
-    Create a cluster resource to manage the virtual IP address for the NFS exports.
+    Create a cluster resource to manage the virtual IP address for the NFS exports:
    </para>
    <procedure xml:id="pro-ha-nfs-create-vip-resource">
     <title>Creating virtual IP address for NFS exports</title>
@@ -766,10 +768,7 @@ include /etc/drbd.d;</screen>
    If you need to configure other mount options, such as a specific transport protocol
    (<option>proto</option>), maximum read and write request sizes (<option>rsize</option>
    and <option>wsize</option>), or a specific NFS version (<option>vers</option>),
-   use the <option>-o</option> option.
-  </para>
-  <para>
-   For example:
+   use the <option>-o</option> option. For example:
   </para>
 <screen>&prompt.root;<command>mount -o proto=tcp,rsize=32768,wsize=32768,vers=3 \
 &nfs-vip-exports;:/srv/nfs/share /home/share</command></screen>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -106,37 +106,40 @@
     flexible distribution of hard disk space over several file
     systems.
    </para>
+   <para>
+    Use <command>crm cluster run</command> to create the LVM devices on both nodes at once.
+   </para>
    <procedure>
     <title>Creating LVM devices for DRBD</title>
     <step>
      <para>
       Create an LVM physical volume and replace <filename>/dev/sdb1</filename>
       with your corresponding device for LVM:</para>
-     <screen>&prompt.root;<command>pvcreate /dev/sdb1</command></screen>
+     <screen>&prompt.root;<command>crm cluster run "pvcreate /dev/sdb1"</command></screen>
     </step>
     <step>
      <para>Create an LVM volume group <systemitem>nfs</systemitem>
             that includes this physical volume: </para>
-     <screen>&prompt.root;<command>vgcreate nfs /dev/sdb1</command></screen>
+     <screen>&prompt.root;<command>crm cluster run "vgcreate nfs /dev/sdb1"</command></screen>
     </step>
     <step>
       <para>
        Create a logical volume named <systemitem>share</systemitem> in the
        volume group <systemitem>nfs</systemitem>:
       </para>
-      <screen>&prompt.root;<command>lvcreate -n share -L 20G nfs</command></screen>
+      <screen>&prompt.root;<command>crm cluster run "lvcreate -n share -L 20G nfs"</command></screen>
      </step>
      <step>
       <para>
        Create a second logical volume, named <systemitem>state</systemitem>,
        in the volume group <systemitem>nfs</systemitem>:
       </para>
-      <screen>&prompt.root;<command>lvcreate -n state -L 4G nfs</command></screen>
+      <screen>&prompt.root;<command>crm cluster run "lvcreate -n state -L 4G nfs"</command></screen>
      </step>
      <step>
       <para>
        Activate the volume group: </para>
-<screen>&prompt.root;<command>vgchange -ay nfs</command></screen>
+<screen>&prompt.root;<command>crm cluster run "vgchange -ay nfs"</command></screen>
      </step>
    </procedure>
    <para>
@@ -168,36 +171,43 @@
    </para>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-config">
-    <title>Creating the DRBD configurations</title>
+    <title>Creating the DRBD configuration</title>
     <para>
      For consistency reasons, it is highly recommended to follow this advice:
     </para>
     <itemizedlist>
      <listitem>
       <para>Use the directory <filename>/etc/drbd.d/</filename> for your
-      configurations.</para>
+      configuration.</para>
      </listitem>
      <listitem>
-      <para>Name the files according to the purpose of the resources.
+      <para>Name the file according to the purpose of the resource.
       </para>
      </listitem>
      <listitem>
-      <para>Put your resource configurations in files with a <filename
-       class="extension">.res</filename> extension.
+      <para>Put your resource configuration in a file with a
+       <filename class="extension">.res</filename> extension.
       </para>
      </listitem>
     </itemizedlist>
     <procedure>
-     <title>Creating DRBD configurations</title>
+     <title>Creating a DRBD configuration</title>
      <step>
       <para>
-       Create the file <filename>/etc/drbd.d/nfs-share.res</filename> with the
+       Create the file <filename>/etc/drbd.d/nfs.res</filename> with the
         following contents:
       </para>
-<screen>resource nfs-share {
-   device /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
-   disk   /dev/nfs/share; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
-   meta-disk internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
+<screen>resource nfs {
+   volume 1 { <co xml:id="co-ha-quick-nfs-drbd-volume"/>
+      device           /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
+      disk             /dev/nfs/state; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
+      meta-disk        internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
+   }
+   volume 1 {
+      device           /dev/drbd2 minor 2;
+      disk             /dev/nfs/share;
+      meta-disk        internal;
+   }
 
    net {
       protocol  C; <co xml:id="co-ha-quick-nfs-drbd-protocol"/>
@@ -207,7 +217,6 @@
    handlers { <co xml:id="co-ha-quick-nfs-fencing-handlers"/>
       fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
       after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
-      # ...
    }
 
    connection-mesh { <co xml:id="co-ha-quick-nfs-connectionmesh"/>
@@ -223,6 +232,9 @@
    }
 }</screen>
       <calloutlist>
+       <callout arearefs="co-ha-quick-nfs-drbd-volume">
+        <para>The volume number for each DRBD device you want to create.</para>
+       </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-device">
         <para>The DRBD device that applications will access.</para>
        </callout>
@@ -270,41 +282,6 @@
      </step>
      <step>
       <para>
-       Create the file <filename>/etc/drbd.d/nfs-state.res</filename> with the
-       following contents. The differences from <filename>/etc/drbd.d/nfs-share.res</filename>
-       are shown in bold:
-      </para>
-<screen>resource nfs_<emphasis role="bold">state</emphasis> {
-   device /dev/<emphasis role="bold">drbd2 minor 2</emphasis>;
-   disk   /dev/nfs/<emphasis role="bold">state</emphasis>;
-   meta-disk internal;
-
-   net {
-      protocol  C;
-      fencing resource-and-stonith;
-   }
-
-   handlers {
-      fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
-      after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
-      # ...
-   }
-
-   connection-mesh {
-      hosts     &node1; &node2;;
-   }
-   on &node1; {
-      address   &subnetI;.1:<emphasis role="bold">&drbd.port2;</emphasis>;
-      node-id   0;
-   }
-   on &node2; {
-      address   &subnetI;.2:<emphasis role="bold">&drbd.port2;</emphasis>;
-      node-id   1;
-   }
-}</screen>
-     </step>
-     <step>
-      <para>
        Open <filename>/etc/csync2/csync2.cfg</filename> and check whether the
        following two lines exist:
       </para>
@@ -330,56 +307,50 @@ include /etc/drbd.d/*.res;</screen>
    <sect2 xml:id="sec-ha-quick-nfs-drbd-activate">
     <title>Activating the DRBD devices</title>
     <para>
-     After preparing the DRBD configurations, activate the devices:
+     After preparing the DRBD configuration, activate the devices:
     </para>
     <procedure>
      <title>Activating DRBD devices</title>
      <step>
       <para>
-       If you use a firewall in the cluster, open ports <systemitem>&drbd.port;</systemitem>
-       and <systemitem>&drbd.port2;</systemitem> in the firewall configuration.
+       If you use a firewall in the cluster, open port
+       <systemitem>&drbd.port;</systemitem> in the firewall configuration.
       </para>
      </step>
      <step>
       <para>
-       Initialize the metadata storage. Run these commands on
-       <emphasis>both</emphasis> nodes:
+       Initialize the metadata storage:
       </para>
-<screen>&prompt.root;<command>drbdadm create-md nfs-share</command>
-&prompt.root;<command>drbdadm create-md nfs-state</command></screen>
+<screen>&prompt.root;<command>crm cluster run "drbdadm create-md nfs"</command></screen>
      </step>
      <step>
       <para>
-       Create the DRBD devices. Run these commands on
-       <emphasis>both</emphasis> nodes:
+       Create the DRBD devices:
       </para>
-<screen>&prompt.root;<command>drbdadm up nfs-share</command>
-&prompt.root;<command>drbdadm up nfs-state</command></screen>
+<screen>&prompt.root;<command>crm cluster run "drbdadm up nfs"</command></screen>
      </step>
      <step>
       <para>
-       The devices do not have data yet, so
-       you can run these commands to skip the initial synchronization:
+       The devices do not have data yet, so you can run these commands to
+       skip the initial synchronization:
       </para>
-<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-share</command>
-&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs-state</command></screen>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/1</command>
+&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/2</command></screen>
      </step>
      <step>
        <para>Make <systemitem>&node1;</systemitem> primary:</para>
-<screen>&prompt.root;<command>drbdadm primary --force nfs-share</command>
-&prompt.root;<command>drbdadm primary --force nfs-state</command></screen>
+<screen>&prompt.root;<command>drbdadm primary --force nfs</command></screen>
      </step>
       <step>
-       <para>Check the DRBD status of <literal>nfs-share</literal>:</para>
-<screen>&prompt.root;<command>drbdadm status nfs-share</command></screen>
+       <para>Check the DRBD status of <literal>nfs</literal>:</para>
+<screen>&prompt.root;<command>drbdadm status nfs</command></screen>
        <para>This returns the following message:</para>
-<screen>nfs-share role:Primary
-  disk:UpToDate
-  &node1; role:Secondary
-    peer-disk:UpToDate</screen>
-     <para>
-      Checking the status of <literal>nfs-state</literal> should return the same message.
-     </para>
+<screen>nfs role:Primary
+  volume:1 disk:UpToDate
+  volume:2 disk:UpToDate
+  &node2; role:Secondary
+    volume:1 peer-disk:UpToDate
+    volume:2 peer-disk:UpToDate</screen>
      </step>
     </procedure>
     <para>
@@ -409,20 +380,6 @@ include /etc/drbd.d/*.res;</screen>
       <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
      </step>
     </procedure>
-    <warning>
-     <title>Low lease time can cause loss of file state</title>
-     <para>
-      NFS clients regularly renew their state with the NFS server. If the lease time
-      is too low, operating system or network delays can cause the timer to expire
-      before the renewal is complete, leading to loss of file state and I/O errors.
-     </para>
-     <para>
-      <literal>NFSV4LEASETIME</literal> is set on the NFS server in the file
-      <filename>/etc/sysconfig/nfs</filename>. The default is 90 seconds.
-      If lowering the lease time is necessary, we recommend a value of 60 or
-      higher. We strongly discourage values lower than 30.
-     </para>
-    </warning>
    </sect2>
   </sect1>
 
@@ -496,14 +453,14 @@ include /etc/drbd.d/*.res;</screen>
     <listitem>
         <para>Into this export directory, the cluster mounts an
             <literal>ext4</literal> file system from the DRBD device
-         <filename>/dev/drbd1</filename>.
+         <filename>/dev/drbd2</filename>.
          This DRBD device sits on top of an LVM logical volume named
          <literal>/dev/nfs/share</literal>.
         </para>
     </listitem>
     <listitem>
      <para>
-      A second DRBD device, <literal>/dev/drbd2</literal>, is used to share the
+      The DRBD device <literal>/dev/drbd1</literal> is used to share the
       NFS client states from <filename>/var/lib/nfs</filename>. This DRBD device
       sits on top of an LVM logical volume named <literal>/dev/nfs/state</literal>.
      </para>
@@ -513,11 +470,11 @@ include /etc/drbd.d/*.res;</screen>
   <sect2 xml:id="sec-ha-quick-nfs-resources-drbd">
    <title>Creating DRBD primitive and promotable clone resources</title>
    <para>
-    First, create cluster resources to manage the DRBD devices, and promotable
-    clones to allow these resources to run on both nodes.
+    Create a cluster resource to manage the DRBD devices, and a promotable
+    clone to allow this resource to run on both nodes.
    </para>
    <procedure>
-    <title>Creating DRBD resources for NFS</title>
+    <title>Creating a DRBD resource for NFS</title>
     <step>
      <para>
       Log in as &rootuser; and start the <command>crm</command> interactive shell:
@@ -526,39 +483,24 @@ include /etc/drbd.d/*.res;</screen>
     </step>
     <step>
      <para>
-      Create a primitive for the DRBD device <literal>nfs-share</literal>:
+      Create a primitive for the DRBD configuration <literal>nfs</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>primitive drbd_nfs-share ocf:linbit:drbd \
-  params drbd_resource="nfs-share" \
-  op monitor interval="15" role="Promoted" \
-  op monitor interval="30" role="Unpromoted"</command></screen>
+<screen>&prompt.crm.conf;<command>primitive drbd_nfs ocf:linbit:drbd \
+  params drbd_resource="nfs" \
+  op monitor interval=15 role=Promoted timeout=20 \
+  op monitor interval=30 role=Unpromoted timeout=20 \
+  op start timeout=240 interval=0s \
+  op promote timeout=90 interval=0s \
+  op demote timeout=90 interval=0s \
+  op stop timeout=100 interval=0s</command></screen>
     </step>
     <step>
      <para>
-      Create a primitive for the DRBD device <literal>nfs-state</literal>:
+      Create a promotable clone for the <literal>drbd_nfs</literal> primitive:
      </para>
-<screen>&prompt.crm.conf;<command>primitive drbd_nfs-state ocf:linbit:drbd \
-  params drbd_resource="nfs-state" \
-  op monitor interval="15" role="Promoted" \
-  op monitor interval="30" role="Unpromoted"</command></screen>
-    </step>
-    <step>
-     <para>
-      Create a promotable clone for the <literal>drbd_nfs-share</literal>
-      primitive:
-     </para>
-<screen>&prompt.crm.conf;<command>clone cl_nfs-share drbd_nfs-share \
+<screen>&prompt.crm.conf;<command>clone cl_nfs drbd_nfs \
   meta promotable="true" promoted-max="1" promoted-node-max="1" \
-  clone-max="2" clone-node-max="1" notify="true"</command></screen>
-    </step>
-    <step>
-     <para>
-      Create a promotable clone for the <literal>drbd_nfs-state</literal>
-      primitive:
-     </para>
-<screen>&prompt.crm.conf;<command>clone cl_nfs-state drbd_nfs-state \
-  meta promotable="true" promoted-max="1" promoted-node-max="1" \
-  clone-max="2" clone-node-max="1" notify="true"</command></screen>
+  clone-max="2" clone-node-max="1" notify="true" interleave=true</command></screen>
     </step>
     <step>
      <para>
@@ -578,7 +520,7 @@ include /etc/drbd.d/*.res;</screen>
   <sect2 xml:id="sec-ha-quick-nfs-resources-lvm">
    <title>Creating file system resources</title>
    <para>
-    Next, create cluster resources to manage the file systems for export and
+    Create cluster resources to manage the file systems for export and
     state tracking. <emphasis>Do not</emphasis> commit this configuration until
     after you add the colocation and order constraints.
    </para>
@@ -586,48 +528,47 @@ include /etc/drbd.d/*.res;</screen>
     <title>Creating file system resources for NFS</title>
     <step>
      <para>
-      Create a primitive for the file system to be exported on
-      <literal>/dev/drbd1</literal>:
-     </para>
-<screen>&prompt.crm.conf;<command>primitive fs_nfs-share Filesystem \
-  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4 \
-  op monitor interval="30s"</command></screen>
-    </step>
-    <step>
-     <para>
-      Create a primitive for the NFS client states on <literal>/dev/drbd2</literal>:
+      Create a primitive for the NFS client states on <literal>/dev/drbd1</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-state Filesystem \
-  params device=/dev/drbd2 directory=/var/lib/nfs fstype=ext4 \
-  op monitor interval="30s"</command></screen>
+  params device=/dev/drbd1 directory=/var/lib/nfs fstype=ext4 \
+  op monitor interval=30s timeout=40s \
+  op start timeout=60s interval=0s \
+  op stop timeout=60s interval=0s</command></screen>
     </step>
     <step>
      <para>
-      Add a colocation constraint to make sure that the two resources
-      always start on the same node:
+      Create a primitive for the file system to be exported on
+      <literal>/dev/drbd2</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co_nfs-share-with-nfs-state \
-  inf: fs_nfs-share fs_nfs-state</command></screen>
+<screen>&prompt.crm.conf;<command>primitive fs_nfs-share Filesystem \
+  params device=/dev/drbd2 directory=/srv/nfs/share fstype=ext4 \
+  op monitor interval=30s timeout=40s \
+  op start timeout=60s interval=0s \
+  op stop timeout=60s interval=0s</command></screen>
     </step>
     <step>
      <para>
-      Add colocation constraints to make sure that each resource always starts
-      on the node where the related DRBD promotable clone is in the primary role:
+      Add both of these resources to a resource group named <literal>g_nfs</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>colocation co_nfs-share-on-drbd \
-  inf: fs_nfs-share cl_nfs-share:Promoted</command>
-&prompt.crm.conf;<command>colocation co_nfs-state-on-drbd \
-  inf: fs_nfs-state cl_nfs-state:Promoted</command></screen>
+<screen>&prompt.crm.conf;<command>group g_nfs fs_nfs-state fs_nfs-share</command></screen>
+     <para>
+      Resources start in the order they are added to the group, and stop in the reverse order.
+     </para>
     </step>
     <step>
      <para>
-      Add order constraints to make sure the DRBD promotable clones always start
-      before the file system resources:
+      Add a colocation constraint to make sure that the resource group always
+      starts on the node where the DRBD promotable clone is in the primary role:
      </para>
-<screen>&prompt.crm.conf;<command>order o_drbd-before-nfs-share \
-  Mandatory: cl_nfs-share:promote fs_nfs-share:start</command>
-&prompt.crm.conf;<command>order o_drbd-before-nfs-state \
-  Mandatory: cl_nfs-state:promote fs_nfs-state:start</command></screen>
+<screen>&prompt.crm.conf;<command>colocation co_nfs-on-drbd inf: g_nfs cl_nfs:Promoted</command></screen>
+    </step>
+    <step>
+     <para>
+      Add an order constraint to make sure the DRBD promotable clone always
+      starts before the resource group:
+     </para>
+<screen>&prompt.crm.conf;<command>order o_drbd-before-nfs Mandatory: cl_nfs:promote g_nfs:start</command></screen>
     </step>
     <step>
      <para>
@@ -637,33 +578,69 @@ include /etc/drbd.d/*.res;</screen>
     </step>
    </procedure>
    <para>
-    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/srv/nfs/share</filename>,
-    and <literal>/dev/drbd2</literal> to <filename>/var/lib/nfs</filename>. Confirm this
+    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/var/lib/nfs</filename>,
+    and <literal>/dev/drbd2</literal> to <filename>srv/nfs/share</filename>. Confirm this
     with <command>mount</command>, or by looking at <filename >/proc/mounts</filename>.
    </para>
   </sect2>
 
-  <sect2 xml:id="sec-ha-quick-nfs-resources-nffserver-exportfs-vip">
-   <title>Creating NFS supporting resources</title>
+  <sect2 xml:id="sec-ha-quick-nfs-resources-nfsserver">
+   <title>Creating an NFS kernel server resource</title>
    <para>
-    Finally, create cluster resources for the NFS server daemon, the NFS exports,
-    and the virtual IP address. <emphasis>Do not</emphasis> commit this configuration
-    until after you add the colocation and order constraints.
+    Create a cluster resource to manage the NFS server daemon.
    </para>
    <para>
-    Make sure the package <package>nfs-kernel-server</package> is installed before
-    performing this procedure.
+    Make sure the package <package>nfs-kernel-server</package> is installed on
+    both nodes before performing this procedure.
    </para>
    <procedure>
-    <title>Creating supporting resources for NFS</title>
+    <title>Creating an NFS kernel server resource</title>
     <step>
      <para>
       Create a primitive to manage the NFS server daemon:
      </para>
 <screen>&prompt.crm.conf;<command>primitive p_nfsserver nfsserver \
   params nfs_server_scope=SUSE \
-  op monitor interval=10s timeout=20s</command></screen>
+  op monitor timeout=20s interval=10s \
+  op start timeout=40s interval=0s \
+  op stop timeout=20s interval=0s</command></screen>
+     <warning>
+      <title>Low lease time can cause loss of file state</title>
+      <para>
+       NFS clients regularly renew their state with the NFS server. If the lease time
+       is too low, operating system or network delays can cause the timer to expire
+       before the renewal is complete, leading to loss of file state and I/O errors.
+      </para>
+      <para>
+       <literal>NFSV4LEASETIME</literal> is set on the NFS server in the file
+       <filename>/etc/sysconfig/nfs</filename>. The default is 90 seconds.
+       If lowering the lease time is necessary, we recommend a value of 60 or
+       higher. We strongly discourage values lower than 30.
+      </para>
+     </warning>
     </step>
+    <step>
+     <para>
+      Append this resource to the existing <literal>g_nfs</literal> resource group:
+     </para>
+<screen>&prompt.crm.conf;<command>modgroup g_nfs add p_nfsserver</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+   </procedure>
+  </sect2>
+
+  <sect2 xml:id="sec-ha-quick-nfs-resources-nfsexport">
+   <title>Creating an NFS export resource</title>
+   <para>
+    Create a cluster resource to manage the NFS exports.
+   </para>
+   <procedure>
+    <title>Creating an NFS export resource</title>
      <step>
       <para>
        Create a primitive for the NFS exports:
@@ -671,12 +648,20 @@ include /etc/drbd.d/*.res;</screen>
 <screen>&prompt.crm.conf;<command>primitive p_exportfs exportfs \
   params directory="/srv/nfs/share" \
   options="rw,mountpoint" clientspec="*" fsid=100 \
-  op monitor interval=30s</command></screen>
+  op monitor interval=30s timeout=90s \
+  op start timeout=40s interval=0s \
+  op stop timeout=120s interval=0s</command></screen>
+      <para>
+       The value of <literal>op monitor timeout</literal> must be higher
+       than the value of <literal>stonith-timeout</literal>. To find the
+       <literal>stonith-timeout</literal> value, run <command>crm configure show</command>
+       and look under the <literal>property</literal> section.
+      </para>
       <important>
        <title>Do not set <literal>wait_for_leasetime_on_stop=true</literal></title>
        <para>
-        Setting this option to <literal>true</literal>
-        in a highly available NFS setup can cause unnecessary delays and loss of locks.
+        Setting this option to <literal>true</literal> in a highly available
+        NFS setup can cause unnecessary delays and loss of locks.
        </para>
        <para>
         The default value for <literal>wait_for_leasetime_on_stop</literal> is
@@ -686,31 +671,12 @@ include /etc/drbd.d/*.res;</screen>
        </para>
       </important>
      </step>
-    <step>
-     <para>
-      Create a primitive for the virtual IP address:
-     </para>
-<screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 \
-  params ip=&nfs-vip-exports; \
-  op monitor interval=10 timeout=20</command></screen>
-    </step>
-    <step>
-     <para>
-      Add a colocation constraint to make sure that the NFS server daemon,
-      the NFS exports, and the virtual IP address all start on the same node
-      as the file system resources:
-     </para>
-<screen>&prompt.crm.conf;<command>colocation co_nfs-resources-with-filesystem \
-  inf: vip_nfs p_exportfs p_nfsserver ( fs_nfs-share fs_nfs-state )</command></screen>
-    </step>
-    <step>
-     <para>
-      Add an order constraint to make sure that the file system resources always start
-      before the NFS server daemon, the NFS exports, and finally the virtual IP address:
-     </para>
-<screen>&prompt.crm.conf;<command>order o_filesystem-before-nfs-resources \
-  Mandatory: ( fs_nfs-share fs_nfs-state ) p_nfsserver p_exportfs vip_nfs</command></screen>
-    </step>
+     <step>
+      <para>
+       Append this resource to the existing <literal>g_nfs</literal> resource group:
+      </para>
+ <screen>&prompt.crm.conf;<command>modgroup g_nfs add p_exportfs</command></screen>
+     </step>
     <step>
      <para>
       Commit this configuration:
@@ -719,16 +685,42 @@ include /etc/drbd.d/*.res;</screen>
     </step>
     <step>
      <para>
-      Leave the <command>crm</command> interactive shell:
-     </para>
-<screen>&prompt.crm.conf;<command>quit</command></screen>
-    </step>
-    <step>
-     <para>
       Confirm that the NFS exports are set up properly:
      </para>
 <screen>&prompt.root;<command>exportfs -v</command>
 /srv/nfs/share   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
+    </step>
+   </procedure>
+  </sect2>
+
+  <sect2 xml:id="sec-ha-quick-nfs-resources-vip">
+   <title>Creating a virtual IP address for NFS exports</title>
+   <para>
+    Create a cluster resource to manage the virtual IP address for the NFS exports.
+   </para>
+   <procedure>
+    <title>Creating virtual IP address for NFS exports</title>
+    <step>
+     <para>
+      Create a primitive for the virtual IP address:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 \
+  params ip=&nfs-vip-exports; \
+  op monitor interval=10 timeout=20 \
+  op start timeout=20s interval=0s \
+  op stop timeout=20s interval=0s</command></screen>
+    </step>
+    <step>
+     <para>
+      Append this resource to the existing <literal>g_nfs</literal> resource group:
+     </para>
+<screen>&prompt.crm.conf;<command>modgroup g_nfs add vip_nfs</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
     </step>
    </procedure>
   </sect2>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -78,7 +78,7 @@
    </listitem>
    <listitem>
     <para>
-      A file system exported through NFS, and a separate file system used to track
+      A file system exported through NFS and a separate file system used to track
       the NFS client states.
     </para>
    </listitem>
@@ -194,7 +194,7 @@
     <title>Creating the DRBD configuration</title>
     <para>
      DRBD configuration files are kept in the <filename>/etc/drbd.d/</filename>
-     directory, and must end with a <filename class="extension">.res</filename>
+     directory and must end with a <filename class="extension">.res</filename>
      extension. In this procedure, the configuration file is named
      <filename>/etc/drbd.d/nfs.res</filename>.
     </para>
@@ -261,7 +261,7 @@
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-protocol">
         <para>The protocol to use for this connection. Protocol <literal>C</literal>
-         provides better data availability, and does not consider a write to be
+         provides better data availability and does not consider a write to be
          complete until it has reached all local and remote disks.
         </para>
        </callout>
@@ -551,7 +551,7 @@ include /etc/drbd.d;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>group g-nfs fs-nfs-state fs-nfs-share</command></screen>
      <para>
-      Resources start in the order they are added to the group, and stop in the reverse order.
+      Resources start in the order they are added to the group and stop in reverse order.
      </para>
     </step>
     <step>
@@ -703,7 +703,7 @@ include /etc/drbd.d;</screen>
     Create a cluster resource to manage the virtual IP address for the NFS exports:
    </para>
    <procedure xml:id="pro-ha-nfs-create-vip-resource">
-    <title>Creating virtual IP address for NFS exports</title>
+    <title>Creating a virtual IP address for NFS exports</title>
     <step>
      <para>
       Create a primitive for the virtual IP address:

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -271,12 +271,37 @@
      <step>
       <para>
        Create the file <filename>/etc/drbd.d/nfs-state.res</filename> with the
-       same contents as <filename>/etc/drbd.d/nfs-share.res</filename>, but
-       change the following lines:
+       following contents. The differences from <filename>/etc/drbd.d/nfs-share.res</filename>
+       are shown in bold:
       </para>
 <screen>resource nfs_<emphasis role="bold">state</emphasis> {
-   device /dev/drbd<emphasis role="bold">2</emphasis> minor <emphasis role="bold">2</emphasis>;
-   disk   /dev/nfs/<emphasis role="bold">state</emphasis>;</screen>
+   device /dev/<emphasis role="bold">drbd2 minor 2</emphasis>;
+   disk   /dev/nfs/<emphasis role="bold">state</emphasis>;
+   meta-disk internal;
+
+   net {
+      protocol  C;
+      fencing resource-and-stonith;
+   }
+
+   handlers {
+      fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
+      after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
+      # ...
+   }
+
+   connection-mesh {
+      hosts     &node1; &node2;;
+   }
+   on &node1; {
+      address   &subnetI;.1:<emphasis role="bold">&drbd.port2;</emphasis>;
+      node-id   0;
+   }
+   on &node2; {
+      address   &subnetI;.2:<emphasis role="bold">&drbd.port2;</emphasis>;
+      node-id   1;
+   }
+}</screen>
      </step>
      <step>
       <para>
@@ -311,8 +336,8 @@ include /etc/drbd.d/*.res;</screen>
      <title>Activating DRBD devices</title>
      <step>
       <para>
-       If you use a firewall in your cluster, open port
-       <systemitem>&drbd.port;</systemitem> in your firewall configuration.
+       If you use a firewall in the cluster, open ports <systemitem>&drbd.port;</systemitem>
+       and <systemitem>&drbd.port2;</systemitem> in the firewall configuration.
       </para>
      </step>
      <step>
@@ -625,6 +650,10 @@ include /etc/drbd.d/*.res;</screen>
     and the virtual IP address. <emphasis>Do not</emphasis> commit this configuration
     until after you add the colocation and order constraints.
    </para>
+   <para>
+    Make sure the package <package>nfs-kernel-server</package> is installed before
+    performing this procedure.
+   </para>
    <procedure>
     <title>Creating supporting resources for NFS</title>
     <step>
@@ -657,13 +686,6 @@ include /etc/drbd.d/*.res;</screen>
        </para>
       </important>
      </step>
-     <step>
-      <para>
-       Confirm that the NFS exports are set up properly:
-      </para>
-<screen>&prompt.root;<command>exportfs -v</command>
-/srv/nfs/share   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
-     </step>
     <step>
      <para>
       Create a primitive for the virtual IP address:
@@ -694,6 +716,19 @@ include /etc/drbd.d/*.res;</screen>
       Commit this configuration:
      </para>
 <screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+    <step>
+     <para>
+      Leave the <command>crm</command> interactive shell:
+     </para>
+<screen>&prompt.crm.conf;<command>quit</command></screen>
+    </step>
+    <step>
+     <para>
+      Confirm that the NFS exports are set up properly:
+     </para>
+<screen>&prompt.root;<command>exportfs -v</command>
+/srv/nfs/share   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
     </step>
    </procedure>
   </sect2>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -101,13 +101,13 @@
  </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-lvm">
-   <title>Creating an LVM device</title>
+   <title>Creating LVM devices</title>
    <para>LVM (<emphasis>Logical Volume Manager</emphasis>) enables
     flexible distribution of hard disk space over several file
     systems.
    </para>
-   <para>To prepare your disks for LVM, do the following:</para>
    <procedure>
+    <title>Creating LVM devices for DRBD</title>
     <step>
      <para>
       Create an LVM physical volume and replace <filename>/dev/sdb1</filename>
@@ -121,11 +121,17 @@
     </step>
     <step>
       <para>
-       Create one or more logical volumes in the volume group
-       <systemitem>nfs</systemitem>. This example assumes a 20 gigabyte volume,
-        named <systemitem>work</systemitem>:
+       Create a logical volume named <systemitem>exportfs</systemitem> in the
+       volume group <systemitem>nfs</systemitem>:
       </para>
-      <screen>&prompt.root;<command>lvcreate -n work -L 20G nfs</command></screen>
+      <screen>&prompt.root;<command>lvcreate -n exportfs -L 20G nfs</command></screen>
+     </step>
+     <step>
+      <para>
+       Create a second logical volume, named <systemitem>state</systemitem>,
+       in the volume group <systemitem>nfs</systemitem>:
+      </para>
+      <screen>&prompt.root;<command>lvcreate -n state -L 20G nfs</command></screen>
      </step>
      <step>
       <para>
@@ -133,11 +139,9 @@
 <screen>&prompt.root;<command>vgchange -ay nfs</command></screen>
      </step>
    </procedure>
-   <para>After you have successfully executed the above steps, your system
-    will make visible the following device: <filename>/dev/<replaceable
-     >VOLGROUP</replaceable>/<replaceable
-      >LOGICAL_VOLUME</replaceable></filename>.
-    In this case it will be <filename>/dev/nfs/work</filename>.
+   <para>
+    You should now see the following devices on the system:
+    <filename>/dev/nfs/exportfs</filename> and <filename>/dev/nfs/state</filename>.
    </para>
   </sect1>
 

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -206,12 +206,12 @@
       </para>
 <screen>resource nfs {
    volume 0 { <co xml:id="co-ha-quick-nfs-drbd-volume"/>
-      device           /dev/drbd1 minor 1; <co xml:id="co-ha-quick-nfs-drbd-device"/>
+      device           /dev/drbd0; <co xml:id="co-ha-quick-nfs-drbd-device"/>
       disk             /dev/nfs/state; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
       meta-disk        internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
    }
    volume 1 {
-      device           /dev/drbd2 minor 2;
+      device           /dev/drbd1;
       disk             /dev/nfs/share;
       meta-disk        internal;
    }
@@ -362,7 +362,7 @@ include /etc/drbd.d/*.res;</screen>
     </procedure>
     <para>
      You can access the DRBD resources on the block devices
-     <filename>/dev/drbd1</filename> and <filename>/dev/drbd2</filename>.
+     <filename>/dev/drbd0</filename> and <filename>/dev/drbd1</filename>.
      </para>
    </sect2>
 
@@ -376,15 +376,15 @@ include /etc/drbd.d/*.res;</screen>
      <title>Creating file systems for DRBD</title>
      <step>
       <para>
-       Create an <literal>ext4</literal> file system on <filename>/dev/drbd1</filename>:
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd0</filename>:
       </para>
-      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd0</command></screen>
      </step>
      <step>
       <para>
-       Create an <literal>ext4</literal> file system on <filename>/dev/drbd2</filename>:
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd1</filename>:
       </para>
-      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
      </step>
     </procedure>
    </sect2>
@@ -460,14 +460,14 @@ include /etc/drbd.d/*.res;</screen>
     <listitem>
         <para>Into this export directory, the cluster mounts an
             <literal>ext4</literal> file system from the DRBD device
-         <filename>/dev/drbd2</filename>.
+         <filename>/dev/drbd1</filename>.
          This DRBD device sits on top of an LVM logical volume named
          <literal>/dev/nfs/share</literal>.
         </para>
     </listitem>
     <listitem>
      <para>
-      The DRBD device <literal>/dev/drbd1</literal> is used to share the
+      The DRBD device <literal>/dev/drbd0</literal> is used to share the
       NFS client states from <filename>/var/lib/nfs</filename>. This DRBD device
       sits on top of an LVM logical volume named <literal>/dev/nfs/state</literal>.
      </para>
@@ -494,12 +494,8 @@ include /etc/drbd.d/*.res;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>primitive drbd_nfs ocf:linbit:drbd \
   params drbd_resource="nfs" \
-  op monitor interval=15 role=Promoted timeout=20 \
-  op monitor interval=30 role=Unpromoted timeout=20 \
-  op start timeout=240 interval=0s \
-  op promote timeout=90 interval=0s \
-  op demote timeout=90 interval=0s \
-  op stop timeout=100 interval=0s</command></screen>
+  op monitor interval=15 role=Promoted \
+  op monitor interval=30 role=Unpromoted</command></screen>
     </step>
     <step>
      <para>
@@ -535,24 +531,18 @@ include /etc/drbd.d/*.res;</screen>
     <title>Creating file system resources for NFS</title>
     <step>
      <para>
-      Create a primitive for the NFS client states on <literal>/dev/drbd1</literal>:
+      Create a primitive for the NFS client states on <literal>/dev/drbd0</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-state Filesystem \
-  params device=/dev/drbd1 directory=/var/lib/nfs fstype=ext4 \
-  op monitor interval=30s timeout=40s \
-  op start timeout=60s interval=0s \
-  op stop timeout=60s interval=0s</command></screen>
+  params device=/dev/drbd0 directory=/var/lib/nfs fstype=ext4</command></screen>
     </step>
     <step>
      <para>
       Create a primitive for the file system to be exported on
-      <literal>/dev/drbd2</literal>:
+      <literal>/dev/drbd1</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-share Filesystem \
-  params device=/dev/drbd2 directory=/srv/nfs/share fstype=ext4 \
-  op monitor interval=30s timeout=40s \
-  op start timeout=60s interval=0s \
-  op stop timeout=60s interval=0s</command></screen>
+  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4</command></screen>
     </step>
     <step>
      <para>
@@ -585,8 +575,8 @@ include /etc/drbd.d/*.res;</screen>
     </step>
    </procedure>
    <para>
-    Pacemaker mounts <literal>/dev/drbd1</literal> to <filename>/var/lib/nfs</filename>,
-    and <literal>/dev/drbd2</literal> to <filename>srv/nfs/share</filename>. Confirm this
+    Pacemaker mounts <literal>/dev/drbd0</literal> to <filename>/var/lib/nfs</filename>,
+    and <literal>/dev/drbd1</literal> to <filename>srv/nfs/share</filename>. Confirm this
     with <command>mount</command>, or by looking at <filename >/proc/mounts</filename>.
    </para>
   </sect2>
@@ -607,10 +597,7 @@ include /etc/drbd.d/*.res;</screen>
       Create a primitive to manage the NFS server daemon:
      </para>
 <screen>&prompt.crm.conf;<command>primitive p_nfsserver nfsserver \
-  params nfs_server_scope=SUSE \
-  op monitor timeout=20s interval=10s \
-  op start timeout=40s interval=0s \
-  op stop timeout=20s interval=0s</command></screen>
+  params nfs_server_scope=SUSE nfs_shared_infodir="/var/lib/nfs"</command></screen>
      <warning>
       <title>Low lease time can cause loss of file state</title>
       <para>
@@ -654,10 +641,8 @@ include /etc/drbd.d/*.res;</screen>
       </para>
 <screen>&prompt.crm.conf;<command>primitive p_exportfs exportfs \
   params directory="/srv/nfs/share" \
-  options="rw,mountpoint" clientspec="*" fsid=101 \
-  op monitor interval=30s timeout=90s \
-  op start timeout=40s interval=0s \
-  op stop timeout=120s interval=0s</command></screen>
+  options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=101 \
+  op monitor interval=30s timeout=90s</command></screen>
       <para>
        The value of <literal>op monitor timeout</literal> must be higher
        than the value of <literal>stonith-timeout</literal>. To find the
@@ -712,10 +697,7 @@ include /etc/drbd.d/*.res;</screen>
       Create a primitive for the virtual IP address:
      </para>
 <screen>&prompt.crm.conf;<command>primitive vip_nfs IPaddr2 \
-  params ip=&nfs-vip-exports; \
-  op monitor interval=10 timeout=20 \
-  op start timeout=20s interval=0s \
-  op stop timeout=20s interval=0s</command></screen>
+  params ip=&nfs-vip-exports;</command></screen>
     </step>
     <step>
      <para>
@@ -802,7 +784,7 @@ include /etc/drbd.d/*.res;</screen>
   to the cluster.
  </para>
  <para>
-  In this example, a new DRBD device named <literal>/dev/drbd3</literal> sits
+  In this example, a new DRBD device named <literal>/dev/drbd2</literal> sits
   on top of an LVM logical volume named <literal>/dev/nfs/share2</literal>.
  </para>
  <procedure>
@@ -819,7 +801,7 @@ include /etc/drbd.d/*.res;</screen>
     under the existing volumes:
    </para>
 <screen>   volume 2 {
-      device           /dev/drbd3;
+      device           /dev/drbd2;
       disk             /dev/nfs/share2;
       meta-disk        internal;
    }</screen>
@@ -858,9 +840,9 @@ include /etc/drbd.d/*.res;</screen>
   <step>
    <para>
     On the node that is in the <literal>Primary</literal> role, create an
-    <literal>ext4</literal> file system on <literal>/dev/drbd3</literal>:
+    <literal>ext4</literal> file system on <literal>/dev/drbd2</literal>:
    </para>
-<screen>&prompt.root;<command>mkfs.ext4 /dev/drbd3</command></screen>
+<screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
   </step>
   <step>
    <para>
@@ -870,13 +852,10 @@ include /etc/drbd.d/*.res;</screen>
   </step>
   <step>
    <para>
-    Create a primitive for the file system to be exported on <literal>/dev/drbd3</literal>:
+    Create a primitive for the file system to be exported on <literal>/dev/drbd2</literal>:
    </para>
 <screen>&prompt.crm.conf;<command>primitive fs_nfs-share2 Filesystem \
-  params device="/dev/drbd3" directory="/srv/nfs/share2" fstype=ext4 \
-  op monitor interval=30s timeout=40s \
-  op start timeout=60s interval=0s \
-  op stop timeout=60s interval=0s</command></screen>
+  params device="/dev/drbd2" directory="/srv/nfs/share2" fstype=ext4</command></screen>
   </step>
   <step>
    <para>
@@ -891,10 +870,8 @@ include /etc/drbd.d/*.res;</screen>
    </para>
 <screen>&prompt.crm.conf;<command>primitive p_exportfs2 exportfs \
   params directory="/srv/nfs/share2" \
-  options="rw,mountpoint" clientspec="*" fsid=102 \
-  op monitor interval=30s timeout=90s \
-  op start timeout=40s interval=0s \
-  op stop timeout=120s interval=0s</command></screen>
+  options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=102 \
+  op monitor interval=30s timeout=90s</command></screen>
   </step>
   <step>
    <para>
@@ -963,6 +940,12 @@ Full List of Resources
    <listitem>
     <para>
      For more information about DRBD, refer to <xref linkend="cha-ha-drbd"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     For more information about cluster resources, refer to
+     <xref linkend="sec-ha-config-basics-resources"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -31,6 +31,7 @@
 <!ENTITY s390          "S/390">
 
 <!ENTITY drbd.port "7790">
+<!ENTITY drbd.port2 "7791">
 
 <!ENTITY example1com    "example1.com">
 <!ENTITY example2com    "example2.com">

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -31,7 +31,6 @@
 <!ENTITY s390          "S/390">
 
 <!ENTITY drbd.port "7790">
-<!ENTITY drbd.port2 "7791">
 
 <!ENTITY example1com    "example1.com">
 <!ENTITY example2com    "example2.com">


### PR DESCRIPTION
### PR creator: Description

The approach detailed in the NFS guide was potentially harmful, as detailed in https://www.suse.com/support/kb/doc/?id=000020396. 

This new version describes a different approach that hopefully avoids the common pitfalls. 

Here is a PDF for anyone who wants to see a rendered version in addition to the diff: 
[article-nfs-storage_en.pdf](https://github.com/SUSE/doc-sleha/files/11539494/article-nfs-storage_en.pdf) **(updated 2023-05-23)**


### PR creator: Are there any relevant issues/feature requests?

* bsc#1201271
* jsc#DOCTEAM-473


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4
  
**Note** that I'll need to change `clone` back to `ms` for versions 12 SP5 and SP4.

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
