### PR TITLE
generic: get rid of outdated &hasi; entity

### DIFF
--- a/xml/article_geo_clustering.xml
+++ b/xml/article_geo_clustering.xml
@@ -239,7 +239,7 @@
    patterns. These patterns are only available after the &productname; is installed.
   </para>
   <para>
-   You can register to the &scc; and install the &hasi; while installing &sles;,
+   You can register to the &scc; and install &productname; while installing &sles;,
    or after installation. For more information, see
    <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-register-sle.html">
    &deploy;</link> for &sles;.
@@ -259,7 +259,7 @@
     <note>
      <title>Installing software packages on all nodes</title>
      <para>
-      For an automated installation of &sls; &productnumber; and the &hasi;,
+      For an automated installation of &sls; &productnumber; and &productname; &productnumber;,
       use &ay; to clone existing nodes. For more
       information, see <xref linkend="sec-ha-installation-autoyast"/>.
      </para>

--- a/xml/article_installation.xml
+++ b/xml/article_installation.xml
@@ -302,8 +302,8 @@
       This pattern is only available after the &productname; is installed.
     </para>
     <para>
-     You can register with the &scc; and install the &hasi; while installing &sles;,
-     or after installation. For more information, see the
+      You can register to the &scc; and install &productname; while installing &sles;,
+      or after installation. For more information, see the
      <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-register-sle.html">
      &deploy;</link> for &sles;.
     </para>
@@ -322,8 +322,8 @@
        <note>
         <title>Installing software packages on all nodes</title>
         <para>
-         For an automated installation of &sls; &productnumber; and the &hasi;,
-         use &ay; to clone existing nodes. For more
+          For an automated installation of &sls; &productnumber; and &productname; &productnumber;,
+          use &ay; to clone existing nodes. For more
          information, see <xref linkend="sec-ha-installation-autoyast"/>.
         </para>
        </note>
@@ -336,7 +336,7 @@
    <para>
     Before you can configure SBD with the bootstrap script, you must enable a watchdog
     on each node. &sls; ships with several kernel modules that provide hardware-specific
-    watchdog drivers. The &hasi; uses the SBD daemon as the software component
+    watchdog drivers. &productname; uses the SBD daemon as the software component
     that <quote>feeds</quote> the watchdog.
    </para>
    <para>

--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -47,10 +47,10 @@
       </dm:docmanager>
     </info>
     <sect1 xml:id="sec-ha-availability">
-  <title>Availability as module or extension</title>
+  <title>Availability as a module or extension</title>
 
   <para>
-   &ha; is available as module or extension for several products. For details, see
+   &ha; is available as a module or extension for several products. For details, see
    <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/article-modules.html#art-modules-high-availability"></link>.
   </para>
  </sect1>

--- a/xml/ha_concepts.xml
+++ b/xml/ha_concepts.xml
@@ -24,8 +24,8 @@
     (load balancing) of individually managed cluster resources).
    </para>
    <para>
-    This chapter introduces the main product features and benefits of the
-    &hasi;. Inside you will find several example clusters and learn about
+    This chapter introduces the main product features and benefits of &productname;.
+    Inside you will find several example clusters and learn about
     the components making up a cluster. The last section provides an
     overview of the architecture, describing the individual architecture
     layers and processes within the cluster.
@@ -47,10 +47,11 @@
       </dm:docmanager>
     </info>
     <sect1 xml:id="sec-ha-availability">
-  <title>Availability as extension</title>
+  <title>Availability as module or extension</title>
 
   <para>
-   The &hasi; is available as an extension to &sls; &productnumber;.
+   &ha; is available as module or extension for several products. For details, see
+   <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/article-modules.html#art-modules-high-availability"></link>.
   </para>
  </sect1>
  <sect1 xml:id="sec-ha-features">
@@ -64,7 +65,7 @@
   <sect2 xml:id="sec-ha-features-scenarios">
    <title>Wide range of clustering scenarios</title>
    <para>
-    The &hasi; supports the following scenarios:
+    &productname; supports the following scenarios:
    </para>
    <itemizedlist>
     <listitem>
