### PR TITLE
Upgrade chapter: add entries for SP5

### DIFF
--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -684,6 +684,36 @@
         </itemizedlist>
        </entry>
       </row>
+      <row>
+       <entry>
+        <para>SLE&nbsp;HA&nbsp;15&nbsp;SP4 to
+         SLE&nbsp;HA&nbsp;15&nbsp;SP5</para>
+       </entry>
+       <entry>
+        <para>Cluster Rolling Upgrade</para>
+       </entry>
+       <entry>
+        <itemizedlist>
+         <listitem>
+          <para>
+           Base System: &upgrade_guide; for
+           &slsa;&nbsp;15&nbsp;SP5
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           SLE&nbsp;HA:
+           <xref linkend="pro-ha-migration-rolling-upgrade" xrefstyle="select:title nopage"/>
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           SLE&nbsp;HA&nbsp;Geo: <xref linkend="cha-ha-geo-upgrade"/>
+          </para>
+         </listitem>
+        </itemizedlist>
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </informaltable>
@@ -1035,6 +1065,12 @@
      <para>
       Upgrading from SLE&nbsp;HA&nbsp;15&nbsp;SP3 to
       SLE&nbsp;HA&nbsp;15&nbsp;SP4
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Upgrading from SLE&nbsp;HA&nbsp;15&nbsp;SP4 to
+      SLE&nbsp;HA&nbsp;15&nbsp;SP5
      </para>
     </listitem>
 <!--<listitem>


### PR DESCRIPTION
### PR creator: Description

The Upgrade chapter was lacking entries for the latest SP version. 


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
