### PR TITLE
Change sdX names to stable names where appropriate

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -127,14 +127,15 @@
     <title>Creating LVM devices for DRBD</title>
     <step>
      <para>
-      Create an LVM physical volume, replacing <filename>/dev/sdb1</filename>
+      Create an LVM physical volume, replacing
+      <filename>/dev/<replaceable>DEVICE_ID</replaceable></filename>
       with your corresponding device for LVM:</para>
-     <screen>&prompt.root;<command>crm cluster run "pvcreate /dev/sdb1"</command></screen>
+     <screen>&prompt.root;<command>crm cluster run "pvcreate /dev/<replaceable>DEVICE_ID</replaceable>"</command></screen>
     </step>
     <step>
      <para>Create an LVM volume group <systemitem>nfs</systemitem>
             that includes this physical volume: </para>
-     <screen>&prompt.root;<command>crm cluster run "vgcreate nfs /dev/sdb1"</command></screen>
+     <screen>&prompt.root;<command>crm cluster run "vgcreate nfs /dev/<replaceable>DEVICE_ID</replaceable>"</command></screen>
     </step>
     <step>
       <para>

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -128,14 +128,14 @@
     <step>
      <para>
       Create an LVM physical volume, replacing
-      <filename>/dev/<replaceable>DEVICE_ID</replaceable></filename>
+      <filename>/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></filename>
       with your corresponding device for LVM:</para>
-     <screen>&prompt.root;<command>crm cluster run "pvcreate /dev/<replaceable>DEVICE_ID</replaceable>"</command></screen>
+     <screen>&prompt.root;<command>crm cluster run "pvcreate /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>"</command></screen>
     </step>
     <step>
      <para>Create an LVM volume group <systemitem>nfs</systemitem>
             that includes this physical volume: </para>
-     <screen>&prompt.root;<command>crm cluster run "vgcreate nfs /dev/<replaceable>DEVICE_ID</replaceable>"</command></screen>
+     <screen>&prompt.root;<command>crm cluster run "vgcreate nfs /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>"</command></screen>
     </step>
     <step>
       <para>

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -214,7 +214,7 @@
      <para>
      Assuming you already have two shared disks, create a shared VG with them:
      </para>
-     <screen>&prompt.root;<command>vgcreate --shared vg1 /dev/sda /dev/sdb</command></screen>
+     <screen>&prompt.root;<command>vgcreate --shared vg1 /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable></command></screen>
     </step>
     <step>
      <para>
@@ -529,9 +529,11 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
     </step>
     <step>
      <para>
-     Create the shared volume group on disks <filename>/dev/sdd</filename> and <filename>/dev/sde</filename>:
+     Create the shared volume group on disks <filename>/dev/sdd</filename> and
+     <filename>/dev/sde</filename>, using their stable device names (for example, in
+      <filename>/dev/disk/by-id/</filename>):
      </para>
-<screen>&prompt.root;<command>vgcreate --shared testvg /dev/sdd /dev/sde</command></screen>
+<screen>&prompt.root;<command>vgcreate --shared testvg /dev/<replaceable>DEVICE_ID</replaceable> /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
     </step>
     <step>
      <para>

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -214,7 +214,7 @@
      <para>
      Assuming you already have two shared disks, create a shared VG with them:
      </para>
-     <screen>&prompt.root;<command>vgcreate --shared vg1 /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable></command></screen>
+     <screen>&prompt.root;<command>vgcreate --shared vg1 /dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable> /dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable></command></screen>
     </step>
     <step>
      <para>
@@ -533,7 +533,7 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
      <filename>/dev/sde</filename>, using their stable device names (for example, in
       <filename>/dev/disk/by-id/</filename>):
      </para>
-<screen>&prompt.root;<command>vgcreate --shared testvg /dev/<replaceable>DEVICE_ID</replaceable> /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+<screen>&prompt.root;<command>vgcreate --shared testvg /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
     </step>
     <step>
      <para>

--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -100,7 +100,8 @@
        device on the node running the DLM resource with the following command:
       </para>
       <screen>&prompt.root;<command>mdadm --create /dev/md0 --bitmap=clustered \
---metadata=1.2 --raid-devices=2 --level=mirror /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable></command></screen>
+--metadata=1.2 --raid-devices=2 --level=mirror \
+/dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable> /dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable></command></screen>
       <para>
        As Cluster MD only works with version 1.2 of the metadata, it is
        recommended to specify the version using the <option>--metadata</option>