@@ -122,11 +123,11 @@
   <sect2 xml:id="sec-ha-features-flexibility">
    <title>Flexibility</title>
    <para>
-    The &hasi; ships with &corosync; messaging and membership layer
+    &productname; ships with &corosync; messaging and membership layer
     and Pacemaker Cluster Resource Manager. Using Pacemaker, administrators
     can continually monitor the health and status of their resources, and manage
     dependencies. They can automatically stop and start services based on highly
-    configurable rules and policies. The &hasi; allows you to tailor a
+    configurable rules and policies. &productname; allows you to tailor a
     cluster to the specific applications and hardware infrastructure that
     fit your organization. Time-dependent configuration enables services to
     automatically migrate back to repaired nodes at specified times.
@@ -136,7 +137,7 @@
   <sect2 xml:id="sec-ha-features-storage">
    <title>Storage and data replication</title>
    <para>
-    With the &hasi; you can dynamically assign and reassign server
+    With &productname; you can dynamically assign and reassign server
     storage as needed. It supports Fibre Channel or iSCSI storage area
     networks (SANs). Shared disk systems are also supported, but they are
     not a requirement. &productname; also comes with a cluster-aware file
@@ -155,8 +156,8 @@
     virtual Linux servers. &sls; &productnumber; ships with &xen;,
     an open source virtualization hypervisor, and with &kvm; (Kernel-based
     Virtual Machine). &kvm; is a virtualization software for Linux which is based on
-    hardware virtualization extensions. The cluster resource manager in the
-    &hasi; can recognize, monitor, and manage services running within
+    hardware virtualization extensions. The cluster resource manager in &productname;
+    can recognize, monitor, and manage services running within
     virtual servers and services running in physical servers. Guest
     systems can be managed as services by the cluster.
    </para>
@@ -270,7 +271,7 @@
   <sect2 xml:id="sec-ha-features-tools">
    <title>User-friendly administration tools</title>
    <para>
-    The &hasi; ships with a set of powerful tools. Use them for basic installation
+    &productname; ships with a set of powerful tools. Use them for basic installation
     and setup of your cluster and for effective configuration and
     administration:
    </para>
@@ -280,7 +281,7 @@
      <listitem>
       <para>
        A graphical user interface for general system installation and
-       administration. Use it to install the &hasi; on top of &sls; as
+       administration. Use it to install &productname; on top of &sls; as
        described in the &haquick;. &yast;
        also provides the following modules in the &ha; category to help
        configure your cluster or individual components:
@@ -337,7 +338,7 @@
   <title>Benefits</title>
 
   <para>
-   The &hasi; allows you to configure up to 32 Linux servers into a
+   &productname; allows you to configure up to 32 Linux servers into a
    high-availability cluster (HA cluster). Resources can be
    dynamically switched or moved to any node in the cluster. Resources can
    be configured to automatically migrate if a node fails, or they can be
@@ -345,9 +346,9 @@
   </para>
 
   <para>
-   The &hasi; provides high availability from commodity components. Lower
+   &productname; provides high availability from commodity components. Lower
    costs are obtained through the consolidation of applications and
-   operations onto a cluster. The &hasi; also allows you to centrally
+   operations onto a cluster. &productname; also allows you to centrally
    manage the complete cluster. You can adjust resources to meet changing
    workload requirements (thus, manually <quote>load balance</quote> the
    cluster). Allowing clusters of more than two nodes also provides savings
@@ -413,7 +414,7 @@
   </para>
 
   <para>
-   The following scenario illustrates some benefits the &hasi; can
+   The following scenario illustrates some benefits &productname; can
    provide.
   </para>
 
@@ -480,7 +481,7 @@
   </para>
 
   <para>
-   When Web Server 1 failed, the &hasi; software did the following:
+   When Web Server 1 failed, the &ha; software did the following:
   </para>
 
   <itemizedlist>
@@ -523,13 +524,13 @@
    either automatically fail back (move back) to Web Server 1, or they can
    stay where they are. This depends on how you configured the resources for
    them. Migrating the services back to Web Server 1 will incur some
