### PR TITLE
Add info about allow-unhealthy-nodes attribute

### DIFF
--- a/xml/ha_configuring_resources.xml
+++ b/xml/ha_configuring_resources.xml
@@ -1574,14 +1574,14 @@ hostname (string): Hostname
    with the <command>crm_resource --meta</command> command or with &hawk2;.
   </para>
   <para>
-   The following resource options are available:
+   The following list shows some common options:
   </para>
   <variablelist>
    <varlistentry>
     <term><literal>priority</literal></term>
     <listitem>
      <para>
-      If not all resources can be active, the cluster stops lower-priority 
+      If not all resources can be active, the cluster stops lower-priority
       resources to keep higher-priority resources active.
      </para>
      <para>
@@ -1701,6 +1701,18 @@ hostname (string): Hostname
       <literal>false</literal> for all other resources.
      </para>
     </listitem>
+   </varlistentry>
+   <varlistentry>
+     <term><literal>allow-unhealthy-nodes</literal></term>
+     <listitem>
+       <para>
+        Allows the resource to run on a node even if the node's health score would otherwise
+        prevent it.
+       </para>
+       <para>
+         The default value is <literal>false</literal>.
+       </para>
+     </listitem>
    </varlistentry>
    <varlistentry>
     <term><literal>remote-node</literal></term>


### PR DESCRIPTION
### PR creator: Description

Added `allow-unhealthy-nodes` to the list of resource meta attributes. 
Also updated the introductory sentence of the list so that it isn't misleading if the list falls out of date.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1215886
* jsc#DOCTEAM-1126


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
