### PR TITLE
Terminology: 'split brain' to 'split-brain'

### DIFF
--- a/xml/geo_concept_i.xml
+++ b/xml/geo_concept_i.xml
@@ -232,7 +232,7 @@
      that have run the resources before.
     </para>
     <para>
-      If automatic failover in case of a split brain scenario is
+      If automatic failover in case of a split-brain scenario is
       <emphasis>not</emphasis> required, administrators can also grant manual
       tickets to the healthy site. How to manage tickets from command line is
       described in <xref linkend="sec-ha-geo-manage-cli" xrefstyle="select:label"/>.

--- a/xml/geo_manage_i.xml
+++ b/xml/geo_manage_i.xml
@@ -109,7 +109,7 @@ booth[27900]: 2014/08/13_10:21:23 info: revoke succeeded!</screen>
         <title>Automatic tickets</title>
         <para>As long as booth can make sure a ticket is granted to one site,
          you cannot grant the same ticket to another site, not even by using
-         the <option>-F</option> option. However, in case of a split brain
+         the <option>-F</option> option. However, in case of a split-brain
          situation, booth might not be able to check if an automatic ticket is
          granted somewhere else. In that case, the &geo; cluster
          administrator can override the automatic process and manually grant

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -701,7 +701,7 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
   <para>
    For example, if the command <command>vgcreate</command> uses the physical
    device instead of using the mirrored block device, DRBD will be confused.
-   This may result in a split brain condition for DRBD.
+   This may result in a split-brain condition for DRBD.
   </para>
 
   <para>

--- a/xml/ha_configuring_resources.xml
+++ b/xml/ha_configuring_resources.xml
@@ -1235,7 +1235,7 @@ IPMI STONITH external device (stonith:external/ipmi)
 
 ipmitool based power management. Apparently, the power off
 method of ipmitool is intercepted by ACPI which then makes
-a regular shutdown. If case of a split brain on a two-node
+a regular shutdown. If case of a split-brain on a two-node
 it may happen that no node survives. For two-node clusters
 use only the reset method.
 

--- a/xml/ha_configuring_resources.xml
+++ b/xml/ha_configuring_resources.xml
@@ -1235,8 +1235,8 @@ IPMI STONITH external device (stonith:external/ipmi)
 
 ipmitool based power management. Apparently, the power off
 method of ipmitool is intercepted by ACPI which then makes
-a regular shutdown. If case of a split-brain on a two-node
-it may happen that no node survives. For two-node clusters
+a regular shutdown. In case of a split brain on a two-node,
+it may happen that no node survives. For two-node clusters,
 use only the reset method.
 
 Parameters (* denotes required, [] the default):

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -1167,7 +1167,7 @@ resource r0-U {
    <title>DRBD devices broken after reboot</title>
    <para>
     In cases when DRBD does not know which of the real devices holds the
-    latest data, it changes to a split brain condition. In this case, the
+    latest data, it changes to a split-brain condition. In this case, the
     respective DRBD subsystems come up as secondary and do not connect to
     each other. In this case, the following message can be found in the
     logging data:

--- a/xml/ha_fencing.xml
+++ b/xml/ha_fencing.xml
@@ -798,7 +798,7 @@ hostlist</screen>
     </term>
     <listitem>
      <para>
-      Article explaining the concepts of split brain, quorum, and fencing in
+      Article explaining the concepts of split-brain, quorum, and fencing in
       HA clusters.
      </para>
     </listitem>

--- a/xml/ha_fencing.xml
+++ b/xml/ha_fencing.xml
@@ -798,7 +798,7 @@ hostlist</screen>
     </term>
     <listitem>
      <para>
-      Article explaining the concepts of split-brain, quorum, and fencing in
+      Article explaining the concepts of split brain, quorum, and fencing in
       HA clusters.
      </para>
     </listitem>

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -147,7 +147,7 @@
     split into partitions but still active. They can only communicate with
     nodes in the same partition and are unaware of the separated nodes. As
     the loss of the nodes on the other partition cannot be confirmed, a
-    split brain scenario develops (see also
+    split-brain scenario develops (see also
     <xref linkend="glos-splitbrain"/>).
    </para>
   </glossdef>
@@ -431,7 +431,7 @@ performance will be met during a contractual measurement period.</para>
     <quote>quorate</quote>) if it has the majority of nodes (or votes).
     Quorum distinguishes exactly one partition. It is part of the algorithm
     to prevent several disconnected partitions or nodes from proceeding and
-    causing data and service corruption (split brain). Quorum is a
+    causing data and service corruption (split-brain). Quorum is a
     prerequisite for fencing, which then ensures that quorum is indeed
     unique.
    </para>
@@ -492,17 +492,17 @@ performance will be met during a contractual measurement period.</para>
   </glossdef>
  </glossentry>
 <!--taroth 2012-01-09: new term (merged from Fabian's version of ha_glossary.xml)-->
- <glossentry xml:id="glos-splitbrain"><glossterm>split brain</glossterm>
+ <glossentry xml:id="glos-splitbrain"><glossterm>split-brain</glossterm>
   <glossdef>
    <para>
     A scenario in which the cluster nodes are divided into two or more
     groups that do not know of each other (either through a software or
-    hardware failure). &stonith; prevents a split brain situation from badly
+    hardware failure). &stonith; prevents a split-brain situation from badly
     affecting the entire cluster. Also known as a <quote>partitioned
     cluster</quote> scenario.
    </para>
    <para>
-    The term split brain is also used in DRBD but means that the two nodes
+    The term split-brain is also used in DRBD but means that the two nodes
     contain different data.
    </para>
   </glossdef>

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -431,7 +431,7 @@ performance will be met during a contractual measurement period.</para>
     <quote>quorate</quote>) if it has the majority of nodes (or votes).
     Quorum distinguishes exactly one partition. It is part of the algorithm
     to prevent several disconnected partitions or nodes from proceeding and