-   down-time. Therefore the &hasi; also allows you to defer the migration until
+   down-time. Therefore &productname; also allows you to defer the migration until
    a period when it will cause little or no service interruption. There are
    advantages and disadvantages to both alternatives.
   </para>
 
   <para>
-   The &hasi; also provides resource migration capabilities. You can move
+   &productname; also provides resource migration capabilities. You can move
    applications, Web sites, etc. to other servers in your cluster as
    required for system management.
   </para>
@@ -545,7 +546,7 @@
   <title>Cluster configurations: storage</title>
 
   <para>
-   Cluster configurations with the &hasi; might or might not include a
+   Cluster configurations with &productname; might or might not include a
    shared disk subsystem. The shared disk subsystem can be connected via
    high-speed Fibre Channel cards, cables, and switches, or it can be
    configured to use iSCSI. If a node fails, another designated node in
@@ -627,7 +628,7 @@
   <title>Architecture</title>
 
   <para>
-   This section provides a brief overview of the &hasi; architecture. It
+   This section provides a brief overview of &productname; architecture. It
    identifies and provides information on the architectural components, and
    describes how those components interoperate.
   </para>
@@ -635,7 +636,7 @@
   <sect2 xml:id="sec-ha-architecture-layers">
    <title>Architecture layers</title>
    <para>
-    The &hasi; has a layered architecture.
+    &productname; has a layered architecture.
     <xref linkend="fig-ha-architecture" xrefstyle="FigureXRef"/> illustrates
     the different layers and their associated components.
    </para>

--- a/xml/ha_config_basics.xml
+++ b/xml/ha_config_basics.xml
@@ -21,7 +21,7 @@
     This chapter introduces some basic concepts you need to know
     when administering your cluster. The following
     chapters show you how to execute the main configuration and
-    administration tasks with each of the management tools the &hasi;
+    administration tasks with each of the management tools &productname;
     provides.
    </para>
       </abstract>
@@ -407,8 +407,8 @@ C = number of cluster nodes</screen>
     </term>
     <listitem>
      <para>
-      Home page of Pacemaker, the cluster resource manager shipped with the
-      &hasi;.
+      Home page of Pacemaker, the cluster resource manager shipped with
+      &productname;.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/ha_configuring_resources.xml
+++ b/xml/ha_configuring_resources.xml
@@ -80,8 +80,8 @@
     start, stop or monitor command.
    </para>
    <para>
-    Typically, resource agents come in the form of shell scripts. The
-    &hasi; supports the following classes of resource agents:
+    Typically, resource agents come in the form of shell scripts. &productname;
+    supports the following classes of resource agents:
    </para>
    <variablelist>
     <varlistentry xml:id="vle-ha-resources-ocf-ra">
@@ -198,7 +198,7 @@
     </varlistentry>
    </variablelist>
    <para>
-    The agents supplied with the &hasi; are written to OCF
+    The agents supplied with &productname; are written to OCF
     specifications.
    </para>
   </sect1>
@@ -310,7 +310,7 @@
    <para>
     If a resource has specific environment requirements, make sure they are
     present and identical on all cluster nodes. This kind of configuration
-    is not managed by the &hasi;. You must do this yourself.
+    is not managed by &productname;. You must do this yourself.
    </para>
    <para>
     You can create primitive resources using either &hawk2; or &crmsh;.
@@ -318,9 +318,9 @@
    <note>
     <title>Do not touch services managed by the cluster</title>
     <para>
-     When managing a resource with the &hasi;, the same resource must not
+     When managing a resource with &productname;, the same resource must not
      be started or stopped otherwise (outside of the cluster, for example
-     manually or on boot or reboot). The &hasi; software is responsible
+     manually or on boot or reboot). The &ha; software is responsible
      for all service start or stop actions.
     </para>
     <para>

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -153,9 +153,9 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
  <sect1 xml:id="sec-ha-drbd-install">
   <title>Installing DRBD services</title>
   <para>
