### PR TITLE
Clarify GFS2 read-only support

### DIFF
--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -35,6 +35,14 @@
         <dm:repository/>
       </dm:docmanager>
     </info>
+
+    <important>
+     <title>GFS2 support</title>
+     <para>
+      &suse; only supports GFS2 in read-only mode. Write operations are not supported.
+     </para>
+    </important>
+
     <sect1 xml:id="sec-ha-gfs2-utils">
   <title>GFS2 packages and management utilities</title>
 


### PR DESCRIPTION
### PR creator: Description

Added a warning that we only support read for GFS2, not write.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1209530
* jsc#DOCTEAM-936


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