-    causing data and service corruption (split-brain). Quorum is a
+    causing data and service corruption (split brain). Quorum is a
     prerequisite for fencing, which then ensures that quorum is indeed
     unique.
    </para>
@@ -502,7 +502,7 @@ performance will be met during a contractual measurement period.</para>
     cluster</quote> scenario.
    </para>
    <para>
-    The term split-brain is also used in DRBD but means that the two nodes
+    The term <literal>split brain</literal> is also used in DRBD but means that the two nodes
     contain different data.
    </para>
   </glossdef>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -659,7 +659,7 @@ Node <replaceable>&node2;</replaceable>: standby
     <para>
      The reason is that stopping &pace; also stops the &corosync; service on
      whose membership and messaging services DLM depends. If &corosync; stops,
-     the DLM resource will assume a split brain scenario and trigger a fencing
+     the DLM resource will assume a split-brain scenario and trigger a fencing
      operation.
     </para>
    </step>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -31,7 +31,7 @@
    <para>
     This chapter explains the concepts behind SBD. It guides you through
     configuring the components needed by SBD to protect your cluster from
-    potential data corruption in case of a split brain scenario.
+    potential data corruption in case of a split-brain scenario.
    </para>
    <para>
     In addition to node level fencing, you can use additional mechanisms for storage
@@ -65,12 +65,12 @@
       <para>
         However, network partitioning or software malfunction could potentially
         cause scenarios where several DCs are elected in a cluster. This
-        split brain scenario can cause data corruption.
+        split-brain scenario can cause data corruption.
       </para>
       <para>
-        Node fencing via &stonith; is the primary mechanism to prevent split brain.
+        Node fencing via &stonith; is the primary mechanism to prevent split-brain.
         Using SBD as a node fencing mechanism is one way of shutting down nodes
-        without using an external power off device in case of a split brain scenario.
+        without using an external power off device in case of a split-brain scenario.
       </para>
 
   <variablelist>
@@ -794,7 +794,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     Configure the SBD &stonith; resource. You do not need to clone this resource.
    </para>
    <para>
-    For a two-node cluster, in case of split brain, fencing is issued from
+    For a two-node cluster, in case of split-brain, fencing is issued from
     each node to the other as expected. To prevent both nodes from being reset at practically
     the same time, it is recommended to apply the following fencing
     delays to help one of the nodes, or even the preferred node, win the fencing match.
@@ -840,7 +840,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
       fencing delay so that it wins any fencing match.
       To make this succeed, each node must have two primitive &stonith;
       devices. In the following configuration, &node1; will win
-      and survive in case of a split brain scenario:
+      and survive in case of a split-brain scenario:
       </para>
 <screen>&prompt.crm.conf;<command>primitive st-sbd-&node1; stonith:external/sbd params \
 pcmk_host_list=&node1; pcmk_delay_base=20</command>
@@ -921,7 +921,7 @@ params pcmk_delay_max=30</command></screen>
          Do <emphasis>not</emphasis> use diskless SBD as a fencing mechanism
          for two-node clusters.
          Use diskless SBD only for clusters with three or more nodes.
-         SBD in diskless mode cannot handle split brain scenarios for two-node clusters.
+         SBD in diskless mode cannot handle split-brain scenarios for two-node clusters.
          If you want to use diskless SBD for two-node clusters, use &qdevice; as
          described in <xref linkend="cha-ha-qdevice"/>.
       </para>
@@ -1206,7 +1206,7 @@ Illegal request, Invalid opcode</screen>
     <para>
      Before acquiring protected resources, the node must first acquire the
      protecting lock. The ordering is enforced by Pacemaker. The sfex
-     component ensures that even if Pacemaker were subject to a split brain
+     component ensures that even if Pacemaker were subject to a split-brain
      situation, the lock will never be granted more than once.
     </para>
     <para>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -68,7 +68,7 @@
         split-brain scenario can cause data corruption.
       </para>
       <para>
-        Node fencing via &stonith; is the primary mechanism to prevent split-brain.
+        Node fencing via &stonith; is the primary mechanism to prevent split brain.
         Using SBD as a node fencing mechanism is one way of shutting down nodes
         without using an external power off device in case of a split-brain scenario.
       </para>
@@ -794,7 +794,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     Configure the SBD &stonith; resource. You do not need to clone this resource.
    </para>
    <para>
-    For a two-node cluster, in case of split-brain, fencing is issued from
+    For a two-node cluster, in case of split brain, fencing is issued from
     each node to the other as expected. To prevent both nodes from being reset at practically
     the same time, it is recommended to apply the following fencing
     delays to help one of the nodes, or even the preferred node, win the fencing match.

--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -542,7 +542,7 @@ INFO: [&node3;]
        <para>
         Check if the connection between your nodes is broken. Most often,
         this is the result of a badly configured firewall. This also may be
-        the reason for a <emphasis>split brain</emphasis> condition, where
+        the reason for a <emphasis>split-brain</emphasis> condition, where
         the cluster is partitioned.
        </para>
       </listitem>


### PR DESCRIPTION
This issue came up in https://github.com/SUSE/doc-sleha/pull/320.

### PR creator: Description

Change the spelling of 'split brain' to 'split-brain' across the complete set of SLE-HA docs. 


### PR creator: Are there any relevant issues/feature requests?

See https://github.com/SUSE/doc-sleha/pull/320#issuecomment-1541962795


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