@@ -123,7 +124,8 @@
        cluster node:
       </para>
      <screen>&prompt.root;<command>mdadm --create /dev/md0 --bitmap=clustered --raid-devices=2 \
---level=mirror --spare-devices=1 /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable> /dev/<replaceable>DEVICE_ID3</replaceable> --metadata=1.2</command></screen>
+--level=mirror --spare-devices=1 --metadata=1.2 \
+/dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable> /dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable> /dev/disk/by-id/<replaceable>DEVICE_ID3</replaceable></command></screen>
      </listitem>
     </itemizedlist>
    </step>
@@ -137,7 +139,7 @@
    <step>
     <para>Open <filename>/etc/mdadm.conf</filename> and add the md device name
      and the devices associated with it. Use the UUID from the previous step: </para>
-<screen>DEVICE /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable>
+<screen>DEVICE /dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable> /dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable>
 ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
    <step>
@@ -198,7 +200,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
   <para>
    Use the following command on one cluster node:
   </para>
-  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --add /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --add /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
 
   <para>The behavior of the new device added depends on the state of the Cluster
    MD device:</para>
@@ -227,7 +229,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
   </para>
   <para>
    To re-add the device, run the following command on one cluster node: </para>
-  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --re-add /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --re-add /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
  </sect1>
 
 
@@ -242,11 +244,11 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
    <step>
     <para>Run the following command on one cluster node to make a device fail:</para>
-    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --fail /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --fail /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
    </step>
    <step>
     <para>Remove the failed device using the command on one cluster node:</para>
-    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --remove /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --remove /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
    </step>
   </procedure>
  </sect1>

--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -78,9 +78,9 @@
   </itemizedlist>
 
   <para>
-   This procedure uses <literal>/dev/sd<replaceable>X</replaceable></literal>
-   device names as examples. For better stability, use persistent device names
-   such as <literal>/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></literal>.
+   For better stability, use persistent device names
+   such as <literal>/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></literal>
+   instead of <literal>/dev/sd<replaceable>X</replaceable></literal> names.
   </para>
 
   <procedure>
@@ -100,7 +100,7 @@
        device on the node running the DLM resource with the following command:
       </para>
       <screen>&prompt.root;<command>mdadm --create /dev/md0 --bitmap=clustered \
-   --metadata=1.2 --raid-devices=2 --level=mirror /dev/sda /dev/sdb</command></screen>
+--metadata=1.2 --raid-devices=2 --level=mirror /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable></command></screen>
       <para>
        As Cluster MD only works with version 1.2 of the metadata, it is
        recommended to specify the version using the <option>--metadata</option>
@@ -123,7 +123,7 @@
        cluster node:
       </para>
      <screen>&prompt.root;<command>mdadm --create /dev/md0 --bitmap=clustered --raid-devices=2 \
-      --level=mirror --spare-devices=1 /dev/sda /dev/sdb /dev/sdc --metadata=1.2</command></screen>
+--level=mirror --spare-devices=1 /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable> /dev/<replaceable>DEVICE_ID3</replaceable> --metadata=1.2</command></screen>
      </listitem>
     </itemizedlist>
    </step>
@@ -137,7 +137,7 @@
    <step>
     <para>Open <filename>/etc/mdadm.conf</filename> and add the md device name
      and the devices associated with it. Use the UUID from the previous step: </para>
-<screen>DEVICE /dev/sda /dev/sdb
+<screen>DEVICE /dev/<replaceable>DEVICE_ID1</replaceable> /dev/<replaceable>DEVICE_ID2</replaceable>
 ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
    <step>
@@ -198,7 +198,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
   <para>
    Use the following command on one cluster node:
   </para>
-  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --add /dev/sdc</command></screen>
+  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --add /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
 
   <para>The behavior of the new device added depends on the state of the Cluster
    MD device:</para>
@@ -227,7 +227,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
   </para>
   <para>
    To re-add the device, run the following command on one cluster node: </para>
-  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --re-add /dev/sdb</command></screen>
+  <screen>&prompt.root;<command>mdadm --manage /dev/md0 --re-add /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
  </sect1>
 
 
@@ -242,11 +242,11 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
    </step>
    <step>
     <para>Run the following command on one cluster node to make a device fail:</para>
