### PR TITLE
Add site and location to glossary

### DIFF
--- a/xml/article_geo_clustering.xml
+++ b/xml/article_geo_clustering.xml
@@ -123,8 +123,8 @@
     <listitem>
      <para>
       You have at least two existing clusters that you want to combine into a
-      &geo; cluster. (If you need to set up two clusters first, follow the
-      instructions in the <xref linkend="article-installation"/>.
+      &geo; cluster (if you need to set up two clusters first, follow the
+      instructions in the <xref linkend="article-installation"/>).
       </para>
     </listitem>
    </varlistentry>
@@ -132,8 +132,9 @@
     <term>Meaningful cluster names</term>
     <listitem>
      <para>
-      Each cluster has a meaningful cluster name defined in &corosync.conf;
-      that reflects its location.
+      Each cluster has a meaningful name that reflects its location,
+      for example: <literal>amsterdam</literal> and <literal>berlin</literal>.
+      Cluster names are defined in &corosync.conf;.
      </para>
    </listitem>
    </varlistentry>
@@ -239,7 +240,7 @@
   </para>
   <para>
    You can register to the &scc; and install the &hasi; while installing &sles;,
-   or after installation. For more information, see 
+   or after installation. For more information, see
    <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-register-sle.html">
    &deploy;</link> for &sles;.
   </para>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -273,7 +273,7 @@
      <para>Defines a name for the cluster, by default
         <systemitem>hacluster</systemitem>. This
       is optional and mostly useful for &geo; clusters. Usually, the cluster
-      name reflects the location and makes it easier to distinguish a site
+      name reflects the geographical location and makes it easier to distinguish a site
       inside a &geo; cluster.</para>
     </listitem>
    </varlistentry>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -84,8 +84,7 @@
        <title>Usage scenario:</title>
        <para>Classic stretched clusters, focus on high availability of services
         and local data redundancy. For databases and enterprise
-        resource planning. One of the most popular setups during the last few
-        years.
+        resource planning. One of the most popular setups.
        </para>
       </formalpara>
      </listitem>

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -296,14 +296,6 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm>Geo cluster (geographically dispersed cluster)</glossterm>
-  <glossdef>
-   <para>
-    See <xref linkend="glos-geo"/>.
-    <remark>toms 2014-02-12: (from Phil): refer to new, common chapter</remark>
-   </para>
-  </glossdef>
- </glossentry>
 <!--taroth 2012-01-09: new term (merged from Fabian's version of ha_glossary.xml)-->
 <!--<glossentry><glossterm>high availability</glossterm>
 <glossdef>
@@ -373,7 +365,7 @@ performance will be met during a contractual measurement period.</para>
    </para>
   </glossdef>
  </glossentry>
- <glossentry xml:id="glos-geo"><glossterm>&geo; cluster</glossterm>
+ <glossentry><glossterm>&geo; cluster (geographically dispersed cluster)</glossterm>
   <glossdef>
    <para>
     Consists of multiple, &geo.dispersed; sites with a local cluster

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -84,7 +84,7 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm>booth</glossterm>
+ <glossentry xml:id="glos-booth"><glossterm>booth</glossterm>
   <glossdef>
    <para>
     The instance that manages the failover process between the sites of a
@@ -149,6 +149,15 @@
     the loss of the nodes on the other partition cannot be confirmed, a
     split-brain scenario develops (see also
     <xref linkend="glos-splitbrain"/>).
+   </para>
+  </glossdef>
+ </glossentry>
+ <glossentry>
+  <glossterm>cluster site</glossterm>
+  <glossdef>
+   <para>
+    In &geo; clustering, a cluster site (or just <quote>site</quote>) is a group of
+    nodes in the same physical location, managed by <xref linkend="glos-booth"/>.
    </para>
   </glossdef>
  </glossentry>
@@ -296,6 +305,17 @@
    </para>
   </glossdef>
  </glossentry>
+  <glossentry><glossterm>&geo; cluster (geographically dispersed cluster)</glossterm>
+  <glossdef>
+   <para>
+    Consists of multiple, &geo.dispersed; sites with a local cluster
+    each. The sites communicate via IP. Failover across the sites is
+    coordinated by a higher-level entity, the booth. &geo; clusters need
+    to cope with limited network bandwidth and high latency. Storage is
+    replicated asynchronously.
+   </para>
+  </glossdef>
+ </glossentry>
 <!--taroth 2012-01-09: new term (merged from Fabian's version of ha_glossary.xml)-->
 <!--<glossentry><glossterm>high availability</glossterm>
 <glossdef>
@@ -320,6 +340,14 @@ performance will be met during a contractual measurement period.</para>
     A single cluster in one location (for example, all nodes are located in
     one data center). Network latency can be neglected. Storage is typically
     accessed synchronously by all nodes.
+   </para>
+  </glossdef>
+ </glossentry>
+ <glossentry><glossterm>location</glossterm>
+  <glossdef>
+   <para>
+    In the context of a <emphasis>location constraint</emphasis>, <quote>location</quote>
+    refers to the nodes on which a resource can or cannot run.
    </para>
   </glossdef>
  </glossentry>
@@ -362,17 +390,6 @@ performance will be met during a contractual measurement period.</para>
   <glossdef>
    <para>
     &def-multicast;
-   </para>
-  </glossdef>
- </glossentry>
- <glossentry><glossterm>&geo; cluster (geographically dispersed cluster)</glossterm>
-  <glossdef>
-   <para>
-    Consists of multiple, &geo.dispersed; sites with a local cluster
-    each. The sites communicate via IP. Failover across the sites is
-    coordinated by a higher-level entity, the booth. &geo; clusters need
-    to cope with limited network bandwidth and high latency. Storage is
-    replicated asynchronously.
    </para>
   </glossdef>
  </glossentry>

--- a/xml/ha_loadbalancing.xml
+++ b/xml/ha_loadbalancing.xml
@@ -110,7 +110,7 @@ toms 2014-05-27:
    </listitem>
    <listitem>
     <formalpara>
-     <title>Balance number of connections per server</title>
+     <title>Balancing the number of connections per server</title>
      <para>
       A load balancer between users and servers can divide the number of
       users across multiple servers.
@@ -119,7 +119,7 @@ toms 2014-05-27:
    </listitem>
    <listitem>
     <formalpara>
-     <title>Geo location</title>
+     <title>Geographic location</title>
      <para>
       It is possible to direct clients to a server nearby.
      </para>

--- a/xml/ha_loadbalancing.xml
+++ b/xml/ha_loadbalancing.xml
@@ -119,7 +119,7 @@ toms 2014-05-27:
    </listitem>
    <listitem>
     <formalpara>
-     <title>Geographic location</title>
+     <title>Geographical location</title>
      <para>
       It is possible to direct clients to a server nearby.
      </para>


### PR DESCRIPTION
### PR creator: Description

Added items for "site" and "location" in the glossary. I didn't include the non-constraint meaning of location, even though it's used in a few places, because it's just a regular non-technical word.


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-108


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
