### PR TITLE
Add procedure for creating a DRBD cluster resource

### DIFF
--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -171,7 +171,7 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
    <title>Adjustments needed</title>
    <para>
     The following procedure uses the server names &node1; and &node2;,
-    and the cluster resource name <literal>r0</literal>. It sets up
+    and the DRBD resource name <literal>r0</literal>. It sets up
     &node1; as the primary node and <filename>/dev/disk/by-id/example-disk1</filename> for
     storage. Make sure to modify the instructions to use your own nodes and
     file names.
@@ -632,6 +632,45 @@ r0 role:Primary
           <screen>&prompt.root;<command>mount /dev/drbd0 /mnt/</command></screen>
         </step>
     </procedure>
+  </sect2>
+  <sect2 xml:id="sec-ha-drbd-configure-cluster-resource">
+   <title>Creating cluster resources for DRBD</title>
+   <para>
+    After you have initialized your DRBD device, create a cluster resource to manage
+    the DRBD device, and a promotable clone to allow this resource to run on both nodes:
+   </para>
+   <procedure xml:id="pro-ha-drbd-configure-cluster-resource">
+    <title>Creating cluster resources for DRBD</title>
+    <step>
+     <para>
+      Start the <command>crm</command> interactive shell:
+     </para>
+<screen>&prompt.root;<command>crm configure</command></screen>
+    </step>
+    <step>
+     <para>
+      Create a primitive for the DRBD resource <literal>r0</literal>:
+     </para>
+<screen>&prompt.crm.conf;<command>primitive drbd-r0 ocf:linbit:drbd \
+  params drbd_resource="r0" \
+  op monitor interval=15 role=Promoted \
+  op monitor interval=30 role=Unpromoted</command></screen>
+    </step>
+    <step>
+     <para>
+      Create a promotable clone for the <literal>drbd-r0</literal> primitive:
+     </para>
+<screen>&prompt.crm.conf;<command>clone cl-drbd-r0 drbd-r0 \
+  meta promotable="true" promoted-max="1" promoted-node-max="1" \
+  clone-max="2" clone-node-max="1" notify="true" interleave=true</command></screen>
+    </step>
+    <step>
+     <para>
+      Commit this configuration:
+     </para>
+<screen>&prompt.crm.conf;<command>commit</command></screen>
+    </step>
+   </procedure>
   </sect2>
  </sect1>
 


### PR DESCRIPTION
### PR creator: Description

The DRBD chapter was lacking a procedure for adding a cluster resource to manage the DRBD device. However, the HA NFS guide does have this procedure, so I've reproduced it in the DRBD chapter with some minor edits to make it fit the context.

The chapter overall could use improvements to its flow, but that's for another PR.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1211587
* jsc#DOCTEAM-998


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
