### PR TITLE
Add figure titles to make images easier to find

### DIFF
--- a/xml/article_pacemaker_remote.xml
+++ b/xml/article_pacemaker_remote.xml
@@ -127,7 +127,8 @@
        between the cluster node and the remote node (see <xref
         linkend="sec-ha-pmremote-install-phys-remote-nodes"/>).
       </para>
-      <informalfigure>
+      <figure xml:id="fig-ha-pmremote-cluster-remote">
+       <title>Cluster with one remote node</title>
        <mediaobject>
         <imageobject>
          <imagedata fileref="ha_pmremote-phys-remote-nodes.svg" width="45%"/>
@@ -140,7 +141,7 @@
          </phrase>
         </textobject>
        </mediaobject>
-      </informalfigure>
+      </figure>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -153,7 +154,8 @@
        <option>remote-node</option> meta attribute (see
        <xref linkend="sec-ha-pmremote-install-virt-guest-nodes"/>).
       </para>
-      <informalfigure>
+      <figure xml:id="fig-ha-pmremote-cluster-guests">
+       <title>Cluster with guest nodes</title>
        <mediaobject>
         <imageobject>
          <imagedata fileref="ha_pmremote-virt-guest-nodes.svg" width="65%"/>
@@ -166,7 +168,7 @@
          </phrase>
         </textobject>
        </mediaobject>
-      </informalfigure>
+      </figure>
       <para>
        For a physical machine that contains several guest nodes, the
        process is as follows:

--- a/xml/ha_acl.xml
+++ b/xml/ha_acl.xml
@@ -268,7 +268,8 @@
       As <guimenu>Xpath</guimenu>, enter the XPath expression
       <literal>/cib</literal>.
      </para>
-     <informalfigure>
+     <figure>
+      <title>&hawk2; Create Role</title>
       <mediaobject>
        <imageobject role="fo">
         <imagedata fileref="hawk2-acl-role.png" width="100%"/>
@@ -276,8 +277,14 @@
        <imageobject role="html">
         <imagedata fileref="hawk2-acl-role.png" width="100%"/>
        </imageobject>
+       <textobject role="description">
+         <phrase>
+           &hawk2;'s <literal>Create Role</literal> screen, showing where to
+           define rules for an ACL role.
+         </phrase>
+       </textobject>
       </mediaobject>
-     </informalfigure>
+     </figure>
     </step>
     <step>
      <para>

--- a/xml/ha_configuring_resources.xml
+++ b/xml/ha_configuring_resources.xml
@@ -1342,7 +1342,8 @@ hostname (string): Hostname
       To see the attributes belonging to each proposed value, hover the mouse
       pointer over the respective value.
      </para>
-     <informalfigure>
+     <figure>
+      <title>Operation values</title>
       <mediaobject>
        <imageobject role="fo">
         <imagedata fileref="hawk2-monitor-op.png" width="70%"/>
@@ -1350,8 +1351,15 @@ hostname (string): Hostname
        <imageobject role="html">
         <imagedata fileref="hawk2-monitor-op.png" width="60%"/>
        </imageobject>
+       <textobject role="description">
+         <phrase>
+           In the <literal>Operations</literal> list, beside the <literal>monitor</literal>
+           operation, hovering the mouse pointer over the number <literal>20</literal> shows
+           that this is the value for the <literal>timeout</literal> attribute.
+         </phrase>
+       </textobject>
       </mediaobject>
-     </informalfigure>
+     </figure>
     </step>
     <step>
      <para>

--- a/xml/ha_hawk2_history_i.xml
+++ b/xml/ha_hawk2_history_i.xml
@@ -115,18 +115,22 @@
        &hawk2; opens a new window and displays a table view of the latest
        events.
       </para>
-      <informalfigure>
+      <figure>
+       <title>Recent events table</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="hawk2-node-events.png" width="100%"
-         />
+         <imagedata fileref="hawk2-node-events.png" width="100%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="hawk2-node-events.png" width="90%"
-         />
+         <imagedata fileref="hawk2-node-events.png" width="90%"/>
         </imageobject>
+        <textobject role="description">
+          <phrase>
+            A table showing the recent resource operations on node &node1;.
+          </phrase>
+        </textobject>
        </mediaobject>
-      </informalfigure>
+      </figure>
      </step>
     </substeps>
    </step>
@@ -265,18 +269,22 @@
      click the report's name or select <guimenu>Show</guimenu> from the
      <guimenu>Operations</guimenu> column.
     </para>
-    <informalfigure>
+    <figure>
+     <title>&hawk2; report details</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="hawk2-history-report-details.png" width="100%"
-      />
+       <imagedata fileref="hawk2-history-report-details.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="hawk2-history-report-details.png" width="90%"
-      />
+       <imagedata fileref="hawk2-history-report-details.png" width="90%"/>
       </imageobject>
+      <textobject role="description">
+        <phrase>
+          Report details, including the name, time frame, node events, and resource events.
+        </phrase>
+      </textobject>
      </mediaobject>
-    </informalfigure>
+    </figure>
    </step>
    <step>
     <para>

