### PR TITLE
Remove non-existent id param from IPaddr2 example

### DIFF
--- a/xml/ha_configuring_resources.xml
+++ b/xml/ha_configuring_resources.xml
@@ -708,10 +708,11 @@
        Configure the primitives:
       </para>
 <screen>&prompt.crm;<command>configure</command>
-&prompt.crm.conf;<command>primitive Public-IP ocf:heartbeat:IPaddr \
-    params ip=1.2.3.4 id= Public-IP</command>
+&prompt.crm.conf;<command>primitive Public-IP ocf:heartbeat:IPaddr2 \
+    params ip=1.2.3.4 \
+    op monitor interval=10s</command>
 &prompt.crm.conf;<command>primitive Email systemd:postfix \
-    params id=Email</command></screen>
+    op monitor interval=10s</command></screen>
      </step>
      <step>
       <para>


### PR DESCRIPTION
### PR creator: Description

Updated this resource example to be correct.

![image](https://github.com/SUSE/doc-sleha/assets/3069029/919a6107-a8c6-4d0f-96eb-c4c128188ae4)



### PR creator: Are there any relevant issues/feature requests?

* bsc#1218645
* jsc#DOCTEAM-1212


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