-   Install the &hasi; on both &sls; machines in your networked
+   Install the &ha; pattern on both &sls; machines in your networked
    cluster as described in <xref linkend="part-install"/>. Installing
-   &hasi; also installs the DRBD program files.
+   the pattern also installs the DRBD program files.
   </para>
 
   <para>
@@ -677,8 +677,8 @@ r0 role:Primary
  <sect1 xml:id="sec-ha-drbd-migrate">
   <title>Migrating from DRBD&nbsp;8 to DRBD&nbsp;9</title>
   <para>
-   Between DRBD&nbsp;8 (shipped with &sle; &hasi;&nbsp;12 SP1) and
-   DRBD&nbsp;9 (shipped with &sle; &hasi;&nbsp;12 SP2), the metadata format
+   Between DRBD&nbsp;8 (shipped with &productname; 12 SP1) and
+   DRBD&nbsp;9 (shipped with &productname;12 SP2), the metadata format
    has changed. DRBD&nbsp;9 does not automatically convert previous metadata
    files to the new format.
   </para>

--- a/xml/ha_example_gui_i.xml
+++ b/xml/ha_example_gui_i.xml
@@ -107,7 +107,7 @@
      <para>
       The name and value are dependent on your hardware configuration and
       what you chose for the media configuration during the installation of
-      the &hasi; software.
+      the &ha; software.
      </para>
     </step>
    </substeps>

--- a/xml/ha_fencing.xml
+++ b/xml/ha_fencing.xml
@@ -138,7 +138,7 @@
 
   <para>
    In a Pacemaker cluster, the implementation of node level fencing is &stonith;
-   (Shoot The Other Node in the Head). The &hasi;
+   (Shoot The Other Node in the Head). &productname;
    includes the <command>stonith</command> command line tool, an extensible
    interface for remotely powering down a node in the cluster. For an
    overview of the available options, run <command>stonith --help</command>
@@ -150,7 +150,7 @@
    <title>&stonith; devices</title>
    <para>
     To use node level fencing, you first need to have a fencing device. To
-    get a list of &stonith; devices which are supported by the &hasi;, run
+    get a list of &stonith; devices which are supported by &productname;, run
     one of the following commands on any of the nodes:
    </para>
 <screen>&prompt.root;<command>stonith -L</command></screen>

--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -188,7 +188,7 @@
   <glossdef>
    <para>
     The management entity responsible for coordinating all non-local
-    interactions in a &ha; cluster. The &hasi; uses Pacemaker as CRM.
+    interactions in a &ha; cluster. &productname; uses Pacemaker as CRM.
     The CRM is implemented as <systemitem
     class="daemon">pacemaker-controld</systemitem>. It interacts with several
     components: local resource managers, both on its own node and on the other nodes,
@@ -450,7 +450,7 @@ performance will be met during a contractual measurement period.</para>
   <glossdef>
    <para>
     A script acting as a proxy to manage a resource (for example, to start,
-    stop, or monitor a resource). The &hasi; supports different
+    stop, or monitor a resource). &productname; supports different
     kinds of resource agents. For details, see
     <xref linkend="sec-ha-config-basics-raclasses"/>.
    </para>

--- a/xml/ha_install.xml
+++ b/xml/ha_install.xml
@@ -10,7 +10,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
  xml:id="cha-ha-install">
 <?dbfo-need height="20em"?>
- <title>Installing the &hasi;</title>
+ <title>Installing &productname;</title>
  <info>
   <abstract>
    <para>If you are setting up a &ha; cluster with &productnamereg; for the first time, the
@@ -40,7 +40,7 @@
  <sect1 xml:id="sec-ha-install-manual">
   <title>Manual installation</title>
   <para>
-   For the manual installation of the packages for &hasi; refer to
+   For the manual installation of the packages for &ha; refer to
    <xref linkend="article-installation"/>. It leads you through the setup of a
    basic two-node cluster.
   </para>

--- a/xml/ha_lb_lvs.xml
+++ b/xml/ha_lb_lvs.xml
@@ -17,7 +17,7 @@
     </info>
     <para>
    The following sections give an overview of the main LVS components and
