### PR TITLE
crmsh can use non-root sudoer SSH keys

### DIFF
--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -377,8 +377,8 @@ softdog           16384  1</screen>
     <command>crm cluster init</command></title>
    <step>
     <para>
-     Log in as &rootuser; to the physical or virtual machine to
-     use as cluster node.
+     Log in to the first cluster node as &rootuser;, or as a user with
+     <command>sudo</command> privileges.
     </para>
    </step>
    <step>
@@ -536,33 +536,40 @@ softdog           16384  1</screen>
     <command>crm cluster join</command></title>
    <step>
     <para>
-     Log in as &rootuser; to the physical or virtual machine you want to add to the cluster.
+     Log in to the second node as &rootuser;, or as a user with
+     <command>sudo</command> privileges.
     </para>
    </step>
    <step>
     <para>
      Start the bootstrap script:
     </para>
+    <para>
+     If you set up the first node as &rootuser;, you can run this command with
+     no additional parameters:
+    </para>
 <screen>&prompt.root;<command>crm cluster join</command></screen>
     <para>
-     If NTP has not been configured to start at boot time, a message
+     If you set up the first node as a <command>sudo</command> user, you must
+     specify that user with the <option>-c</option> option:
+    </para>
+<screen>&prompt.user;<command>sudo crm cluster join -c <replaceable>USER</replaceable>@&node1;</command></screen>
+    <para>
+     If NTP is not configured to start at boot time, a message
      appears. The script also checks for a hardware watchdog device.
      You are warned if none is present.
     </para>
    </step>
    <step>
     <para>
-     If you decide to continue anyway, you will be prompted for the IP
-     address of an existing node. Enter the IP address of the first node
-     (<systemitem class="server">&node1;</systemitem>, <systemitem
-      class="ipaddress">&subnetI;.1</systemitem>).
+     If you did not already specify <systemitem class="server">&node1;</systemitem>
+     with <option>-c</option>, you will be prompted for the IP address of the first node.
     </para>
    </step>
    <step>
     <para>
-     If you have not already configured passwordless SSH access between
-     both machines, you will be prompted for the &rootuser; password
-     of the existing node.
+     If you did not already configure passwordless SSH access between
+     both machines, you will be prompted for the password of the first node.
     </para>
     <para>
      After logging in to the specified node, the script copies the

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -380,6 +380,19 @@ softdog           16384  1</screen>
      Log in to the first cluster node as &rootuser;, or as a user with
      <command>sudo</command> privileges.
     </para>
+    <important>
+     <title><command>sudo</command> user SSH key access</title>
+     <para>
+      The cluster uses passwordless SSH access for communication between the nodes.
+      The <command>crm cluster init</command> script checks for SSH keys and generates
+      them if they do not already exist.
+     </para>
+     <para>
+      If you intend to set up the first node as a user with <command>sudo</command> privileges,
+      you must ensure the user's SSH keys exist (or will be generated) locally on the node,
+      not on a remote system.
+     </para>
+    </important>
    </step>
    <step>
     <para>
@@ -398,7 +411,7 @@ softdog           16384  1</screen>
     </para>
     <para>
      The script checks for NTP configuration and a hardware watchdog service.
-     It generates the public and private SSH keys used for SSH access and
+     If required, it generates the public and private SSH keys used for SSH access and
      &csync; synchronization and starts the respective services.
     </para>
    </step>

--- a/xml/ha_config_cli.xml
+++ b/xml/ha_config_cli.xml
@@ -44,14 +44,30 @@
   <title>User privileges</title>
   <para>
    Sufficient privileges are necessary to manage a cluster. The
-   <command>crm</command> command and its subcommands need to be run either
-   as &rootuser; user or as the CRM owner user (typically the user
-   <systemitem class="username">hacluster</systemitem>).
+   <command>crm</command> command and its subcommands need to be run
+   as one of the following users:
   </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     The &rootuser; user or a user with <command>sudo</command> privileges.
+     These users have full privileges for <command>crm cluster init</command>,
+     <command>crm cluster join</command>, <command>crm report</command>,
+     the cluster CIB, and other operations.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The CRM owner user (typically the user <systemitem class="username">hacluster</systemitem>).
+     This user can make changes to the cluster CIB, but has limited privileges for
+     <command>crm report</command>.
+    </para>
+   </listitem>
+  </itemizedlist>
   <para>
    However, the <option>user</option> option allows you to run
    <command>crm</command> and its subcommands as a regular (unprivileged)
-   user and to change its ID using <command>sudo</command> whenever
+   user and to change its ID using <command>sudo</command> when
    necessary. For example, with the following command <command>crm</command>
    uses <systemitem class="username">hacluster</systemitem> as the
    privileged user ID:

--- a/xml/ha_crmreport_passl.xml
+++ b/xml/ha_crmreport_passl.xml
@@ -32,9 +32,12 @@
   data from the current node.
  </para>
  <para>
-  If passwordless SSH &rootuser; access does not comply with regulatory
-  requirements, you can use a work-around for running cluster reports. It
-  consists of the following basic steps:
+  If your security policy does not allow passwordless &rootuser; SSH login, or prevents
+  &rootuser; SSH login entirely, then running <command>crm report</command> as &rootuser;
+  fails on all remote nodes. If the cluster was initialized by a non-root user with
+  <command>sudo</command> privileges, this user can run cluster reports successfully
+  under these restrictions. However, if the cluster was initialized by the &rootuser; user,
+  you must use the following workaround to run cluster reports:
  </para>
  <orderedlist>
   <listitem>
@@ -61,20 +64,7 @@
    </para>
   </listitem>
  </orderedlist>
- <para>
-  By default when <command>crm report</command> is run, it attempts to
-  log in to
-  remote nodes first as &rootuser;, then as user
-  <systemitem class="username">hacluster</systemitem>. However, if your
-  local security policy prevents &rootuser; login using SSH, the script
-  execution will fail on all remote nodes. Even attempting to run the script
-  as user <systemitem class="username">hacluster</systemitem> will fail
-  because this is a service account, and its shell is set to
-  <filename>/bin/false</filename>, which prevents login. Creating a
-  dedicated local user is the only option to successfully run the
-  <command>crm report</command> script on
-  all nodes in the &ha; cluster.
- </para>
+
  <sect1 xml:id="sec-crmreport-nonroot-user">
   <title>Creating a local user account</title>
 

--- a/xml/ha_crmreport_passl.xml
+++ b/xml/ha_crmreport_passl.xml
@@ -380,6 +380,13 @@ ALL     ALL=(ALL) ALL
      to run <command>crm report</command>, your local SSH keys are passed to the node for
      authentication.
     </para>
+    <note>
+     <title>SSH agent forwarding for <command>crm report</command> only</title>
+     <para>
+      SSH agent forwarding is only supported for <command>crm report</command>,
+      not for any other &crmsh; functions.
+     </para>
+    </note>
    </step>
   </procedure>
 


### PR DESCRIPTION
### PR creator: Description

New feature allowing you to set up the cluster and run cluster tasks as a sudo user instead of root. I'll include details of the changes in a comment.


### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-2861


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
