### PR TITLE
Add warning about live migration in active clusters

### DIFF
--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -160,6 +160,36 @@
     virtual servers and services running in physical servers. Guest
     systems can be managed as services by the cluster.
    </para>
+   <important>
+    <title>Live migration in &ha; clusters</title>
+    <para>
+     Use caution when performing live migration in an active cluster. The cluster stack
+     might not tolerate an operating system freeze caused by the live migration process,
+     which could lead to the node being fenced.
+    </para>
+    <para>
+     We recommend either of the following actions to help avoid node fencing during live migration:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       Increase the &corosync; token timeout and the SBD watchdog timeout, along with
+       any other related settings. The appropriate values depend on your specific setup.
+       For more information, see <xref linkend="sec-ha-storage-protect-watchdog-timings"/>.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Before performing live migration, stop the cluster services on either the node or
+       the whole cluster. For more information, see <xref linkend="sec-ha-maint-overview"/>.
+      </para>
+     </listitem>
+    </itemizedlist>
+    <para>
+     You <emphasis role="bold">must</emphasis> thoroughly test this setup before attempting
+     live migration in a production environment.
+    </para>
+   </important>
   </sect2>
 
   <sect2 xml:id="sec-ha-features-geo">

--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -163,9 +163,9 @@
    <important>
     <title>Live migration in &ha; clusters</title>
     <para>
-     Use caution when performing live migration in an active cluster. The cluster stack
-     might not tolerate an operating system freeze caused by the live migration process,
-     which could lead to the node being fenced.
+     Use caution when performing live migration of nodes in an active cluster.
+     The cluster stack might not tolerate an operating system freeze caused by the
+     live migration process, which could lead to the node being fenced.
     </para>
     <para>
      We recommend either of the following actions to help avoid node fencing during live migration:


### PR DESCRIPTION
### PR creator: Description

Live migration is supported, but is risky. I've added a warning along with suggestions for lowering the risk.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1210426
* jsc#DOCTEAM-969


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3 **(adjust description of stopping cluster services)**
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