-   concepts. Then we explain how to set up &lvs; on &hasi;.
+   concepts. Then we explain how to set up &lvs; on &productname;.
   </para>
 
   <sect2 xml:id="sec-ha-lvs-overview-director">

--- a/xml/ha_loadbalancing.xml
+++ b/xml/ha_loadbalancing.xml
@@ -31,7 +31,7 @@ toms 2014-05-27:
   one large, fast server to outside clients. This apparent single server is
   called a <emphasis>virtual server</emphasis>. It consists of one or more
   load balancers dispatching incoming requests and several real servers
-  running the actual services. With a load balancing setup of &hasi;, you
+  running the actual services. With a load balancing setup of &productname;, you
   can build highly scalable and highly available network services, such as
   Web, cache, mail, FTP, media and VoIP services.
  </para>
@@ -41,7 +41,7 @@ toms 2014-05-27:
  <sect1 xml:id="sec-ha-lb-overview">
   <title>Conceptual overview</title>
   <para>
-   &hasi; supports two technologies for load balancing: &lvs; (LVS) and
+   &productname; supports two technologies for load balancing: &lvs; (LVS) and
    &haproxy;. The key difference is &lvs; operates at OSI layer 4
    (Transport), configuring the network layer of kernel, while &haproxy;
    operates at layer 7 (Application), running in user space. Thus &lvs;

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -297,7 +297,7 @@
      attribute.
     </para>
     <para>
-     From this point on, &hasi; will take over cluster management again.
+     From this point on, &ha; will take over cluster management again.
     </para>
    </step>
   </procedure>
@@ -550,7 +550,7 @@ Node <replaceable>&node2;</replaceable>: standby
      that resource.
     </para>
     <para>
-     From this point on, the resource will be managed by the &hasi; software
+     From this point on, the resource will be managed by the &ha; software
      again.
     </para>
    </step>
@@ -611,7 +611,7 @@ Node <replaceable>&node2;</replaceable>: standby
      default value) and apply your changes.
     </para>
     <para>
-     From this point on, the resource will be managed by the &hasi; software
+     From this point on, the resource will be managed by the &ha; software
      again.
     </para>
    </step>
@@ -626,7 +626,7 @@ Node <replaceable>&node2;</replaceable>: standby
        If the cluster or a node is in maintenance mode, you can use tools external
        to the cluster stack (for example, <command>systemctl</command>) to manually
        operate the components that are managed by the cluster as resources.
-       The &hasi; will not monitor them or attempt to restart them.
+       The &ha; software will not monitor them or attempt to restart them.
       </para>
       <para>
        If you stop the cluster services on a node, all daemons and processes

--- a/xml/ha_management.xml
+++ b/xml/ha_management.xml
@@ -44,7 +44,7 @@ from the book, except for a general overview-->
       </dm:docmanager>
     </info>
     <para>
-  &hasi; ships with a comprehensive set of tools to assists you in
+  &productname; ships with a comprehensive set of tools to assists you in
   managing your cluster from the command line. This chapter introduces the
   tools needed for managing the cluster configuration in the CIB and the
   cluster resources. Other command line tools for managing resource agents
@@ -125,7 +125,7 @@ from the book, except for a general overview-->
      database (CIB) for consistency and other problems. It can check a file
      containing the configuration or connect to a running cluster. It
      reports two classes of problems. Errors must be fixed before the
-     &hasi; can work properly while warning resolution is up to the
+     &ha; software can work properly while warning resolution is up to the
      administrator. <command>crm_verify</command> assists in creating new or
      modified configurations. You can take a local copy of a CIB in the
      running cluster, edit it, validate it using

--- a/xml/ha_managing_resources.xml
+++ b/xml/ha_managing_resources.xml
@@ -246,14 +246,14 @@ primitive admin_addr IPaddr2 \
   <note>
    <title>Do not touch services managed by the cluster</title>
    <para>
