### PR TITLE
Admin Guide linkcheck: replace or remove commented links

### DIFF
--- a/xml/ha_agents.xml
+++ b/xml/ha_agents.xml
@@ -169,13 +169,13 @@
    </step>
   </procedure>
 
-  <!--taroth 2023-05-16: daps linkcheck failing, therefore commenting-->
-  <!--<para>
+  <para>
    More details about writing OCF resource agents can be found at
-   <link xlink:href="http://www.linux-ha.org/wiki/Resource_Agents"/>. Find
+   <link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/> in the guide
+   <citetitle>Pacemaker Administration</citetitle>. Find
    special information about several concepts at
    <xref linkend="cha-ha-concepts"/>.
-  </para>-->
+  </para>
  </sect1>
  <xi:include href="ha_error_codes.xml"/>
 </chapter>

--- a/xml/ha_fencing.xml
+++ b/xml/ha_fencing.xml
@@ -763,37 +763,14 @@ hostlist</screen>
      </para>
     </listitem>
    </varlistentry>
-   <!--taroth 2023-05-16: daps linkcheck failing, therefore commenting-->
-   <!--<varlistentry>
-    <term><link xlink:href="http://www.linux-ha.org/wiki/STONITH"/>
-    </term>
-    <listitem>
-     <para>
-      Information about &stonith; on the home page of The High
-      Availability Linux Project.
-     </para>
-    </listitem>
-   </varlistentry>-->
    <varlistentry>
     <term><link xlink:href="http://www.clusterlabs.org/pacemaker/doc/"/>
     </term>
     <listitem>
-     <itemizedlist>
-<!-- taroth 2015-05-06: commenting for now since it is a little bit outdated
-       (clones are still used in stonith configuration examples)
-       <listitem>
-       <para>
-       <citetitle>Configuring Fencing with crmsh</citetitle>: Information about
-       fencing on the home page of the Pacemaker Project.
-       </para>
-       </listitem>-->
-      <listitem>
-       <para>
-        &paceex;: Explains the concepts used to configure Pacemaker.
-        Contains comprehensive and detailed information for reference.
-       </para>
-      </listitem>
-     </itemizedlist>
+     <para>
+      &paceex;: Explains the concepts used to configure Pacemaker.
+      Contains comprehensive and detailed information for reference.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>

--- a/xml/ha_samba.xml
+++ b/xml/ha_samba.xml
@@ -658,12 +658,6 @@ Cluster AD member NETBIOS name = "CTDB-SERVER"</screen>-->
   <title>For more information</title>
 
   <itemizedlist>
-   <!--taroth 2023-05-16: daps linkcheck failing, therefore commenting-->
-   <!--<listitem>
-    <para>
-     <link xlink:href="http://www.linux-ha.org/doc/man-pages/re-ra-CTDB.html"/>
-    </para>
-   </listitem>-->
    <listitem>
     <para>
      <link xlink:href="http://wiki.samba.org/index.php/CTDB_Setup"/>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -1308,17 +1308,7 @@ Illegal request, Invalid opcode</screen>
  <sect1 xml:id="sec-ha-storage-protect-moreinfo">
   <title>For more information</title>
    <para>
-    For more details, see the man page of
-    <command>sdb</command>.
+    For more details, see <command>man sbd</command>.
    </para>
-  <!--taroth 2023-05-16: daps linkcheck failing, therefore commenting-->
-  <!--<itemizedlist>
-    <listitem>
-      <para><command>man sbd</command></para>
-    </listitem>
-     <listitem>
-      <para><link xlink:href="http://www.linux-ha.org/wiki/SBD_Fencing"/></para>
-    </listitem>
-  </itemizedlist>-->
  </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description

I checked the links that were commented out for the last loc drop, and mostly didn't find any good replacements, so I've removed most of them for good. I did replace one with a link to clusterlabs. 

It probably makes sense to backport this change, since the old links are presumably broken in the earlier versions, too.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
