### PR TITLE
conventions: latest doc-kit changes

### DIFF
--- a/xml/common_intro_convention_ha.xml
+++ b/xml/common_intro_convention_ha.xml
@@ -84,20 +84,37 @@
     A cross-reference to another chapter in this guide.
    </para>
   </listitem>
-  <listitem>
+   <listitem>
    <para>
-    Commands that must be run with &rootuser; privileges. Often you can also
+    Commands that must be run with &rootuser; privileges. You can also
     prefix these commands with the <command>sudo</command> command to run them
-    as non-privileged user.
+    as a non-privileged user:
    </para>
    <screen>&prompt.root;<command>command</command>
 &prompt.sudo;<command>command</command></screen>
   </listitem>
   <listitem>
    <para>
-    Commands that can be run by non-privileged users.
+    Commands that can be run by non-privileged users:
    </para>
 <screen>&prompt.user;<command>command</command></screen>
+  </listitem>
+  <listitem>
+   <para>
+    Commands can be split into two or multiple lines by a backslash character
+    (<literal>\</literal>) at the end of a line. The backslash informs the shell that
+    the command invocation will continue after the line's end:
+   </para>
+   <screen>&prompt.user;<command>echo</command> a b \
+c d</screen>
+  </listitem>
+  <listitem>
+    <para>
+     A code block that shows both the command (preceded by a prompt)
+     and the respective output returned by the shell:
+    </para>
+    <screen>&prompt.user;<command>command</command>
+output</screen>
   </listitem>
   <listitem>
    <para>


### PR DESCRIPTION
### PR creator: Description

As doc-sleha uses its own `common_intro_conventions*.xml` file, propagate the latest changes for `common_intro_conventions.xml` from doc-kit manually.


### PR creator: Are there any relevant issues/feature requests?

* see https://github.com/openSUSE/doc-kit/pull/88

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