-    When managing a resource via the &hasi;, the resource must not be started
+    When managing a resource via the &ha; software, the resource must not be started
     or stopped otherwise (outside the cluster, for example manually or on
-    boot or reboot). The &hasi; software is responsible for all service start
+    boot or reboot). The &ha; software is responsible for all service start
     or stop actions.
    </para>
    <para>
     However, if you want to check if the service is configured properly, start
-    it manually, but make sure that it is stopped again before the &hasi; takes
+    it manually, but make sure that it is stopped again before the &ha; software takes
     over.
    </para>
    <para>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -131,7 +131,7 @@
   </para>
 
   <para>
-   The &hasi; has the same supported upgrade paths as the underlying base system. For a complete
+   &productname; has the same supported upgrade paths as the underlying base system. For a complete
    overview, see the section <link
    xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/cha-upgrade-paths.html#sec-upgrade-paths-supported"
    ><citetitle>Supported Upgrade Paths to &sls; &productnumber;</citetitle></link> in the
@@ -810,7 +810,7 @@
    <procedure xml:id="pro-ha-migration-offline">
     <title>Upgrading from product version 11 to 12: cluster offline upgrade</title>
     <para>
-     The &hasi; 12 cluster stack comes with major changes in various
+     &productname; 12 cluster stack comes with major changes in various
      components (for example, &corosync.conf;, disk formats of OCFS2).
      Therefore, a <literal>cluster rolling upgrade</literal> from any &productname;
      11 version is not supported. Instead, all cluster nodes must be offline

--- a/xml/ha_monitoring_clusters.xml
+++ b/xml/ha_monitoring_clusters.xml
@@ -33,7 +33,7 @@
   <title>Monitoring system health with the <literal>SysInfo</literal> resource agent</title>
   <para>
    To prevent a node from running out of disk space and thus being unable to
-   manage any resources that have been assigned to it, the &hasi;
+   manage any resources that have been assigned to it, &productname;
    provides a resource agent,
    <systemitem>ocf:pacemaker:SysInfo</systemitem>. Use it to monitor a
    node's health with regard to disk partitions.

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -141,7 +141,7 @@
 
   <para>
    The &ocfs; Kernel module (<literal>ocfs2</literal>) is installed
-   automatically in the &hasi; on &slsreg; &productnumber;. To use
+   automatically in &productname; &productnumber;. To use
    &ocfs;, make sure the following packages are installed on each node in
    the cluster: <package>ocfs2-tools</package> and
    the matching <package>ocfs2-kmp-*</package>

--- a/xml/ha_remote_hosts.xml
+++ b/xml/ha_remote_hosts.xml
@@ -43,13 +43,13 @@
    </para>
    <para>
     By providing support for monitoring plug-ins (formerly named Nagios
-    plug-ins), the &hasi; now also allows you to monitor services on
+    plug-ins), &productname; now also allows you to monitor services on
     remote hosts. You can collect external statuses on the guests without
     modifying the guest image. For example, VM guests might run Web services
     or simple network resources that need to be accessible. With the Nagios
     resource agents, you can now monitor the Web service or the network
     resource on the guest. If these services are not reachable anymore,
