### PR TITLE
Terminology: LVM, LVM2, and Cluster LVM

### DIFF
--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -126,7 +126,7 @@
        </listitem>
        <listitem>
         <para> The SBD device <emphasis>must not</emphasis>
-         use host-based RAID, LVM2, nor reside on a DRBD* instance.
+         use host-based RAID, LVM, or DRBD*.
         </para>
        </listitem>
       </itemizedlist>

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -11,9 +11,8 @@
       <abstract>
         <para>
     When managing shared storage on a cluster, every node must be informed
-    about changes that are done to the storage subsystem. The Logical Volume
-    Manager&nbsp;2 (LVM2), which is widely used to manage local storage,
-    has been extended to support transparent management of volume groups
+    about changes to the storage subsystem. Logical Volume
+    Manager (LVM) supports transparent management of volume groups
     across the whole cluster. Volume groups shared among multiple hosts
     can be managed using the same commands as local storage.
    </para>
@@ -45,10 +44,10 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Logical volume manager (LVM2)</term>
+    <term>Logical Volume Manager (LVM)</term>
     <listitem>
      <para>
-      LVM2 provides a virtual pool of disk space and enables flexible distribution of
+      LVM provides a virtual pool of disk space and enables flexible distribution of
       one logical volume over several disks.
      </para>
     </listitem>
@@ -57,10 +56,10 @@
     <term>Cluster logical volume manager (&clvm;)</term>
     <listitem>
      <para>
-      The term <literal>&clvm;</literal> indicates that LVM2 is being used
+      The term <literal>&clvm;</literal> indicates that LVM is being used
       in a cluster environment. This needs some configuration adjustments
-      to protect the LVM2 metadata on shared storage. From &sle; 15 onward, the
-      cluster extension uses lvmlockd, which replaces the well-known
+      to protect the LVM metadata on shared storage. From &sle; 15 onward, the
+      cluster extension uses lvmlockd, which replaces
       clvmd. For more information about lvmlockd, see the man page of the
       <command>lvmlockd</command> command (<command>man 8
       lvmlockd</command>).
@@ -71,7 +70,7 @@
     <term>Volume group and logical volume</term>
     <listitem>
      <para>
-      Volume groups (VGs) and logical volumes (LVs) are basic concepts of LVM2.
+      Volume groups (VGs) and logical volumes (LVs) are basic concepts of LVM.
       A volume group is a storage pool of multiple physical
       disks. A logical volume belongs to a volume group, and can be seen as an
       elastic volume on which you can create a file system. In a cluster environment,
@@ -105,8 +104,8 @@
    </listitem>
    <listitem>
     <para>
-     From &sle; 15 onward, we use lvmlockd as the LVM2 cluster extension,
-     rather than clvmd. Make sure the clvmd daemon is not running,
+     From &sle; 15 onward, the cluster extension uses lvmlockd, which replaces
+      clvmd. Make sure the clvmd daemon is not running,
      otherwise lvmlockd will fail to start.
     </para>
    </listitem>
@@ -676,28 +675,26 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
     </step>
     <step>
      <para>
-      <remark role="grammar">taroth 2011-10-24: comment by bwiedemann: as file system
-      mounts or raw usage - *as* raw usage passt nicht - for?</remark>
       The logical volumes within the VG are now available as file system
-      mounts or raw usage. Ensure that services using them have proper
+      mounts for raw usage. Ensure that services using them have proper
       dependencies to collocate them with and order them after the VG has
       been activated.
      </para>
     </step>
    </procedure>
    <para>
-    After finishing these configuration steps, the LVM2 configuration can be
+    After finishing these configuration steps, the LVM configuration can be
     done like on any stand-alone workstation.
    </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-ha-clvm-drbd">
-  <title>Configuring eligible LVM2 devices explicitly</title>
+  <title>Configuring eligible LVM devices explicitly</title>
 
   <para>
    When several devices seemingly share the same physical volume signature
    (as can be the case for multipath devices or DRBD), we recommend to
-   explicitly configure the devices which LVM2 scans for PVs.
+   explicitly configure the devices which LVM scans for PVs.
   </para>
 
   <para>
@@ -707,7 +704,7 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
   </para>
 
   <para>
-   To deactivate a single device for LVM2, do the following:
+   To deactivate a single device for LVM, do the following:
   </para>
 
   <procedure>
@@ -763,7 +760,7 @@ Login to [iface: default, target: iqn.2010-03.de.&wsI;:san1, portal: &wwwip;,326
 <sect1 xml:id="sec-ha-clvm-migrate">
   <title>Online migration from mirror LV to cluster MD</title>
   <para>
-   Starting with &productname; 15, <systemitem class="daemon">cmirrord</systemitem> in cluster LVM is deprecated. We highly
+   Starting with &productname; 15, <systemitem class="daemon">cmirrord</systemitem> in &clvm; is deprecated. We highly
    recommend to migrate the mirror logical volumes in your cluster to cluster MD.
    Cluster MD stands for cluster multi-device and is a software-based
    RAID storage solution for a cluster.

--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -140,7 +140,7 @@
     storage as needed. It supports Fibre Channel or iSCSI storage area
     networks (SANs). Shared disk systems are also supported, but they are
     not a requirement. &productname; also comes with a cluster-aware file
-    system (OCFS2) and the cluster Logical Volume Manager (cluster LVM2).
+    system (OCFS2) and the cluster Logical Volume Manager (&clvm;).
     For replication of your data, use DRBD* to mirror the data of
     a &ha; service from the active node of a cluster to its standby node.
     Furthermore, &productname; also supports CTDB (Cluster Trivial Database),
@@ -555,9 +555,9 @@
   </para>
 
   <important>
-   <title>Shared disk subsystem with LVM2</title>
+   <title>Shared disk subsystem with LVM</title>
    <para>
-    When using a shared disk subsystem with LVM2, that subsystem must be
+    When using a shared disk subsystem with LVM, that subsystem must be
     connected to all servers in the cluster from which it needs to be
     accessed.
    </para>

--- a/xml/ha_config_example.xml
+++ b/xml/ha_config_example.xml
@@ -6,7 +6,7 @@
 ]>
 <!-- Converted by suse-upgrade version 1.1 -->
 <appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ha-config-example">
