### PR TITLE
Fix crm configure -> just crm where appropriate

### DIFF
--- a/xml/ha_configuring_resources.xml
+++ b/xml/ha_configuring_resources.xml
@@ -1205,7 +1205,7 @@
      Log in as &rootuser; and start the <command>crm</command>
      interactive shell:
     </para>
-<screen>&prompt.root;<command>crm configure</command></screen>
+<screen>&prompt.root;<command>crm</command></screen>
    </step>
    <step>
     <para>

--- a/xml/ha_lb_haproxy.xml
+++ b/xml/ha_lb_haproxy.xml
@@ -331,7 +331,7 @@ backend LB
    <para>
     Configure a new CIB:
    </para>
-   <screen>&prompt.root;<command>crm configure</command>
+   <screen>&prompt.root;<command>crm</command>
 &prompt.crm;<command>cib new haproxy-config</command>
 &prompt.crmhp;<command>primitive haproxy systemd:haproxy \
     op start timeout=120 interval=0 \


### PR DESCRIPTION
### PR creator: Description

A couple of places said `crm configure` where they should, in that particular context, only say `crm`.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1218647
* jsc#DOCTEAM-1213


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