-    the &hasi; triggers a restart or migration of the respective guest.
+    &productname; triggers a restart or migration of the respective guest.
    </para>
    <para>
     If your guests depend on a service (for example, an NFS server to be
@@ -161,7 +161,7 @@ group g-vm1-and-services vm1 vm1-sshd \
     not need to run the cluster stack to become members of the cluster.
    </para>
    <para>
-    The &hasi; can now launch virtual environments (KVM and LXC), plus
+    &productname; can now launch virtual environments (KVM and LXC), plus
     the resources that live within those virtual environments without
     requiring the virtual environments to run &pace; or &corosync;.
    </para>
@@ -173,8 +173,8 @@ group g-vm1-and-services vm1 vm1-sshd \
    <itemizedlist>
     <listitem>
      <para>
-      The <quote>normal</quote> (bare-metal) cluster nodes run the
-      &hasi;.
+      The <quote>normal</quote> (bare-metal) cluster nodes run
+      &productname;.
      </para>
     </listitem>
     <listitem>

--- a/xml/ha_resource_constraints.xml
+++ b/xml/ha_resource_constraints.xml
@@ -1080,7 +1080,7 @@
     the resources diminish in performance (or even fail).
    </para>
    <para>
-    To take this into account, the &hasi; allows you to specify the
+    To take this into account, &productname; allows you to specify the
     following parameters:
    </para>
    <orderedlist spacing="normal">
@@ -1126,7 +1126,7 @@
    </para>
    <para>
     If multiple resources with utilization attributes are grouped or have
-    colocation constraints, the &hasi; takes that into account. If
+    colocation constraints, &productname; takes that into account. If
     possible, the resources is placed on a node that can fulfill
     <emphasis>all</emphasis> capacity requirements.
    </para>
@@ -1140,7 +1140,7 @@
     </para>
    </note>
    <para>
-    The &hasi; also provides the means to detect and configure both node
+    &productname; also provides the means to detect and configure both node
     capacity and resource requirements automatically:
    </para>
    <para>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -381,7 +381,7 @@ stonith-timeout = Timeout (msgwait) + 20%</screen>
    be used as kernel watchdog module.
  </para>
  <para>
-   The &hasi; uses the SBD daemon as the software component that <quote>feeds</quote>
+   &productname; uses the SBD daemon as the software component that <quote>feeds</quote>
    the watchdog.</para>
 
   <sect2 xml:id="sec-ha-storage-protect-hw-watchdog">

--- a/xml/ha_troubleshooting.xml
+++ b/xml/ha_troubleshooting.xml
@@ -45,11 +45,10 @@
      <para>
       The packages needed for configuring and managing a cluster are
       included in the <literal>High Availability</literal> installation
-      pattern, available with the &hasi;.
+      pattern, available with &productname;.
      </para>
      <para>
-      Check if &hasi; is installed as an extension to &sls;
-      &productnumber; on each of the cluster nodes and if the
+      Check if &productname; is installed on each of the cluster nodes and if the
       <guimenu>High Availability</guimenu> pattern is installed on each of
       the machines as described in the &haquick;.
      </para>

--- a/xml/ha_yast_cluster.xml
+++ b/xml/ha_yast_cluster.xml
@@ -599,7 +599,7 @@
        alternatively over the available networks. </para>
      </listitem>
     </itemizedlist>
-    <para>When RRP is used, the &hasi; monitors the status of the current
+    <para>When RRP is used, &productname; monitors the status of the current
      rings and automatically re-enables redundant rings after faults.</para>
     <para>Alternatively, check the ring status manually with
      <command>corosync-cfgtool</command>. View the available options with

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -80,7 +80,7 @@
 "Allow interaction with the in-kernel connection tracking system for
     enabling <emphasis
     xmlns='http://docbook.org/ns/docbook'>stateful</emphasis> packet
-    inspection for iptables. Used by the &hasi; to synchronize the connection
+    inspection for iptables. Used by &productname; to synchronize the connection
     status between cluster nodes.">
 
 <!ENTITY def-ay

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -1,8 +1,8 @@
 <!-- PRODUCT NAME AND VERSIONS -->
-<!ENTITY productname "&sle; &hasi;">
-<!ENTITY productnamereg "&slereg; &hasi;">
+<!ENTITY productname "&sle; &ha;">
+<!ENTITY productnamereg "&slereg; &ha;">
 <!ENTITY productnumber "15 SP5">
-<!ENTITY productnameshort "SLEHA">
+<!ENTITY productnameshort "SLE&nbsp;HA">
 
 <!ENTITY product-ga    "15">
 <!ENTITY product-sp    "5">


### PR DESCRIPTION
### PR creator: Description

To correct the productnames to the approved ones as per our terminology database several steps are needed. This is the first step: 

The following preparations were needed before we can fix the value of `&productname;` via doc-kit:

  * replace `[T,t]he &hasi;` with `&productname;` where appropriate
  * replace `[T,t]he &hasi;` with `&ha; (software)` where appropriate

### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-1133


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [x] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
