### PR TITLE
Add warning to older NFS guides

### DIFF
--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -37,7 +37,7 @@
     </para>
     <para>
      The process for configuring highly available NFS storage has been improved in
-     version 15 SP4.
+     version 15 SP3.
     </para>
    </warning>
   </abstract>

--- a/xml/art_sle_ha_nfs_quick.xml
+++ b/xml/art_sle_ha_nfs_quick.xml
@@ -29,6 +29,17 @@
    <para>
     &abstract-nfsquick;
    </para>
+   <warning>
+    <title>This guide is no longer recommended</title>
+    <para>
+     The method described in this version of the guide is outdated and may cause issues in some
+     setups. For more information, see <link xlink:href="https://www.suse.com/support/kb/doc/?id=000020396"/>.
+    </para>
+    <para>
+     The process for configuring highly available NFS storage has been improved in
+     version 15 SP4.
+    </para>
+   </warning>
   </abstract>
  </info>
 


### PR DESCRIPTION
### PR creator: Description

Since the new NFS guide can't be backported to all version due to technical changes, here is a warning directing people to newer versions.

PDF: 
[art-sleha-nfs-quick_en.pdf](https://github.com/SUSE/doc-sleha/files/11621886/art-sleha-nfs-quick_en.pdf)


### PR creator: Are there any relevant issues/feature requests?

* bsc#1201271
* jsc#DOCTEAM-473


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