-    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --fail /dev/sda</command></screen>
+    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --fail /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
    </step>
    <step>
     <para>Remove the failed device using the command on one cluster node:</para>
-    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --remove /dev/sda</command></screen>
+    <screen>&prompt.root;<command>mdadm --manage /dev/md0 --remove /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
    </step>
   </procedure>
  </sect1>

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -172,7 +172,7 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
    <para>
     The following procedure uses the server names &node1; and &node2;,
     and the cluster resource name <literal>r0</literal>. It sets up
-    &node1; as the primary node and <filename>/dev/sda1</filename> for
+    &node1; as the primary node and <filename>/dev/disk/by-id/example-disk1</filename> for
     storage. Make sure to modify the instructions to use your own nodes and
     file names.
    </para>
@@ -300,7 +300,7 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
       </para>
 <screen>resource r0 { <co xml:id="co-drbd-config-r0"/>
   device /dev/drbd0; <co xml:id="co-drbd-config-device"/>
-  disk /dev/sda1; <co xml:id="co-drbd-config-disk"/>
+  disk /dev/disk/by-id/example-disk1; <co xml:id="co-drbd-config-disk"/>
   meta-disk internal; <co xml:id="co-drbd-config-meta-disk"/>
   on &node1; { <co xml:id="co-drbd-config-resname"/>
     address  &subnetI;.10:7788; <co xml:id="co-drbd-config-address"/>
@@ -515,8 +515,8 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
          <para>
           A real device may also be used for multiple DRBD resources. For
           example, if your <guimenu>Meta-Disk</guimenu> is
-          <filename>/dev/sda6[0]</filename> for the first resource, you may
-          use <filename>/dev/sda6[1]</filename> for the second resource.
+          <filename>/dev/disk/by-id/example-disk6[0]</filename> for the first resource, you may
+          use <filename>/dev/disk/by-id/example-disk6[1]</filename> for the second resource.
           However, there must be at least 128 MB space for each resource
           available on this disk. The fixed metadata size limits the maximum
           data size that you can replicate.
@@ -555,7 +555,7 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
        will be rejected in the LVM filter. Only <filename>/dev/drbd</filename>
        can be scanned for an LVM device.</para>
      <para>
-       For example, if <filename>/dev/sda1</filename> is used as a DRBD disk,
+       For example, if <filename>/dev/disk/by-id/example-disk1</filename> is used as a DRBD disk,
        the device name will be inserted as the first entry in the LVM filter.
        To change the filter manually, click the
        <guimenu>Modify LVM Device Filter Automatically</guimenu> check box.
@@ -765,7 +765,7 @@ r0 role:Primary
 resource r0 {
   protocol C;
   device    /dev/drbd0;
-  disk      /dev/sda1;
+  disk      /dev/disk/by-id/example-disk1;
   meta-disk internal;
 
   on &cluster1;-&node1; {
@@ -786,7 +786,7 @@ resource r0-U {
   }
 
   on &cluster2;-&node3; {
-    disk       /dev/sda10;
+    disk       /dev/disk/by-id/example-disk10;
     address    &subnetII;.2:7910; # Public IP of the backup node<!-- 10.0.0.2 -->
     meta-disk  internal;
   }

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -140,9 +140,7 @@
    </step>
    <step>
     <para>
-     Configure <literal>external/sbd</literal> as fencing device with
-     <literal>/dev/sdb2</literal> being a dedicated partition on the shared
-     storage for heartbeating and fencing:
+     Configure <literal>external/sbd</literal> as the fencing device:
     </para>
 <screen>&prompt.crm.conf;<command>primitive sbd_stonith stonith:external/sbd \
     params pcmk_delay_max=30 meta target-role="Started"</command></screen>
@@ -261,15 +259,19 @@
      the <command>mkfs.gfs2</command> man page.
     </para>
     <para>
-     For example, to create a new GFS2 file system on
-     <filename>/dev/sdb1</filename> that supports up to 32 cluster nodes,
+     For example, to create a new GFS2 file system
+     that supports up to 32 cluster nodes,
      use the following command:
     </para>
-<screen>&prompt.root;<command>mkfs.gfs2 -t hacluster:mygfs2 -p lock_dlm -j 32 /dev/sdb1</command></screen>
+<screen>&prompt.root;<command>mkfs.gfs2 -t hacluster:mygfs2 -p lock_dlm -j 32 /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
     <para>
      The <systemitem class="server">hacluster</systemitem> name relates to
      the entry <option>cluster_name</option> in the file
      <filename>/etc/corosync/corosync.conf</filename> (this is the default).
+    </para>
+    <para>
+      Always use a stable device name (for example:
+      <filename>/dev/disk/by-id/scsi-ST2000DM001-0123456_Wabcdefg</filename>).
     </para>
    </step>
   </procedure>
@@ -335,7 +337,7 @@
      cluster:
     </para>
 <screen>&prompt.crm.conf;<command>primitive gfs2-1 ocf:heartbeat:Filesystem \
-  params device="/dev/sdb1" directory="/mnt/shared" fstype="gfs2" \
+  params device="/dev/disk/by-partlabel/gfs2-1" directory="/mnt/shared" fstype="gfs2" \
   op monitor interval="20" timeout="40" \
   op start timeout="60" op stop timeout="60" \
   meta target-role="Stopped"</command></screen>

--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -263,7 +263,7 @@
      that supports up to 32 cluster nodes,
      use the following command:
     </para>
-<screen>&prompt.root;<command>mkfs.gfs2 -t hacluster:mygfs2 -p lock_dlm -j 32 /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+<screen>&prompt.root;<command>mkfs.gfs2 -t hacluster:mygfs2 -p lock_dlm -j 32 /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
     <para>
      The <systemitem class="server">hacluster</systemitem> name relates to
      the entry <option>cluster_name</option> in the file
@@ -337,7 +337,7 @@
      cluster:
     </para>
 <screen>&prompt.crm.conf;<command>primitive gfs2-1 ocf:heartbeat:Filesystem \
-  params device="/dev/disk/by-partlabel/gfs2-1" directory="/mnt/shared" fstype="gfs2" \
+  params device="/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>" directory="/mnt/shared" fstype="gfs2" \
   op monitor interval="20" timeout="40" \
   op start timeout="60" op stop timeout="60" \
   meta target-role="Stopped"</command></screen>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -436,7 +436,7 @@
      that supports up to 32 cluster nodes,
      enter the following command:
     </para>
-<screen>&prompt.root;<command>mkfs.ocfs2 -N 32 /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+<screen>&prompt.root;<command>mkfs.ocfs2 -N 32 /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
     <para>
       Always use a stable device name (for example:
       <filename>/dev/disk/by-id/scsi-ST2000DM001-0123456_Wabcdefg</filename>).
@@ -529,7 +529,7 @@
      the cluster:
     </para>
 <screen>&prompt.crm.conf;<command>primitive ocfs2-1 ocf:heartbeat:Filesystem \
-  params device="/dev/disk/by-partlabel/ocfs2-1" directory="/mnt/shared" fstype="ocfs2" \
+  params device="/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>" directory="/mnt/shared" fstype="ocfs2" \
   op monitor interval="20" timeout="40" \
   op start timeout="60" op stop timeout="60" \
   meta target-role="Started"</command></screen>
@@ -606,7 +606,7 @@
      Create the primitive for the first &ocfs; volume:
     </para>
 <screen>&prompt.crm.conf;<command>primitive ocfs2-1 Filesystem \
-  params directory="/srv/ocfs2-1" fstype=ocfs2 device="/dev/disk/by-partlabel/ocfs2-1" \
+  params directory="/srv/ocfs2-1" fstype=ocfs2 device="/dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable>" \
   op monitor interval=20 timeout=40 \
   op start timeout=60 interval=0 \
   op stop timeout=60 interval=0</command></screen>
@@ -616,7 +616,7 @@
      Create the primitive for the second &ocfs; volume:
     </para>
 <screen>&prompt.crm.conf;<command>primitive ocfs2-2 Filesystem \
-  params directory="/srv/ocfs2-2" fstype=ocfs2 device="/dev/disk/by-partlabel/ocfs2-2" \
+  params directory="/srv/ocfs2-2" fstype=ocfs2 device="/dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable>" \
   op monitor interval=20 timeout=40 \
   op start timeout=60 interval=0 \
   op stop timeout=60 interval=0</command></screen>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -252,9 +252,7 @@
    </step>
    <step>
     <para>
-     Configure <literal>external/sbd</literal> as fencing device with
-     <literal>/dev/sdb2</literal> being a dedicated partition on the shared
-     storage for heartbeating and fencing:
+     Configure <literal>external/sbd</literal> as the fencing device:
     </para>
 <screen>&prompt.crm.conf;<command>primitive sbd_stonith stonith:external/sbd \
   params pcmk_delay_max=30 meta target-role="Started"</command></screen>
@@ -434,11 +432,15 @@
      the <command>mkfs.ocfs2</command> man page.
     </para>
     <para>
-     For example, to create a new &ocfs; file system on
-     <filename>/dev/sdb1</filename> that supports up to 32 cluster nodes,
-     enter the following commands:
+     For example, to create a new &ocfs; file system
+     that supports up to 32 cluster nodes,
+     enter the following command:
     </para>
-<screen>&prompt.root;<command>mkfs.ocfs2 -N 32 /dev/sdb1</command></screen>
+<screen>&prompt.root;<command>mkfs.ocfs2 -N 32 /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+    <para>
+      Always use a stable device name (for example:
+      <filename>/dev/disk/by-id/scsi-ST2000DM001-0123456_Wabcdefg</filename>).
+    </para>
 <!-- Brendo, 17.11.2010: maybe add -b 4k in the example (this is common
         for software raids) -->
 <!--taroth 2014-08-14: additional info from bnc#853631:
@@ -527,7 +529,7 @@
      the cluster:
     </para>
 <screen>&prompt.crm.conf;<command>primitive ocfs2-1 ocf:heartbeat:Filesystem \
-  params device="/dev/sdb1" directory="/mnt/shared" fstype="ocfs2" \
+  params device="/dev/disk/by-partlabel/ocfs2-1" directory="/mnt/shared" fstype="ocfs2" \
   op monitor interval="20" timeout="40" \
   op start timeout="60" op stop timeout="60" \
   meta target-role="Started"</command></screen>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -600,20 +600,17 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
     </step>
     <step>
      <para>Initialize the SBD device with the following command: </para>
-<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> create</command></screen>
-     <para>(Replace <filename>/dev/<replaceable>DEVICE_ID</replaceable></filename>
-       with your actual path, for example:
-       <filename>/dev/disk/by-id/scsi-ST2000DM001-0123456_Wabcdefg</filename>.)</para>
+<screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> create</command></screen>
         <para> To use more than one device for SBD, specify the <option>-d</option> option multiple times, for
       example: </para>
-<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID1</replaceable> -d /dev/<replaceable>DEVICE_ID2</replaceable> -d /dev/<replaceable>DEVICE_ID3</replaceable> create</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable> -d /dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable> -d /dev/disk/by-id/<replaceable>DEVICE_ID3</replaceable> create</command></screen>
     </step>
     <step>
      <para>If your SBD device resides on a multipath group, use the <option>-1</option>
       and <option>-4</option> options to adjust the timeouts to use for SBD. For
       details, see <xref linkend="sec-ha-storage-protect-watchdog-timings"/>.
       All timeouts are given in seconds:</para>
-<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> -4 180</command><co xml:id="co-ha-sbd-msgwait"/> <command>-1 90</command><co xml:id="co-ha-sbd-watchdog"/> <command>create</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> -4 180</command><co xml:id="co-ha-sbd-msgwait"/> <command>-1 90</command><co xml:id="co-ha-sbd-watchdog"/> <command>create</command></screen>
      <calloutlist>
       <callout arearefs="co-ha-sbd-msgwait">
        <para> The <option>-4</option> option is used to specify the
@@ -630,7 +627,7 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
     </step>
     <step>
      <para>Check what has been written to the device: </para>
-     <screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> dump</command>
+     <screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> dump</command>
 Header version     : 2.1
 UUID               : 619127f4-0e06-434c-84a0-ea82036e144c
 Number of slots    : 255
@@ -639,7 +636,7 @@ Timeout (watchdog) : 5
 Timeout (allocate) : 2
 Timeout (loop)     : 1
 Timeout (msgwait)  : 10
-==Header on disk /dev/<replaceable>DEVICE_ID</replaceable> is dumped</screen>
+==Header on disk /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> is dumped</screen>
     <para> As you can see, the timeouts are also stored in the header, to ensure
     that all participating nodes agree on them. </para>
     </step>
@@ -672,11 +669,12 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
      </para>
    </step>
    <step>
-    <para> Edit this line by replacing <replaceable>SBD</replaceable> with your SBD device:</para>
-    <screen>SBD_DEVICE="/dev/<replaceable>DEVICE_ID</replaceable>"</screen>
+    <para> Edit this line by replacing /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>
+     with your SBD device:</para>
+    <screen>SBD_DEVICE="/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>"</screen>
     <para> If you need to specify multiple devices in the first line, separate them with semicolons
      (the order of the devices does not matter):</para>
-    <screen>SBD_DEVICE="/dev/<replaceable>DEVICE_ID1</replaceable>;/dev/<replaceable>DEVICE_ID2</replaceable>;/dev/<replaceable>DEVICE_ID3</replaceable>"</screen>
+    <screen>SBD_DEVICE="/dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable>;/dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable>;/dev/disk/by-id/<replaceable>DEVICE_ID3</replaceable>"</screen>
     <para> If the SBD device is not accessible, the daemon fails to start and inhibits
      cluster start-up. </para>
    </step>
@@ -723,7 +721,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     <step>
      <para> The following command dumps the node slots and their current
       messages from the SBD device: </para>
-<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> list</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> list</command></screen>
     <para> Now you should see all cluster nodes that have ever been started with SBD listed here.
      For example, if you have a two-node cluster, the message slot should show
       <literal>clear</literal> for both nodes:</para>
@@ -732,12 +730,13 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     </step>
     <step>
      <para> Try sending a test message to one of the nodes: </para>
-<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> message &node1; test</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> message &node1; test</command></screen>
     </step>
     <step>
      <para> The node acknowledges the receipt of the message in the system
       log files: </para>
-<screen>May 03 16:08:31 &node1; sbd[66139]: /dev/<replaceable>DEVICE_ID</replaceable>: notice: servant: Received command test from &node2; on disk /dev/<replaceable>DEVICE_ID</replaceable></screen>
+<screen>May 03 16:08:31 &node1; sbd[66139]: /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>: notice: servant:
+Received command test from &node2; on disk /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></screen>
      <para> This confirms that SBD is indeed up and running on the node and
       that it is ready to receive messages. </para>
     </step>
@@ -1116,7 +1115,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
    <para>Before you proceed, check if your disk supports
     persistent reservations. Use the following command (replace
      <replaceable>DEVICE_ID</replaceable> with your device name):</para>
-    <screen>&prompt.root;<command>sg_persist -n --in --read-reservation -d /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
+    <screen>&prompt.root;<command>sg_persist -n --in --read-reservation -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></command></screen>
    <para>The result shows whether your disk supports persistent reservations:</para>
     <itemizedlist>
      <listitem>
@@ -1141,7 +1140,7 @@ Illegal request, Invalid opcode</screen>
     </para>
      <screen>&prompt.root;<command>crm configure</command>
 &prompt.crm.conf;<command>primitive sg sg_persist \
-    params devs="/dev/<replaceable>DEVICE_ID</replaceable>" reservation_type=3 \
+    params devs="/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>" reservation_type=3 \
     op monitor interval=60 timeout=60</command></screen>
     </step>
     <step>
@@ -1160,7 +1159,7 @@ Illegal request, Invalid opcode</screen>
      <para> Add a file system primitive for Ext4, using a stable device name for
      the disk partition: </para>
      <screen>&prompt.crm.conf;<command>primitive ext4 Filesystem \
-    params device="/dev/<replaceable>DEVICE_ID</replaceable>" directory="/mnt/ext4" fstype=ext4</command></screen>
+    params device="/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>" directory="/mnt/ext4" fstype=ext4</command></screen>
     </step>
     <step>
      <para> Add the following order relationship plus a collocation between the

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -600,20 +600,20 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
     </step>
     <step>
      <para>Initialize the SBD device with the following command: </para>
-     <screen>&prompt.root;<command>sbd -d /dev/<replaceable>SBD</replaceable> create</command></screen>
-     <para>(Replace <filename>/dev/<replaceable>SBD</replaceable></filename>
+<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> create</command></screen>
+     <para>(Replace <filename>/dev/<replaceable>DEVICE_ID</replaceable></filename>
        with your actual path, for example:
        <filename>/dev/disk/by-id/scsi-ST2000DM001-0123456_Wabcdefg</filename>.)</para>
         <para> To use more than one device for SBD, specify the <option>-d</option> option multiple times, for
       example: </para>
-     <screen>&prompt.root;<command>sbd -d /dev/<replaceable>SBD1</replaceable> -d /dev/<replaceable>SBD2</replaceable> -d /dev/<replaceable>SBD3</replaceable> create</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID1</replaceable> -d /dev/<replaceable>DEVICE_ID2</replaceable> -d /dev/<replaceable>DEVICE_ID3</replaceable> create</command></screen>
     </step>
     <step>
      <para>If your SBD device resides on a multipath group, use the <option>-1</option>
       and <option>-4</option> options to adjust the timeouts to use for SBD. For
       details, see <xref linkend="sec-ha-storage-protect-watchdog-timings"/>.
       All timeouts are given in seconds:</para>
-      <screen>&prompt.root;<command>sbd -d /dev/<replaceable>SBD</replaceable> -4 180</command><co xml:id="co-ha-sbd-msgwait"/> <command>-1 90</command><co xml:id="co-ha-sbd-watchdog"/> <command>create</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> -4 180</command><co xml:id="co-ha-sbd-msgwait"/> <command>-1 90</command><co xml:id="co-ha-sbd-watchdog"/> <command>create</command></screen>
      <calloutlist>
       <callout arearefs="co-ha-sbd-msgwait">
        <para> The <option>-4</option> option is used to specify the
@@ -630,7 +630,7 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
     </step>
     <step>
      <para>Check what has been written to the device: </para>
-     <screen>&prompt.root;<command>sbd -d /dev/<replaceable>SBD</replaceable> dump</command>
+     <screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> dump</command>
 Header version     : 2.1
 UUID               : 619127f4-0e06-434c-84a0-ea82036e144c
 Number of slots    : 255
@@ -639,7 +639,7 @@ Timeout (watchdog) : 5
 Timeout (allocate) : 2
 Timeout (loop)     : 1
 Timeout (msgwait)  : 10
-==Header on disk /dev/<replaceable>SBD</replaceable> is dumped</screen>
+==Header on disk /dev/<replaceable>DEVICE_ID</replaceable> is dumped</screen>
     <para> As you can see, the timeouts are also stored in the header, to ensure
     that all participating nodes agree on them. </para>
     </step>
@@ -673,10 +673,10 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
    </step>
    <step>
     <para> Edit this line by replacing <replaceable>SBD</replaceable> with your SBD device:</para>
-    <screen>SBD_DEVICE="/dev/<replaceable>SBD</replaceable>"</screen>
+    <screen>SBD_DEVICE="/dev/<replaceable>DEVICE_ID</replaceable>"</screen>
     <para> If you need to specify multiple devices in the first line, separate them with semicolons
      (the order of the devices does not matter):</para>
-    <screen>SBD_DEVICE="/dev/<replaceable>SBD1</replaceable>;/dev/<replaceable>SBD2</replaceable>;/dev/<replaceable>SBD3</replaceable>"</screen>
+    <screen>SBD_DEVICE="/dev/<replaceable>DEVICE_ID1</replaceable>;/dev/<replaceable>DEVICE_ID2</replaceable>;/dev/<replaceable>DEVICE_ID3</replaceable>"</screen>
     <para> If the SBD device is not accessible, the daemon fails to start and inhibits
      cluster start-up. </para>
    </step>
@@ -723,7 +723,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     <step>
      <para> The following command dumps the node slots and their current
       messages from the SBD device: </para>
-     <screen>&prompt.root;<command>sbd -d /dev/<replaceable>SBD</replaceable> list</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> list</command></screen>
     <para> Now you should see all cluster nodes that have ever been started with SBD listed here.
      For example, if you have a two-node cluster, the message slot should show
       <literal>clear</literal> for both nodes:</para>
@@ -732,12 +732,12 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
     </step>
     <step>
      <para> Try sending a test message to one of the nodes: </para>
-     <screen>&prompt.root;<command>sbd -d /dev/<replaceable>SBD</replaceable> message &node1; test</command></screen>
+<screen>&prompt.root;<command>sbd -d /dev/<replaceable>DEVICE_ID</replaceable> message &node1; test</command></screen>
     </step>
     <step>
      <para> The node acknowledges the receipt of the message in the system
       log files: </para>
-     <screen>May 03 16:08:31 &node1; sbd[66139]: /dev/<replaceable>SBD</replaceable>: notice: servant: Received command test from &node2; on disk /dev/<replaceable>SBD</replaceable></screen>
+<screen>May 03 16:08:31 &node1; sbd[66139]: /dev/<replaceable>DEVICE_ID</replaceable>: notice: servant: Received command test from &node2; on disk /dev/<replaceable>DEVICE_ID</replaceable></screen>
      <para> This confirms that SBD is indeed up and running on the node and
       that it is ready to receive messages. </para>
     </step>
@@ -1115,8 +1115,8 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
    </note>
    <para>Before you proceed, check if your disk supports
     persistent reservations. Use the following command (replace
-     <replaceable>DISK</replaceable> with your device name):</para>
-    <screen>&prompt.root;<command>sg_persist -n --in --read-reservation -d /dev/<replaceable>DISK</replaceable></command></screen>
+     <replaceable>DEVICE_ID</replaceable> with your device name):</para>
+    <screen>&prompt.root;<command>sg_persist -n --in --read-reservation -d /dev/<replaceable>DEVICE_ID</replaceable></command></screen>
    <para>The result shows whether your disk supports persistent reservations:</para>
     <itemizedlist>
      <listitem>
@@ -1136,11 +1136,12 @@ Illegal request, Invalid opcode</screen>
    <procedure>
     <step>
      <para>
-      To create the primitive resource <literal>sg_persist</literal>,
-      run the following commands as &rootuser;: </para>
+      Create the primitive resource <literal>sg_persist</literal>,
+      using a stable device name for the disk:
+    </para>
      <screen>&prompt.root;<command>crm configure</command>
 &prompt.crm.conf;<command>primitive sg sg_persist \
-    params devs="/dev/sdc" reservation_type=3 \
+    params devs="/dev/<replaceable>DEVICE_ID</replaceable>" reservation_type=3 \
     op monitor interval=60 timeout=60</command></screen>
     </step>
     <step>
@@ -1151,14 +1152,15 @@ Illegal request, Invalid opcode</screen>
     </step>
     <step>
      <para>Test the setup. When the resource is promoted, you can
-      mount and write on <filename>/dev/sdc1</filename> on the cluster node where
+      mount and write to the disk partitions on the cluster node where
       the primary instance is running, but you cannot write on the cluster node
       where the secondary instance is running.</para>
     </step>
     <step>
-     <para> Add a file system primitive for Ext4: </para>
+     <para> Add a file system primitive for Ext4, using a stable device name for
+     the disk partition: </para>
      <screen>&prompt.crm.conf;<command>primitive ext4 Filesystem \
-    params device="/dev/sdc1" directory="/mnt/ext4" fstype=ext4</command></screen>
+    params device="/dev/<replaceable>DEVICE_ID</replaceable>" directory="/mnt/ext4" fstype=ext4</command></screen>
     </step>
     <step>
      <para> Add the following order relationship plus a collocation between the

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -1152,7 +1152,7 @@ Illegal request, Invalid opcode</screen>
     <step>
      <para>Test the setup. When the resource is promoted, you can
       mount and write on <filename>/dev/sdc1</filename> on the cluster node where
-      the primary instance is running, while you cannot write on the cluster node
+      the primary instance is running, but you cannot write on the cluster node
       where the secondary instance is running.</para>
     </step>
     <step>
@@ -1163,7 +1163,7 @@ Illegal request, Invalid opcode</screen>
     <step>
      <para> Add the following order relationship plus a collocation between the
       <literal>sg_persist</literal> clone and the file system resource: </para>
-     <screen>&prompt.crm.conf;<command>order o-ms-sg-before-ext4 Mandatory: clone-sg:promote ext4:start</command>
+     <screen>&prompt.crm.conf;<command>order o-clone-sg-before-ext4 Mandatory: clone-sg:promote ext4:start</command>
 &prompt.crm.conf;<command>colocation col-ext4-with-sg-persist inf: ext4 clone-sg:Promoted</command></screen>
     </step>
     <step>


### PR DESCRIPTION
### PR creator: Description

Changes sdX names to stable names (or replaceables), especially in commands where it's very easy to just copy what's there without thinking. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1213522
* jsc#DOCTEAM-1057


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
