### PR TITLE
Fix removing resources with crmsh procedure

### DIFF
--- a/xml/ha_managing_resources.xml
+++ b/xml/ha_managing_resources.xml
@@ -535,31 +535,29 @@ primitive admin_addr IPaddr2 \
       Log in as &rootuser; and start the <command>crm</command>
       interactive shell:
      </para>
- <screen>&prompt.root;<command>crm configure</command></screen>
+ <screen>&prompt.root;<command>crm</command></screen>
     </step>
     <step>
      <para>
-      Run the following command to get a list of your resources:
+      Get a list of your resources:
      </para>
- <screen>&prompt.crm;<command>resource status</command></screen>
-     <para>
-      For example, the output can look like this (where <quote>myIP</quote> is the
-      relevant identifier of your resource):
-     </para>
- <screen>myIP    (ocf:IPaddr:heartbeat) ...</screen>
+ <screen>&prompt.crm;<command>resource status</command>
+Full List of Resources:
+  * admin-ip     (ocf:heartbeat:IPaddr2):     Started
+  * stonith-sbd  (stonith:external/sbd):      Started
+  * nfsserver    (ocf:heartbeat:nfsserver):   Started</screen>
+    </step>
+    <step>
+      <para>
+        Stop the resource you want to remove:
+      </para>
+<screen>&prompt.crm;<command>resource stop <replaceable>RESOURCE</replaceable></command></screen>
     </step>
     <step>
      <para>
-      Delete the resource with the relevant identifier (which implies a
-      <command>commit</command> too):
+      Delete the resource:
      </para>
- <screen>&prompt.crm;<command>configure delete <replaceable>YOUR_ID</replaceable></command></screen>
-    </step>
-    <step>
-     <para>
-      Commit the changes:
-     </para>
- <screen>&prompt.crm;<command>configure commit</command></screen>
+ <screen>&prompt.crm;<command>configure delete <replaceable>RESOURCE</replaceable></command></screen>
     </step>
    </procedure>
   </sect2>


### PR DESCRIPTION
### PR creator: Description

I ran into the initial issue with procedure (need to stop the resource first) while doing something else. I've since tested it, both typing the full commands and via the crm shell, and found this wasn't the only issue. I have therefore fixed up the whole procedure.


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-1113


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