- <title>Example configuration for OCFS2 and LVM2</title>
+ <title>Example configuration for OCFS2 and LVM</title>
  <info>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:maintainer></dm:maintainer>
@@ -19,18 +19,16 @@
         <dm:repository></dm:repository>
       </dm:docmanager>
     </info>
-    <remark>taroth 2014-08-15: todo - for next revision, also take into account GFS2
-  here...</remark>
  <para>
   The following is an example configuration that can help you setting up
-  your resources for use of either OCFS2, LVM2, or both. The configuration
+  your resources for use of either OCFS2, LVM, or both. The configuration
   below does not represent a complete cluster configuration but is only an
-  extract, including all resources needed for OCFS2 and LVM2, and ignoring
+  extract, including all resources needed for OCFS2 and LVM, and ignoring
   any other resources that you might need. Attributes and attribute values
   may need adjustment to your specific setup.
  </para>
  <example xml:id="ex-ha-config-ocfs2-clvm">
-  <title>Cluster configuration for OCFS2 and LVM2</title>
+  <title>Cluster configuration for OCFS2 and LVM</title>
 <screen>primitive ocf:heartbeat:clvm \
      op start interval="0" timeout="90" \
      op stop interval="0" timeout="100" \

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -19,7 +19,7 @@
  * OCFS2
  * bonding
  * LVS
- * Cluster LVM2
+ * Cluster LVM
  * SAN
  * UDP-->
 <!--taroth 2014-07-04: found this somewhere in my notes, check against current

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -462,7 +462,7 @@
           </para>
          </listitem>
          <listitem>
-          <para>Clustered LVM: <xref
+          <para>&clvm;: <xref
            linkend="sec-ha-clvm-migrate" xrefstyle="select:title nopage"/></para>
          </listitem>
         </itemizedlist>
@@ -525,7 +525,7 @@
           </para>
          </listitem>
          <listitem>
-          <para>Clustered LVM: <xref
+          <para>&clvm;: <xref
            linkend="sec-ha-clvm-migrate" xrefstyle="select:title nopage"/></para>
          </listitem>
         </itemizedlist>
@@ -558,7 +558,7 @@
           </para>
          </listitem>
          <listitem>
-          <para>Clustered LVM: <xref
+          <para>&clvm;: <xref
            linkend="sec-ha-clvm-migrate" xrefstyle="select:title nopage"/></para>
          </listitem>
         </itemizedlist>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -35,7 +35,7 @@
    </para>
    <para>
     In addition to node level fencing, you can use additional mechanisms for storage
-    protection, such as LVM2 exclusive activation or OCFS2 file locking support
+    protection, such as LVM exclusive activation or OCFS2 file locking support
     (resource level fencing). They protect your system against administrative or
     application faults.
    </para>
@@ -203,7 +203,7 @@
    </listitem>
    <listitem>
     <para> The shared storage segment <emphasis>must not</emphasis>
-     use host-based RAID, LVM2, or DRBD*. DRBD can be split, which is
+     use host-based RAID, LVM, or DRBD*. DRBD can be split, which is
      problematic for SBD, as there cannot be two states in SBD.
      Cluster multi-device (Cluster MD) cannot be used for SBD.
     </para>
@@ -1239,12 +1239,12 @@ Illegal request, Invalid opcode</screen>
       </listitem>
       <listitem>
        <para>
-        The shared sfex partition must not use host-based RAID, nor DRBD.
+        The shared sfex partition must not use host-based RAID or DRBD.
        </para>
       </listitem>
       <listitem>
        <para>
-        Using an LVM2 logical volume is possible.
+        Using an LVM logical volume is possible.
        </para>
       </listitem>
      </itemizedlist>

--- a/xml/nfs_quick_clusterscript.xml
+++ b/xml/nfs_quick_clusterscript.xml
@@ -148,7 +148,7 @@
         Death</emphasis>) setup. It is appropriate for clusters
       where all of your data is on the same shared storage. The shared
       storage segment <emphasis>must not</emphasis> use host-based RAID,
-      LVM2, nor DRBD*. See <xref linkend="cha-ha-storage-protect"/> and
+      LVM, or DRBD*. See <xref linkend="cha-ha-storage-protect"/> and
         <xref linkend="cha-ha-fencing"/> for further details. Proceed as
       follows: </para>
 


### PR DESCRIPTION
### PR creator: Description

* Used the existing `clvm` entity in the remaining places where it wasn't used.
* Changed all instances of LVM2 (except package names and command output) to LVM. As far as I can tell, LVM1 is obsolete, so I think it's safe to just use the term LVM without causing confusion.


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-111


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
