### PR TITLE
NFS overhaul (for 12 SP5)

### DIFF
--- a/xml/art_sle_ha_install_quick.xml
+++ b/xml/art_sle_ha_install_quick.xml
@@ -52,7 +52,7 @@
     <listitem>
      <para>
       A floating, virtual IP address (<systemitem class="ipaddress"
-       >&subnetII;.1</systemitem>) which
+       >&subnetI;.1</systemitem>) which
       allows clients to connect to the service no matter which physical node it
       is running on.
      </para>
@@ -636,7 +636,7 @@ info: Received command test from &node1; on disk <replaceable>SBDDEVICE</replace
       virtual IP address.</para></step>
      <step>
       <para>Enter an unused IP address that you want to use as administration IP
-       for &hawk2;: <literal>&subnetII;.1</literal>
+       for &hawk2;: <literal>&subnetI;.1</literal>
       </para>
       <para>Instead of logging in to an individual cluster node with &hawk2;,
        you can connect to the virtual IP address.</para>
@@ -815,10 +815,10 @@ info: Received command test from &node1; on disk <replaceable>SBDDEVICE</replace
      <title>Testing Resource Failover</title>
      <step>
       <para>
-       Open a terminal and ping <systemitem>&subnetII;.1</systemitem>,
+       Open a terminal and ping <systemitem>&subnetI;.1</systemitem>,
        your virtual IP address:
       </para>
-      <screen>&prompt.root;<command>ping</command> &subnetII;.1</screen>
+      <screen>&prompt.root;<command>ping</command> &subnetI;.1</screen>
      </step>
      <step>
       <para>

--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -111,6 +111,50 @@
     </para>
 <screen>&prompt.root;<command>zypper install nfs-kernel-server</command></screen>
    </step>
+   <step>
+    <para>
+     On <emphasis>both</emphasis> nodes, set the NFS server scope:
+    </para>
+    <substeps>
+     <step>
+      <para>
+       Create a new directory named <filename>nfs-server.service.d</filename>:
+      </para>
+<screen>&prompt.root;<command>mkdir -p /etc/systemd/system/nfs-server.service.d</command></screen>
+     </step>
+     <step>
+      <para>
+       Create the file <filename>/etc/systemd/system/nfs-server.service.d/scope.conf</filename>
+       and add the following content:
+      </para>
+<screen>[Service]
+ExecStart= <co xml:id="co-nfs-server-empty-exec"/>
+ExecStart=/usr/sbin/rpc.nfsd --scope SUSE $RPCNFSDARGS <co xml:id="co-nfs-server-scope"/></screen>
+      <calloutlist>
+       <callout arearefs="co-nfs-server-empty-exec">
+        <para>
+         A service can only have one <literal>ExecStart</literal> setting, so the empty
+         <literal>ExecStart</literal> line in this override file is used to undo
+         any existing <literal>ExecStart</literal> setting in the NFS service file.
+        </para>
+       </callout>
+       <callout arearefs="co-nfs-server-scope">
+        <para>
+         The scope must be the same on all nodes in the cluster that run the NFS server.
+         All clusters using &suse; software can use the same scope, so we recommend setting
+         the value to <literal>SUSE</literal>.
+        </para>
+       </callout>
+      </calloutlist>
+     </step>
+     <step>
+      <para>
+       Reload the &systemd; files:
+      </para>
+<screen>&prompt.root;<command>systemctl daemon-reload</command></screen>
+     </step>
+    </substeps>
+   </step>
   </procedure>
  </sect1>
 
@@ -597,13 +641,7 @@ include /etc/drbd.d;</screen>
       Create a primitive to manage the NFS server daemon:
      </para>
 <screen>&prompt.crm.conf;<command>primitive nfsserver nfsserver \
-  params nfs_server_scope=SUSE nfs_shared_infodir="/var/lib/nfs"</command></screen>
-     <para>
-      The <literal>nfs_server_scope</literal> must be the same on all nodes in the
-      cluster that run the NFS server, but this is not set by default. All clusters
-      using &suse; software can use the same scope, so we recommend setting the value
-      to <literal>SUSE</literal>.
-     </para>
+  params nfs_shared_infodir="/var/lib/nfs"</command></screen>
      <warning>
       <title>Low lease time can cause loss of file state</title>
       <para>

--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -34,13 +34,12 @@
  <sect1 xml:id="sec-ha-quick-nfs-usagescenario">
   <title>Usage Scenario</title>
   <para>
-   This document will help you set up a highly available NFS server.
-   The cluster used to for the highly available NFS storage has the
+   This document helps you set up a highly available NFS server.
+   The cluster used for the highly available NFS storage has the
    following properties:
   </para>
 
   <itemizedlist>