--- a/xml/ha_hawk2_monitor_i.xml
+++ b/xml/ha_hawk2_monitor_i.xml
@@ -196,7 +196,8 @@
        Enter the fully qualified host name of one of the nodes in the second
        cluster. For example, <literal>&node3;</literal>.
       </para>
-      <informalfigure>
+      <figure>
+       <title>&hawk2; add cluster details</title>
        <mediaobject>
         <imageobject role="fo">
          <imagedata fileref="hawk2-dashboard-add-cluster.png" width="100%"/>
@@ -204,8 +205,14 @@
         <imageobject role="html">
          <imagedata fileref="hawk2-dashboard-add-cluster.png" width="100%"/>
         </imageobject>
+        <textobject role="description">
+          <phrase>
+            The <literal>Add Cluster</literal> pop-up has fields for the cluster name,
+            the name of a node in the cluster, and the server port to connect to.
+          </phrase>
+        </textobject>
        </mediaobject>
-      </informalfigure>
+      </figure>
      </step>
      <step>
       <para>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -714,7 +714,8 @@
      The wizard displays the configuration snippet that will be applied to
      the CIB and any additional changes, if required.
     </para>
-    <informalfigure>
+    <figure>
+     <title>&hawk2; summary screen of &ocfs; CIB changes</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="hawk2-wizard-ocfs2-verify.png" width="70%"/>
@@ -722,8 +723,14 @@
       <imageobject role="html">
        <imagedata fileref="hawk2-wizard-ocfs2-verify.png" width="70%"/>
       </imageobject>
+      <textobject role="description">
+        <phrase>
+          A summary screen showing the changes to be applied to the CIB for
+          the &ocfs; resource.
+        </phrase>
+      </textobject>
      </mediaobject>
-    </informalfigure>
+    </figure>
    </step>
    <step>
     <para>

--- a/xml/ha_resource_constraints.xml
+++ b/xml/ha_resource_constraints.xml
@@ -1306,7 +1306,7 @@
        value must be an integer.
       </para>
       <figure>
-       <title>&hawk2;: Edit node utilization attributes</title>
+       <title>&hawk2;: edit node utilization attributes</title>
        <mediaobject>
         <imageobject role="fo">
          <imagedata fileref="hawk2-utilization-node.png" width="100%"/>

--- a/xml/ha_resource_constraints.xml
+++ b/xml/ha_resource_constraints.xml
@@ -915,7 +915,8 @@
        and enter a <guimenu>Value</guimenu> for the
        <literal>failure-timeout</literal>.
       </para>
-      <informalfigure>
+      <figure>
+       <title>&hawk2;: meta attributes for resource failover</title>
        <mediaobject>
         <imageobject role="fo">
          <imagedata fileref="hawk2-failover-node.png" width="100%"/>
@@ -923,8 +924,15 @@
         <imageobject role="html">
          <imagedata fileref="hawk2-failover-node.png" width="100%"/>
         </imageobject>
+        <textobject role="description">
+          <phrase>
+            &hawk2;'s <literal>Edit Primitive</literal> screen, showing where to add
+            and edit the meta attributes <literal>migration-threshold</literal> and
+            <literal>failure-timeout</literal>.
+          </phrase>
+        </textobject>
        </mediaobject>
-      </informalfigure>
+      </figure>
      </step>
      <step>
       <para>
@@ -1050,7 +1058,8 @@
        Specify a value between <literal>-INFINITY</literal> and
        <literal>INFINITY</literal> for <literal>resource-stickiness</literal>.
       </para>
-      <informalfigure>
+      <figure>
+       <title>&hawk2;: meta attributes for resource failback</title>
        <mediaobject>
         <imageobject role="fo">
          <imagedata fileref="hawk2-rsc-stickiness.png" width="100%"/>
@@ -1058,8 +1067,14 @@
         <imageobject role="html">
          <imagedata fileref="hawk2-rsc-stickiness.png" width="100%"/>
         </imageobject>
+        <textobject role="description">
+          <phrase>
+            &hawk2;'s <literal>Edit Primitive</literal> screen, showing where to add
+            and edit the meta attribute <literal>resource-stickiness</literal>.
+          </phrase>
+        </textobject>
        </mediaobject>
-      </informalfigure>
+      </figure>
      </step>
     </procedure>
    </sect2>
@@ -1290,7 +1305,8 @@
        In the empty text box next to the attribute, enter an attribute value. The
        value must be an integer.
       </para>
-      <informalfigure>
+      <figure>
+       <title>&hawk2;: Edit node utilization attributes</title>
        <mediaobject>
         <imageobject role="fo">
          <imagedata fileref="hawk2-utilization-node.png" width="100%"/>
@@ -1298,8 +1314,14 @@
         <imageobject role="html">
          <imagedata fileref="hawk2-utilization-node.png" width="100%"/>
         </imageobject>
+        <textobject role="description">
+          <phrase>
+            &hawk2;'s <literal>Edit Node</literal> screen, showing where to add
+            and edit utilization attributes.
+          </phrase>
+        </textobject>
        </mediaobject>
-      </informalfigure>
+      </figure>
      </step>
      <step>
       <para>


### PR DESCRIPTION
### PR creator: Description

Having figure titles for all images means I can Ctrl-F for "Figure" to check all images that are in use in the doc set. 

I also added descriptions where these were missing for images I added titles to. 


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