-   <!-- Taken from art_sle_ha_install_quick.xml: -->
    <listitem>
     <para>
      Two nodes: <systemitem class="server">&node1;</systemitem> (IP: <systemitem
@@ -55,8 +54,8 @@
      Two floating, virtual IP addresses (<systemitem class="ipaddress"
       >&nfs-vip-hawk;</systemitem> and <systemitem class="ipaddress"
       >&nfs-vip-exports;</systemitem>), allowing clients to connect to
-     the service no matter which physical node it is running on.
-     One IP address is used for cluster administration with &hawk2;, the other
+     a service no matter which physical node it is running on.
+     One IP address is used for cluster administration with &hawk2;, and the other
      IP address is used exclusively for the NFS exports.
     </para>
    </listitem>
@@ -73,13 +72,14 @@
    </listitem>
    <listitem>
     <para>
-     Local storage on each host. The data is synchronized between the
-     hosts using DRBD on top of LVM.
+     Local storage on each node. The data is synchronized between the
+     nodes using DRBD on top of LVM.
     </para>
    </listitem>
    <listitem>
     <para>
-      A file system exported through NFS.
+      A file system exported through NFS and a separate file system used to track
+      the NFS client states.
     </para>
    </listitem>
   </itemizedlist>
@@ -92,23 +92,39 @@
  </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-installation">
-  <title>Installing a Basic Two-Node Cluster</title>
+  <title>Preparing a Two-node Cluster</title>
   <para>
-   Before you proceed, install and set up a basic two-node cluster. This task is
-   described in the &haquick;. The &haquick; describes
-   how to use the &crmshell; to set up a
-   cluster with minimal effort.
+   Before you can set up highly available NFS storage, you must prepare a &ha; cluster:
   </para>
+  <procedure xml:id="pro-ha-nfs-prepare-cluster">
+   <title>Preparing a Two-node Cluster for NFS Storage</title>
+   <step>
+    <para>
+     Install and set up a basic two-node cluster as described in
+     <link xlink:href="&doc-url;/html/SLE-HA-all/article-installation.html">&haquick;</link>.
+<!--trichardson 2023-05-17: using doc-url because this link needs to be version-specific, not generic-->
+    </para>
+   </step>
+   <step>
+    <para>
+     On <emphasis>both</emphasis> nodes, install the package <package>nfs-kernel-server</package>:
+    </para>
+<screen>&prompt.root;<command>zypper install nfs-kernel-server</command></screen>
+   </step>
+  </procedure>
  </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-lvm">
-   <title>Creating an LVM Device</title>
-   <para>LVM (<emphasis>Logical Volume Manager</emphasis>) enables
-    flexible distribution of hard disk space over several file
-    systems.
+   <title>Creating LVM Devices</title>
+   <para>
+    LVM (Logical Volume Manager) enables flexible distribution of storage space
+    across several file systems.
    </para>
-   <para>To prepare your disks for LVM, do the following:</para>
-   <procedure>
+   <para>
+    Use <command>crm cluster run</command> to run these commands on both nodes at once.
+   </para>
+   <procedure xml:id="pro-ha-nfs-create-lvm-devices">
+    <title>Creating LVM Devices for DRBD</title>
     <step>
      <para>
       Check if the locking type of LVM2 is cluster-aware. The keyword
@@ -120,44 +136,53 @@
     </step>
     <step>
      <para>
-      Create an LVM volume group and replace <filename>/dev/sdb<replaceable>X</replaceable></filename>
+      Create an LVM physical volume, replacing <filename>/dev/sdb1</filename>
       with your corresponding device for LVM:</para>
-     <screen>&prompt.root;<command>pvcreate</command> /dev/sdb<replaceable>X</replaceable></screen>
+     <screen>&prompt.root;<command>crm cluster run "pvcreate /dev/sdb1"</command></screen>
     </step>
     <step>
-     <para>Create an LVM Volume Group <systemitem>nfs</systemitem>
+     <para>Create an LVM volume group <systemitem>nfs</systemitem>
             that includes this physical volume: </para>
-     <screen>&prompt.root;<command>vgcreate</command> nfs /dev/sdb<replaceable>X</replaceable></screen>
+     <screen>&prompt.root;<command>crm cluster run "vgcreate nfs /dev/sdb1"</command></screen>
     </step>
     <step>
       <para>
-       Create one or more logical volumes in the volume group
-       <systemitem>nfs</systemitem>. This example assumes a 20 gigabyte volume,
-        named <systemitem>work</systemitem>:
+       Create a logical volume named <systemitem>share</systemitem> in the
+       volume group <systemitem>nfs</systemitem>:
       </para>
-      <screen>&prompt.root;<command>lvcreate</command> -n work -L 20G nfs</screen>
+      <screen>&prompt.root;<command>crm cluster run "lvcreate -n share -L 20G nfs"</command></screen>
+      <para>
+       This volume is for the NFS exports.
+      </para>
      </step>
      <step>
       <para>
-       Activate the volume group<!-- and create file systems on the new logical
-       volumes. This example assumes <literal>ext3</literal> as the file
-       system type-->: </para>
-<screen>&prompt.root;<command>vgchange</command> -ay nfs</screen>
+       Create a logical volume named <systemitem>state</systemitem> in the
+       volume group <systemitem>nfs</systemitem>:
+      </para>
+      <screen>&prompt.root;<command>crm cluster run "lvcreate -n state -L 8G nfs"</command></screen>
+      <para>
+       This volume is for the NFS client states. The 8 GB volume size
+       used in this example should support several thousand concurrent NFS clients.
+      </para>
+     </step>
+     <step>
+      <para>
+       Activate the volume group: </para>
+<screen>&prompt.root;<command>crm cluster run "vgchange -ay nfs"</command></screen>
      </step>
    </procedure>
-   <para>After you have successfully executed the above steps, your system
-    will make visible the following device: <filename>/dev/<replaceable
-     >VOLGROUP</replaceable>/<replaceable
-      >LOGICAL_VOLUME</replaceable></filename>.
-    In this case it will be <filename>/dev/nfs/work</filename>.
+   <para>
+    You should now see the following devices on the system:
+    <filename>/dev/nfs/share</filename> and <filename>/dev/nfs/state</filename>.
    </para>
   </sect1>
 
  <sect1 xml:id="sec-ha-quick-nfs-drbd-device">
-   <title>Creating a DRBD Device</title>
+   <title>Creating DRBD Devices</title>
    <para>
-    This section describes how to set up a DRBD device on top of LVM. The
-    configuration of LVM as a back-end of DRBD has some benefits:
+    This section describes how to set up DRBD devices on top of LVM.
+    Using LVM as a back-end of DRBD has the following benefits:
    </para>
   <itemizedlist>
    <listitem>
@@ -170,49 +195,36 @@
    </listitem>
   </itemizedlist>
   <para>
-    As the LVM volume group is named <literal>nfs</literal>, the
-    DRBD resource uses the same name.
+    The following procedures result in two DRBD devices: one device for the
+    NFS exports, and a second device to track the NFS client states.
    </para>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-config">
-    <title>Creating DRBD Configuration</title>
+    <title>Creating the DRBD Configuration</title>
     <para>
-     For consistency reasons, it is highly recommended to follow this advice:
+     DRBD configuration files are kept in the <filename>/etc/drbd.d/</filename>
+     directory and must end with a <filename class="extension">.res</filename>
+     extension. In this procedure, the configuration file is named
+     <filename>/etc/drbd.d/nfs.res</filename>.
     </para>
-
-    <itemizedlist>
-     <listitem>
-      <para>Use the directory <filename>/etc/drbd.d/</filename> for your
-      configuration.</para>
-     </listitem>
-     <listitem>
-      <para>Name the file according to the purpose of the resource.
-      </para>
-     </listitem>
-     <listitem>
-      <para>Put your resource configuration in a file with a <filename
-       class="extension">.res</filename> extension. In the following
-        examples, the file <filename>/etc/drbd.d/nfs.res</filename> is
-        used.
-      </para>
-     </listitem>
-    </itemizedlist>
-
-    <para>
-     Proceed as follows:
-    </para>
-    <procedure>
+    <procedure xml:id="pro-ha-nfs-create-drbd-config">
      <title>Creating a DRBD Configuration</title>
      <step>
       <para>
        Create the file <filename>/etc/drbd.d/nfs.res</filename> with the
         following contents:
       </para>
-      <!--<remark>toms 2016-07-25: TODO bsc#981560</remark>-->
 <screen>resource nfs {
-   device /dev/drbd0; <co xml:id="co-ha-quick-nfs-drbd-device"/>
-   disk   /dev/nfs/work; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
-   meta-disk internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
+   volume 0 { <co xml:id="co-ha-quick-nfs-drbd-volume"/>
+      device           /dev/drbd0; <co xml:id="co-ha-quick-nfs-drbd-device"/>
+      disk             /dev/nfs/state; <co xml:id="co-ha-quick-nfs-drbd-disk"/>
+      meta-disk        internal; <co xml:id="co-ha-quick-nfs-drbd-metadisk"/>
+   }
+   volume 1 {
+      device           /dev/drbd1;
+      disk             /dev/nfs/share;
+      meta-disk        internal;
+   }
 
    net {
       protocol  C; <co xml:id="co-ha-quick-nfs-drbd-protocol"/>
@@ -222,7 +234,6 @@
    handlers { <co xml:id="co-ha-quick-nfs-fencing-handlers"/>
       fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
       after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
-      # ...
    }
 
    connection-mesh { <co xml:id="co-ha-quick-nfs-connectionmesh"/>
@@ -238,8 +249,11 @@
    }
 }</screen>
       <calloutlist>
+       <callout arearefs="co-ha-quick-nfs-drbd-volume">
+        <para>The volume number for each DRBD device you want to create.</para>
+       </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-device">
-        <para>The DRBD device that applications are supposed to access.</para>
+        <para>The DRBD device that applications will access.</para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-disk">
         <para>The lower-level block device used by DRBD to store the actual
@@ -248,25 +262,23 @@
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-metadisk">
-        <para>Where the metadata format is stored. Using
+        <para>Where the metadata is stored. Using
          <literal>internal</literal>, the metadata is stored together with
          the user data on the same device. See the man page for further
          information.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-protocol">
-        <para>The specified protocol to be used for this connection. For protocol
-         <literal>C</literal>, a write is considered to be complete when
-         it has reached all disks, be they local or remote.
+        <para>The protocol to use for this connection. Protocol <literal>C</literal>
+         provides better data availability and does not consider a write to be
+         complete until it has reached all local and remote disks.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-fencing-handlers">
         <para>
          Enables resource-level fencing. If the DRBD replication link
          becomes disconnected, &pace; tries to promote the DRBD resource
-         to another node. During this process, the scripts were called.
-         See <xref linkend="sec-ha-drbd-fencing"/> for more
-         information.
+         to another node. For more information, see <xref linkend="sec-ha-drbd-fencing"/>.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-connectionmesh">
@@ -283,7 +295,7 @@
        following two lines exist:
       </para>
 <screen>include /etc/drbd.conf;
-include /etc/drbd.d/*.res;</screen>
+include /etc/drbd.d;</screen>
       <para>
        If not, add them to the file.
       </para>
@@ -294,7 +306,7 @@ include /etc/drbd.d/*.res;</screen>
       </para>
 <screen>&prompt.root;<command>csync2</command> -xv</screen>
       <para>
-       For information about &csync;, refer to
+       For information about &csync;, see
        <xref linkend="sec-ha-installation-setup-csync2"/>.
       </para>
      </step>
@@ -302,115 +314,108 @@ include /etc/drbd.d/*.res;</screen>
    </sect2>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-activate">
-    <title>Activating the DRBD Device</title>
+    <title>Activating the DRBD Devices</title>
     <para>
-     After you have prepared your DRBD configuration, proceed as follows:
+     After preparing the DRBD configuration, activate the devices:
     </para>
-
-    <!--
-    Taken some steps from https://github.com/SUSE/doc-sleha/commit/5bb10f7fc6
-    -->
-    <procedure>
+    <procedure xml:id="pro-ha-nfs-activate-drbd-devices">
+     <title>Activating DRBD Devices</title>
      <step>
-      <para> If you use a firewall in your cluster, open port
-              <systemitem>&drbd.port;</systemitem> in your firewall configuration. </para>
-     </step>
-     <step>
-      <para>The first time you do this, execute the following
-        commands on <emphasis>both</emphasis> nodes (in our example, <systemitem>&node1;</systemitem>
-        and <systemitem>&node2;</systemitem>):
-      </para>
-<screen>&prompt.root;<command>drbdadm</command> create-md nfs
-&prompt.root;<command>drbdadm</command> up nfs</screen>
-      <para> This initializes the metadata storage and creates the
-              <filename>/dev/drbd0</filename> device.
+      <para>
+       If you use a firewall in the cluster, open port
+       <systemitem>&drbd.port;</systemitem> in the firewall configuration.
       </para>
      </step>
      <step>
       <para>
-       If the DRBD devices on all nodes have the same data, skip
-       the initial resynchronization. Use the following command:
+       Initialize the metadata storage:
       </para>
-      <screen>&prompt.root;<command>drbdadm</command
-              > new-current-uuid --clear-bitmap nfs/0</screen>
+<screen>&prompt.root;<command>crm cluster run "drbdadm create-md nfs"</command></screen>
+     </step>
+     <step>
+      <para>
+       Create the DRBD devices:
+      </para>
+<screen>&prompt.root;<command>crm cluster run "drbdadm up nfs"</command></screen>
+     </step>
+     <step>
+      <para>
+       The devices do not have data yet, so you can run these commands to
+       skip the initial synchronization:
+      </para>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/0</command>
+&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/1</command></screen>
      </step>
      <step>
        <para>Make <systemitem>&node1;</systemitem> primary:</para>
-       <screen>&prompt.root;<command>drbdadm</command> primary --force nfs</screen>
+<screen>&prompt.root;<command>drbdadm primary --force nfs</command></screen>
      </step>
       <step>
-       <para>Check the DRBD status:</para>
-       <screen>&prompt.root;<command>drbdadm</command> status nfs</screen>
+       <para>Check the DRBD status of <literal>nfs</literal>:</para>
+<screen>&prompt.root;<command>drbdadm status nfs</command></screen>
        <para>This returns the following message:</para>
-          <screen>nfs role:Primary
-  disk:UpToDate
-  &node1; role:Secondary
-    peer-disk:UpToDate</screen>
+<screen>nfs role:Primary
+  volume:0 disk:UpToDate
+  volume:1 disk:UpToDate
+  &node2; role:Secondary
+    volume:0 peer-disk:UpToDate
+    volume:1 peer-disk:UpToDate</screen>
      </step>
     </procedure>
     <para>
-     After the synchronization is complete, you can access the DRBD resource
-     on the block device <filename>/dev/drbd0</filename>. Use this device
-     for creating your file system.
-     Find more information about DRBD in <xref linkend="cha-ha-drbd"/>.
+     You can access the DRBD resources on the block devices
+     <filename>/dev/drbd0</filename> and <filename>/dev/drbd1</filename>.
      </para>
    </sect2>
 
    <sect2 xml:id="sec-ha-quick-nfs-drbd-createfs">
-    <title>Creating the File System</title>
-    <para>After you have finished <xref
-      linkend="sec-ha-quick-nfs-drbd-activate"/>,
-    you should see a DRBD device on <filename>/dev/drbd0</filename>:
+    <title>Creating the File Systems</title>
+    <para>
+     After activating the DRBD devices, create file systems on them:
+
     </para>
-    <screen>&prompt.root;<command>mkfs.ext3</command> /dev/drbd0</screen>
+    <procedure xml:id="pro-ha-nfs-create-drbd-file-systems">
+     <title>Creating File Systems for DRBD</title>
+     <step>
+      <para>
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd0</filename>:
+      </para>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd0</command></screen>
+     </step>
+     <step>
+      <para>
+       Create an <literal>ext4</literal> file system on <filename>/dev/drbd1</filename>:
+      </para>
+      <screen>&prompt.root;<command>mkfs.ext4 /dev/drbd1</command></screen>
+     </step>
+    </procedure>
    </sect2>
   </sect1>
 
- <sect1 xml:id="sec-ha-quick-nfs-initial-pacemaker">
-  <title>Adjusting Pacemaker's Configuration</title>
-  &failback-nodes;
-  <para>
-    To adjust the option, open the &crmshell; as &rootuser; (or any
-    non-&rootuser; user that is part of the
-    <systemitem class="groupname">haclient</systemitem> group) and run the
-    following commands:
-   </para>
-   <screen>&prompt.root;<command>crm</command> configure
-&prompt.crm.conf;<command>rsc_defaults</command> resource-stickiness="200"
-&prompt.crm.conf;<command>commit</command></screen>
-
-<!--
-   <formalpara>
-   <title>With &hawk2;</title>
-   <para>
-   To adjust the option in &hawk2;, click <guimenu>Cluster Configuration</guimenu>.
-   In the text field <guimenu>resource-stickiness</guimenu> enter
-   <literal>200</literal>. Confirm with <guimenu>Apply</guimenu>.
-  </para>
-  </formalpara>
--->
-   <para>
-    For more information about global cluster options, refer to
-    <xref linkend="sec-ha-config-basics-global"/>.
-   </para>
- </sect1>
-
  <sect1 xml:id="sec-ha-quick-nfs-resources">
-  <title>Creating Cluster Resources<!-- for an HA NFS Server--></title>
-  <para>The following sections cover the configuration of
-    the required resources for a highly available NFS cluster.
-    The configuration steps use the &crmshell;.
-    The following list shows the necessary cluster resources:
+  <title>Creating Cluster Resources</title>
+  <para>
+   The following procedures describe how to configure the resources required
+   for a highly available NFS cluster.
   </para>
-  <variablelist xml:id="vl-ha-quick-nfs-overview-cluster-res">
+  <variablelist>
    <title>Overview of Cluster Resources</title>
    <varlistentry>
-    <term>DRBD Primitive and Multi-state Resource</term>
+    <term>DRBD Primitive and Multi-state Resources</term>
     <listitem>
      <para>
       These resources are used to replicate data. The multi-state resource
-      is switched from and to the Primary and Secondary roles as deemed
-      necessary by the cluster resource manager.
+      is switched to and from the primary and secondary roles as deemed necessary
+      by the cluster resource manager.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>File System Resources</term>
+    <listitem>
+     <para>
+      These resources manage the file system that will be exported, and the
+      file system that will track NFS client states.
      </para>
     </listitem>
    </varlistentry>
@@ -418,29 +423,30 @@ include /etc/drbd.d/*.res;</screen>
     <term>NFS Kernel Server Resource</term>
     <listitem>
      <para>
-      With this resource, Pacemaker ensures that the NFS server daemons are
-      always available.
+      This resource manages the NFS server daemon.
      </para>
     </listitem>
    </varlistentry>
-   <!--<varlistentry>
-    <term>NFSv4 Virtual File System Root</term>
-    <listitem>
-     <para>
-      A virtual NFS root export (only needed for NFSv4 clients).
-     </para>
-    </listitem>
-   </varlistentry>-->
    <varlistentry>
     <term>NFS Exports</term>
     <listitem>
      <para>
-      One or more NFS exports, typically corresponding to the file system.
+      This resource is used to export the directory <filename>/srv/nfs/share</filename>
+      to clients.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Virtual IP Address</term>
+    <listitem>
+     <para>
+      The initial installation creates an administrative virtual IP address for &hawk2;.
+      Create another virtual IP address exclusively for NFS exports. This makes it
+      easier to apply security restrictions later.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
-
   <itemizedlist>
     <title>Example NFS Scenario</title>
     <listitem>
@@ -450,254 +456,300 @@ include /etc/drbd.d/*.res;</screen>
          <systemitem class="ipaddress">&subnetI;.x/24</systemitem> subnet.</para>
     </listitem>
     <listitem>
-        <para>The service <!--hosts an NFSv4 virtual file system root
-        from <literal>/srv/nfs</literal>, with--> exports data served from
-         <literal>/srv/nfs/work</literal>. </para>
+        <para>The service exports data served from
+         <literal>/srv/nfs/share</literal>. </para>
     </listitem>
     <listitem>
-        <para>Into this export directory, the cluster will mount
-            <literal>ext3</literal> file systems from the DRBD device
-         <filename>/dev/drbd0</filename>.
-         This DRBD device sits on top of an LVM logical volume with the name
-         <literal>nfs</literal>.
+        <para>Into this export directory, the cluster mounts an
+            <literal>ext4</literal> file system from the DRBD device
+         <filename>/dev/drbd1</filename>.
+         This DRBD device sits on top of an LVM logical volume named
+         <literal>/dev/nfs/share</literal>.
         </para>
+    </listitem>
+    <listitem>
+     <para>
+      The DRBD device <literal>/dev/drbd0</literal> is used to share the
+      NFS client states from <filename>/var/lib/nfs</filename>. This DRBD device
+      sits on top of an LVM logical volume named <literal>/dev/nfs/state</literal>.
+     </para>
     </listitem>
   </itemizedlist>
 
   <sect2 xml:id="sec-ha-quick-nfs-resources-drbd">
-   <title>DRBD Primitive and Multi-state Resource</title>
+   <title>Creating DRBD Primitive and Multi-state Resources</title>
    <para>
-    To configure these resources, run the following commands from the
-   &crmshell;:
+    Create a cluster resource to manage the DRBD devices, and a promotable
+    clone to allow this resource to run on both nodes:
    </para>
-<screen>&prompt.crm;<command>configure</command>
-&prompt.crm.conf;<command>primitive</command> drbd_nfs \
-  ocf:linbit:drbd \
-    params drbd_resource="nfs" \
-  op monitor interval="15" role="Master" \
-  op monitor interval="30" role="Slave"
-&prompt.crm.conf;<command>ms</command> ms-drbd_nfs drbd_nfs \
-  meta master-max="1" master-node-max="1" clone-max="2" \
-  clone-node-max="1" notify="true"
-&prompt.crm.conf;<command>commit</command></screen>
-   <para>
-    This will create a Pacemaker multi-state resource corresponding to the
-    DRBD resource <literal>nfs</literal>. Pacemaker should now activate your
-    DRBD resource on both nodes and promote it to the master role on one of
-    them.
-   </para>
-   <para>
-    Check the state of the cluster with the <command>crm status</command>
-     command, or run <command>drbdadm status</command>.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-quick-nfs-resources-nfsserver">
-   <title>NFS Kernel Server Resource</title>
-   <para>
-    In the &crmshell;, the resource for the NFS server
-    daemons must be configured as a <emphasis>clone</emphasis> of a
-    <literal>systemd</literal> resource type.
-   </para>
-<screen>&prompt.crm.conf;<command>primitive</command> nfsserver \
-  systemd:nfs-server \
-  op monitor interval="30s"
-&prompt.crm.conf;<command>clone</command> cl-nfsserver nfsserver \
-   meta interleave=true
-&prompt.crm.conf;<command>commit</command></screen>
-   <para>
-    After you have committed this configuration, Pacemaker should start the
-    NFS Kernel server processes on both nodes.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="sec-ha-quick-nfs-resources-lvm">
-   <title>File System Resource</title>
-   <orderedlist>
-    <listitem>
+   <procedure xml:id="pro-ha-nfs-create-drbd-resource">
+    <title>Creating a DRBD Resource for NFS</title>
+    <step>
      <para>
-      Configure the file system type resource as follows (but
-      <emphasis>do not</emphasis> commit this configuration yet):
+      Start the <command>crm</command> interactive shell:
      </para>
-<screen>&prompt.crm.conf;<command>primitive</command> fs_work \
-  ocf:heartbeat:Filesystem \
-  params device=/dev/drbd0 \
-    directory=/srv/nfs/work \
-    fstype=ext3 \
-  op monitor interval="10s"</screen>
-    </listitem>
-    <listitem>
+<screen>&prompt.root;<command>crm configure</command></screen>
+    </step>
+    <step>
      <para>
-      Combine these resources into a Pacemaker resource
-      <emphasis>group</emphasis>:
+      Create a primitive for the DRBD configuration <literal>nfs</literal>:
      </para>
-<screen>&prompt.crm.conf;<command>group</command> g-nfs fs_work</screen>
-    </listitem>
-    <listitem>
+<screen>&prompt.crm.conf;<command>primitive drbd-nfs ocf:linbit:drbd \
+  params drbd_resource="nfs" \
+  op monitor interval=15 role=Promoted \
+  op monitor interval=30 role=Unpromoted</command></screen>
+    </step>
+    <step>
      <para>
-      Add the following constraints to make sure that the group is started
-      on the same node on which the DRBD multi-state resource is in the
-      master role:
+      Create a promotable clone for the <literal>drbd-nfs</literal> primitive:
      </para>
-<screen>&prompt.crm.conf;<command>order</command> o-drbd_before_nfs inf: \
-  ms-drbd_nfs:promote g-nfs:start
-&prompt.crm.conf;<command>colocation</command> col-nfs_on_drbd inf: \
-  g-nfs ms-drbd_nfs:Master</screen>
-    </listitem>
-    <listitem>
+<screen>&prompt.crm.conf;<command>clone cl-nfs drbd-nfs \
+  meta promotable="true" promoted-max="1" promoted-node-max="1" \
+  clone-max="2" clone-node-max="1" notify="true" interleave=true</command></screen>
+    </step>
+    <step>
      <para>
       Commit this configuration:
      </para>
 <screen>&prompt.crm.conf;<command>commit</command></screen>
-    </listitem>
-   </orderedlist>
+    </step>
+   </procedure>
    <para>
-    After these changes have been committed, Pacemaker mounts the DRBD device
-    to <filename>/srv/nfs/work</filename> on the same node. Confirm this with
-    <command>mount</command> (or by looking at <filename
-     >/proc/mounts</filename>).
+    Pacemaker activates the DRBD resources on both nodes and promotes
+    them to the primary role on one of the nodes. Check the state of the
+    cluster with the <command>crm status</command> command, or run
+    <command>drbdadm status</command>.
    </para>
+  </sect2>
+
+  <sect2 xml:id="sec-ha-quick-nfs-resources-lvm">
+   <title>Creating File System Resources</title>
+   <para>
+    Create cluster resources to manage the file systems for export and state tracking:
+   </para>
+   <procedure xml:id="pro-ha-nfs-create-fs-resource">
+    <title>Creating File System Resources for NFS</title>
+    <step>
+     <para>
+      Create a primitive for the NFS client states on <literal>/dev/drbd0</literal>:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive fs-nfs-state Filesystem \
+  params device=/dev/drbd0 directory=/var/lib/nfs fstype=ext4</command></screen>
+    </step>
+    <step>
+     <para>
+      Create a primitive for the file system to be exported on
+      <literal>/dev/drbd1</literal>:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive fs-nfs-share Filesystem \
+  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4</command></screen>
+     <para>
+      <emphasis>Do not</emphasis> commit this configuration until
+    after you add the colocation and order constraints.
+     </para>
+    </step>
+    <step>
+     <para>
+      Add both of these resources to a resource group named <literal>g-nfs</literal>:
+     </para>
+<screen>&prompt.crm.conf;<command>group g-nfs fs-nfs-state fs-nfs-share</command></screen>
+     <para>
+      Resources start in the order they are added to the group and stop in reverse order.
+     </para>
+    </step>
+    <step>
+     <para>
+      Add a colocation constraint to make sure that the resource group always
+      starts on the node where the DRBD promotable clone is in the primary role:
+     </para>
+<screen>&prompt.crm.conf;<command>colocation col-nfs-on-drbd inf: g-nfs cl-nfs:Promoted</command></screen>
+    </step>
+    <step>
+     <para>
+      Add an order constraint to make sure the DRBD promotable clone always
+      starts before the resource group:
+     </para>
+<screen>&prompt.crm.conf;<command>order o-drbd-before-nfs Mandatory: cl-nfs:promote g-nfs:start</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+   </procedure>
+   <para>
+    Pacemaker mounts <literal>/dev/drbd0</literal> to <filename>/var/lib/nfs</filename>,
+    and <literal>/dev/drbd1</literal> to <filename>srv/nfs/share</filename>. Confirm this
+    with <command>mount</command>, or by looking at <filename >/proc/mounts</filename>.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-ha-quick-nfs-resources-nfsserver">
+   <title>Creating an NFS Kernel Server Resource</title>
+   <para>
+    Create a cluster resource to manage the NFS server daemon:
+   </para>
+   <procedure xml:id="pro-ha-nfs-create-nfs-server-resource">
+    <title>Creating an NFS Kernel Server Resource</title>
+    <step>
+     <para>
+      Create a primitive to manage the NFS server daemon:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive nfsserver nfsserver \
+  params nfs_server_scope=SUSE nfs_shared_infodir="/var/lib/nfs"</command></screen>
+     <para>
+      The <literal>nfs_server_scope</literal> must be the same on all nodes in the
+      cluster that run the NFS server, but this is not set by default. All clusters
+      using &suse; software can use the same scope, so we recommend setting the value
+      to <literal>SUSE</literal>.
+     </para>
+     <warning>
+      <title>Low lease time can cause loss of file state</title>
+      <para>
+       NFS clients regularly renew their state with the NFS server. If the lease time
+       is too low, system or network delays can cause the timer to expire before the
+       renewal is complete. This can lead to I/O errors and loss of file state.
+      </para>
+      <para>
+       <literal>NFSV4LEASETIME</literal> is set on the NFS server in the file
+       <filename>/etc/sysconfig/nfs</filename>. The default is 90 seconds.
+       If lowering the lease time is necessary, we recommend a value of 60 or
+       higher. We strongly discourage values lower than 30.
+      </para>
+     </warning>
+    </step>
+    <step>
+     <para>
+      Append this resource to the existing <literal>g-nfs</literal> resource group:
+     </para>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add nfsserver</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+   </procedure>
   </sect2>
 
   <sect2 xml:id="sec-ha-quick-nfs-resources-nfsexport">
-   <title>NFS Export Resources</title>
+   <title>Creating an NFS Export Resource</title>
    <para>
-    When your DRBD, LVM, and file system resources are working properly,
-    continue with the resources managing your NFS exports. To create highly
-    available NFS export resources, use the <literal>exportfs</literal>
-    resource type.
+    Create a cluster resource to manage the NFS exports:
    </para>
-
-<!-- According to Neal, this is can be removed completely
-
-   <sect3 xml:id="sec-ha-quick-nfs-resources-nfsexport-nfsv4root">
-    <title>NFSv4 Virtual File System Root</title>
-    <para>
-     If clients exclusively use NFSv3 to connect to the server, you do not
-     need this resource. In this case, continue with
-     <xref linkend="sec-ha-quick-nfs-resources-nfsexport-nonroot"/>.
-    </para>
-    <orderedlist>
-     <listitem>
+   <procedure xml:id="pro-ha-nfs-create-nfs-export-resource">
+    <title>Creating an NFS Export Resource</title>
+     <step>
       <para>
-       Create a virtual NFSv4 file system:
+       Create a primitive for the NFS exports:
       </para>
-<screen>&prompt.crm.conf;<command>primitive</command> exportfs_root \
-  ocf:heartbeat:exportfs \
-  params directory="/srv/nfs" fsid=0 \
-    options="rw,crossmnt" \
-    clientspec="&nfs-clientspec;" \<!-\- 10.9.9.0/24 -\->
-  op monitor interval="30s"
-&prompt.crm.conf;<command>clone</command> cl-exportfs_root exportfs_root</screen>
-      <remark>toms 2016-09-01: What clientspec should be used here?</remark>
+<screen>&prompt.crm.conf;<command>primitive exportfs-nfs exportfs \
+  params directory="/srv/nfs/share" \
+  options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=101 \</command><co xml:id="co-exportfs-fsid"/>
+  <command>op monitor interval=30s timeout=90s</command><co xml:id="co-exportfs-monitor-timeout"/></screen>
+      <calloutlist>
+       <callout arearefs="co-exportfs-fsid">
+        <para>
+         The <literal>fsid</literal> must be unique for each NFS export resource.
+        </para>
+       </callout>
+       <callout arearefs="co-exportfs-monitor-timeout">
+        <para>
+         The value of <literal>op monitor timeout</literal> must be higher
+         than the value of <literal>stonith-timeout</literal>. To find the
+         <literal>stonith-timeout</literal> value, run <command>crm configure show</command>
+         and look under the <literal>property</literal> section.
+        </para>
+       </callout>
+      </calloutlist>
+      <important>
+       <title>Do not set <literal>wait_for_leasetime_on_stop=true</literal></title>
+       <para>
+        Setting this option to <literal>true</literal> in a highly available
+        NFS setup can cause unnecessary delays and loss of locks.
+       </para>
+       <para>
+        The default value for <literal>wait_for_leasetime_on_stop</literal> is
+        <literal>false</literal>. There is no need to set it to <literal>true</literal>
+        when <filename>/var/lib/nfs</filename> and <literal>nfsserver</literal>
+        are configured as described in this guide.
+       </para>
+      </important>
+     </step>
+     <step>
       <para>
-       This resource does not hold any actual NFS-exported data, merely the
-       empty directory (<filename>/srv/nfs</filename>) that the other NFS
-       exports are mounted into. Since there is no shared data involved
-       here, you can safely <emphasis>clone</emphasis> this resource.
+       Append this resource to the existing <literal>g-nfs</literal> resource group:
       </para>
-     </listitem>
-     <listitem>
-      <para>
-       Since any data should be exported only on nodes where this clone has
-       been properly started, add the following constraints to the
-       configuration:
-      </para>
-<screen>&prompt.crm.conf;<command>order</command> o-root_before_nfs Mandatory: \
-  cl-exportfs_root g-nfs:start
-&prompt.crm.conf;<command>colocation</command> c-nfs_on_root inf: \
-  g-nfs cl-exportfs_root
-&prompt.crm.conf;<command>commit</command></screen>
-      <para>
-       After this, Pacemaker should start the NFSv4 virtual file system root
-       on both nodes.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Check the output of the <command>exportfs -v</command> command to
-       verify this:
-      </para>
-      <screen>&prompt.root;<command>exportfs</command> -v
-/srv/nfs/work   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(...)
-/srv/nfs        <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(...)</screen>
-     </listitem>
-    </orderedlist>
-   </sect3>
--->
-
-<!--   <sect3 xml:id="sec-ha-quick-nfs-resources-nfsexport-nonroot">
-    <title>NFS Exports</title>-->
-    <para>
-     To export the <filename>/srv/nfs/work</filename> directory to clients,
-     use the following primitive:
-    </para>
-    <orderedlist>
-     <listitem>
-      <para>
-       Create NFS exports with the following commands:
-      </para>
-<screen>&prompt.crm.conf;<command>primitive</command> exportfs_work \
-  ocf:heartbeat:exportfs \
-    params directory="/srv/nfs/work" \
-      options="rw,mountpoint" \
-      clientspec="&nfs-clientspec;" \
-      wait_for_leasetime_on_stop=true \
-      fsid=100 \
-  op monitor interval="30s"</screen>
-     </listitem>
-     <listitem>
-      <para>
-       After you have created these resources, append them to the existing
-       <literal>g-nfs</literal> resource group:
-      </para>
-<screen>&prompt.crm.conf;<command>modgroup</command> g-nfs add exportfs_work</screen>
-     </listitem>
-     <listitem>
-      <para>
-       Commit this configuration:
-      </para>
+ <screen>&prompt.crm.conf;<command>modgroup g-nfs add exportfs-nfs</command></screen>
+     </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
 <screen>&prompt.crm.conf;<command>commit</command></screen>
-      <para>
-       Pacemaker will export the NFS virtual file system root and the two
-       other exports.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Confirm that the NFS exports are set up properly:
-      </para>
-<screen>&prompt.root;<command>exportfs</command> -v
-/srv/nfs/work   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)<!--
-/srv/nfs        <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)--></screen>
-     </listitem>
-    </orderedlist>
-   <!--</sect3>-->
+    </step>
+    <step>
+     <para>
+      Confirm that the NFS exports are set up properly:
+     </para>
+<screen>&prompt.root;<command>exportfs -v</command>
+/srv/nfs/share   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
+    </step>
+   </procedure>
   </sect2>
 
   <sect2 xml:id="sec-ha-quick-nfs-resources-vip">
-   <title>Virtual IP Address for NFS Exports</title>
+   <title>Creating a Virtual IP Address for NFS Exports</title>
    <para>
-    The initial installation creates an administrative virtual IP address for
-    &hawk2;. Although you could use this IP address for your NFS exports too,
-    create another one exclusively for NFS exports. This makes it easier to
-    apply security restrictions later. Use the following commands in the
-    &crmshell;:
+    Create a cluster resource to manage the virtual IP address for the NFS exports:
    </para>
-   <screen>&prompt.crm.conf;<command>primitive</command> vip_nfs IPaddr2 \
-   params ip=&nfs-vip-exports; cidr_netmask=24 \
-   op monitor interval=10 timeout=20
-&prompt.crm.conf;<command>modgroup</command> g-nfs add vip_nfs
-&prompt.crm.conf;<command>commit</command></screen>
+   <procedure xml:id="pro-ha-nfs-create-vip-resource">
+    <title>Creating a Virtual IP Address for NFS Exports</title>
+    <step>
+     <para>
+      Create a primitive for the virtual IP address:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive vip-nfs IPaddr2 params ip=&nfs-vip-exports;</command></screen>
+    </step>
+    <step>
+     <para>
+      Append this resource to the existing <literal>g-nfs</literal> resource group:
+     </para>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add vip-nfs</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+    <step>
+     <para>
+      Leave the <command>crm</command> interactive shell:
+     </para>
+  <screen>&prompt.crm.conf;<command>quit</command></screen>
+    </step>
+    <step>
+     <para>
+      Check the status of the cluster. The resources in the <literal>g-nfs</literal>
+      group should appear in the following order:
+     </para>
+  <screen>&prompt.root;<command>crm status</command>
+  [...]
+  Full List of Resources
+    [...]
+    * Resource Group: g-nfs:
+      * fs-nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
+      * fs-nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
+      * nfsserver       (ocf:heartbeat:nfsserver):    Started &node1;
+      * exportfs-nfs    (ocf:heartbeat:exportfs):     Started &node1;
+      * vip-nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
+    </step>
+   </procedure>
   </sect2>
  </sect1>
-
- <!-- toms 2015-10-23: This is an attempt to descript how to set up
-      a HA NFS cluster with cluster scripts
-
-      toms 2016-08-23: Still disabled for the time being as not really finished
-   -->
- <!--<xi:include href="nfs_quick_clusterscript.xml"/>-->
 
  <sect1 xml:id="sec-ha-quick-nfs-use">
   <title>Using the NFS Service</title>
@@ -711,24 +763,203 @@ include /etc/drbd.d/*.res;</screen>
    configured on one of the cluster nodes' network interfaces. For compatibility
    reasons, use the <emphasis>full</emphasis> path of the NFS export on the server.
   </para>
+  <para>
+   The command to mount the NFS export looks like this:
+  </para>
+<screen>&prompt.root;<command>mount &nfs-vip-exports;:/srv/nfs/share /home/share</command></screen>
+  <para>
+   If you need to configure other mount options, such as a specific transport protocol
+   (<option>proto</option>), maximum read and write request sizes (<option>rsize</option>
+   and <option>wsize</option>), or a specific NFS version (<option>vers</option>),
+   use the <option>-o</option> option. For example:
+  </para>
+<screen>&prompt.root;<command>mount -o proto=tcp,rsize=32768,wsize=32768,vers=3 \
+&nfs-vip-exports;:/srv/nfs/share /home/share</command></screen>
+  <para>
+   For further NFS mount options, see the <command>nfs</command> man page.
+  </para>
+  <note>
+   <title>Loopback mounts</title>
+   <para>
+    Loopback mounts are only supported for NFS version 3, <emphasis>not</emphasis>
+    NFS version 4. For more information, see
+    <link xlink:href="https://www.suse.com/support/kb/doc/?id=000018709"/>.
+   </para>
+  </note>
+ </sect1>
 
-  <para>In its simplest form, the command to mount the NFS export looks like
-   this:</para>
-  <screen>&prompt.root;<command>mount</command> -t nfs &nfs-vip-exports;:/srv/nfs/work /home/work</screen>
-  <para>
-   To configure a specific transport protocol (<option>proto</option>)
-   and maximum read and write request sizes (<option>rsize</option> and
-    <option>wsize</option>), use:
-  </para>
-  <screen>&prompt.root;<command>mount</command> -o rsize=32768,wsize=32768 \
-    &nfs-vip-exports;:/srv/nfs/work /home/work</screen>
-  <para>
-   In case you need to be compatible with NFS version&nbsp;3, include the value
-   <option>vers=3</option> after the <option>-o</option> option.
-  </para>
-  <para>
-   For further NFS mount options, consult the <command>nfs</command> man page.
-  </para>
+<sect1 xml:id="sec-ha-quick-nfs-add-filesystems">
+ <title>Adding More NFS Shares to the Cluster</title>
+ <para>
+  If you need to increase the available storage, you can add more NFS shares
+  to the cluster.
+ </para>
+ <para>
+  In this example, a new DRBD device named <literal>/dev/drbd2</literal> sits
+  on top of an LVM logical volume named <literal>/dev/nfs/share2</literal>.
+ </para>
+ <procedure xml:id="pro-ha-nfs-add-nfs-shares">
+  <title>Adding More NFS Shares to the Cluster</title>
+  <step>
+   <para>
+    Create an LVM logical volume for the new share:
+   </para>
+<screen>&prompt.root;<command>crm cluster run "lvcreate -n share2 -L 20G nfs"</command></screen>
+  </step>
+  <step>
+   <para>
+    Update the file <filename>/etc/drbd.d/nfs.res</filename> to add the new volume
+    under the existing volumes:
+   </para>
+<screen>   volume 2 {
+      device           /dev/drbd2;
+      disk             /dev/nfs/share2;
+      meta-disk        internal;
+   }</screen>
+  </step>
+  <step>
+   <para>
+    Copy the updated file to the other nodes:
+   </para>
+<screen>&prompt.root;<command>csync2 -xv</command></screen>
+  </step>
+  <step>
+   <para>
+    Initialize the metadata storage for the new volume:
+   </para>
+<screen>&prompt.root;<command>crm cluster run "drbdadm create-md nfs/2 --force"</command></screen>
+  </step>
+  <step>
+   <para>
+    Update the <literal>nfs</literal> configuration to create the new device:
+   </para>
+<screen>&prompt.root;<command>crm cluster run "drbdadm adjust nfs"</command></screen>
+  </step>
+  <step>
+   <para>
+    Skip the initial synchronization for the new device:
+   </para>
+<screen>&prompt.root;<command>drbdadm new-current-uuid --clear-bitmap nfs/2</command></screen>
+  </step>
+  <step>
+   <para>
+    The NFS cluster resources might have moved to another node since they were created.
+    Check the DRBD status with <command>drbdadm status nfs</command>, and make a
+    note of which node is in the <literal>Primary</literal> role.
+   </para>
+  </step>
+  <step>
+   <para>
+    On the node that is in the <literal>Primary</literal> role, create an
+    <literal>ext4</literal> file system on <literal>/dev/drbd2</literal>:
+   </para>
+<screen>&prompt.root;<command>mkfs.ext4 /dev/drbd2</command></screen>
+  </step>
+  <step>
+   <para>
+    Start the <command>crm</command> interactive shell:
+   </para>
+<screen>&prompt.root;<command>crm configure</command></screen>
+  </step>
+  <step>
+   <para>
+    Create a primitive for the file system to be exported on <literal>/dev/drbd2</literal>:
+   </para>
+<screen>&prompt.crm.conf;<command>primitive fs-nfs-share2 Filesystem \
+  params device="/dev/drbd2" directory="/srv/nfs/share2" fstype=ext4</command></screen>
+  </step>
+  <step>
+   <para>
+    Add the new file system resource to the <literal>g-nfs</literal> group
+    <emphasis>before</emphasis> the <literal>nfsserver</literal> resource:
+   </para>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add fs-nfs-share2 before nfsserver</command></screen>
+  </step>
+  <step>
+   <para>
+    Create a primitive for NFS exports from the new share:
+   </para>
+<screen>&prompt.crm.conf;<command>primitive exportfs-nfs2 exportfs \
+  params directory="/srv/nfs/share2" \
+  options="rw,mountpoint" clientspec="192.168.1.0/24" fsid=102 \
+  op monitor interval=30s timeout=90s</command></screen>
+  </step>
+  <step>
+   <para>
+    Add the new NFS export resource to the <literal>g-nfs</literal> group
+    <emphasis>before</emphasis> the <literal>vip-nfs</literal> resource:
+   </para>
+<screen>&prompt.crm.conf;<command>modgroup g-nfs add exportfs-nfs2 before vip-nfs</command></screen>
+  </step>
+  <step>
+   <para>
+    Commit this configuration:
+   </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+  </step>
+  <step>
+   <para>
+    Leave the <command>crm</command> interactive shell:
+   </para>
+<screen>&prompt.crm.conf;<command>quit</command></screen>
+  </step>
+  <step>
+   <para>
+    Check the status of the cluster. The resources in the <literal>g-nfs</literal>
+    group should appear in the following order:
+   </para>
+<screen>&prompt.root;<command>crm status</command>
+[...]
+Full List of Resources
+  [...]
+  * Resource Group: g-nfs:
+    * fs-nfs-state    (ocf:heartbeat:Filesystem):   Started &node1;
+    * fs-nfs-share    (ocf:heartbeat:Filesystem):   Started &node1;
+    * fs-nfs-share2   (ocf:heartbeat:Filesystem):   Started &node1;
+    * nfsserver       (ocf:heartbeat:nfsserver):    Started &node1;
+    * exportfs-nfs    (ocf:heartbeat:exportfs):     Started &node1;
+    * exportfs-nfs2   (ocf:heartbeat:exportfs):     Started &node1;
+    * vip-nfs         (ocf:heartbeat:IPaddr2):      Started &node1;</screen>
+  </step>
+  <step>
+   <para>
+    Confirm that the NFS exports are set up properly:
+   </para>
+<screen>&prompt.root;<command>exportfs -v</command>
+/srv/nfs/share   <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)
+/srv/nfs/share2  <replaceable>IP_ADDRESS_OF_CLIENT</replaceable>(<replaceable>OPTIONS</replaceable>)</screen>
+  </step>
+ </procedure>
+</sect1>
+
+ <sect1 xml:id="sec-ha-quick-nfs-more-info">
+  <title>For More Information</title>
+  <itemizedlist>
+   <listitem>
+    <para>
+     For more details about the steps in this guide, see
+     <link xlink:href="https://www.suse.com/support/kb/doc/?id=000020396"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     For more information about NFS and LVM, see
+     <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/book-storage.html">
+     &storage_guide; for &sles;</link>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     For more information about DRBD, see <xref linkend="cha-ha-drbd"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     For more information about cluster resources, see
+     <xref linkend="sec-ha-config-basics-resources"/>.
+    </para>
+   </listitem>
+  </itemizedlist>
  </sect1>
  <xi:include href="common_legal.xml"/>
 </article>

--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -479,8 +479,8 @@ include /etc/drbd.d;</screen>
   <sect2 xml:id="sec-ha-quick-nfs-resources-drbd">
    <title>Creating DRBD Primitive and Multi-state Resources</title>
    <para>
-    Create a cluster resource to manage the DRBD devices, and a promotable
-    clone to allow this resource to run on both nodes:
+    Create a cluster resource to manage the DRBD devices, and a multi-state
+    resource to allow the DRBD resource to run on both nodes:
    </para>
    <procedure xml:id="pro-ha-nfs-create-drbd-resource">
     <title>Creating a DRBD Resource for NFS</title>
@@ -501,11 +501,11 @@ include /etc/drbd.d;</screen>
     </step>
     <step>
      <para>
-      Create a promotable clone for the <literal>drbd-nfs</literal> primitive:
+      Create a multi-state resource for the <literal>drbd-nfs</literal> primitive:
      </para>
-<screen>&prompt.crm.conf;<command>clone cl-nfs drbd-nfs \
-  meta promotable="true" promoted-max="1" promoted-node-max="1" \
-  clone-max="2" clone-node-max="1" notify="true" interleave=true</command></screen>
+<screen>&prompt.crm.conf;<command>ms ms-drbd-nfs drbd-nfs \
+  meta master-max="1" master-node-max="1" \
+  clone-max="2" clone-node-max="1" notify="true"</command></screen>
     </step>
     <step>
      <para>
@@ -560,16 +560,16 @@ include /etc/drbd.d;</screen>
     <step>
      <para>
       Add a colocation constraint to make sure that the resource group always
-      starts on the node where the DRBD promotable clone is in the primary role:
+      starts on the node where the DRBD multi-state resource is in the primary role:
      </para>
-<screen>&prompt.crm.conf;<command>colocation col-nfs-on-drbd inf: g-nfs cl-nfs:Promoted</command></screen>
+<screen>&prompt.crm.conf;<command>colocation col-nfs-on-drbd inf: g-nfs ms-drbd-nfs:Master</command></screen>
     </step>
     <step>
      <para>
-      Add an order constraint to make sure the DRBD promotable clone always
+      Add an order constraint to make sure the DRBD multi-state resource always
       starts before the resource group:
      </para>
-<screen>&prompt.crm.conf;<command>order o-drbd-before-nfs Mandatory: cl-nfs:promote g-nfs:start</command></screen>
+<screen>&prompt.crm.conf;<command>order o-drbd-before-nfs Mandatory: ms-drbd-nfs:promote g-nfs:start</command></screen>
     </step>
     <step>
      <para>

--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -540,8 +540,8 @@ include /etc/drbd.d;</screen>
      </para>
 <screen>&prompt.crm.conf;<command>primitive drbd-nfs ocf:linbit:drbd \
   params drbd_resource="nfs" \
-  op monitor interval=15 role=Promoted \
-  op monitor interval=30 role=Unpromoted</command></screen>
+  op monitor interval=15 role=Master \
+  op monitor interval=30 role=Slave</command></screen>
     </step>
     <step>
      <para>


### PR DESCRIPTION
### PR creator: Description

Here is the NFS guide overhaul, with changes for 12 SP5.

Changes specifically for 12 SP5 are in separate commits from the changes cherry-picked from 15 SP4/5.

PDF: 
[art-ha-quick-nfs_en.pdf](https://github.com/SUSE/doc-sleha/files/11621486/art-ha-quick-nfs_en.pdf)


### PR creator: Are there any relevant issues/feature requests?

* bsc#1201271
* jsc#DOCTEAM-473


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
