### PR TITLE
EOL SLE-HA SP1: Switch validation to DocBook 5.2

### DIFF
--- a/DC-SLE-HA-all
+++ b/DC-SLE-HA-all
@@ -19,3 +19,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLE-HA-geo-guide
+++ b/DC-SLE-HA-geo-guide
@@ -23,3 +23,4 @@ export DOCCONF=$BASH_SOURCE
 
 ##do not show remarks directly in the (PDF) text
 #XSLTPARAM="--param use.xep.annotate.pdf=0"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLE-HA-geo-quick
+++ b/DC-SLE-HA-geo-quick
@@ -23,3 +23,4 @@ export DOCCONF=$BASH_SOURCE
 
 ##do not show remarks directly in the (PDF) text
 #XSLTPARAM="--param use.xep.annotate.pdf=0"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLE-HA-guide
+++ b/DC-SLE-HA-guide
@@ -26,3 +26,4 @@ export DOCCONF=$BASH_SOURCE
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLE-HA-install-quick
+++ b/DC-SLE-HA-install-quick
@@ -23,3 +23,4 @@ export DOCCONF=$BASH_SOURCE
 
 ##do not show remarks directly in the (PDF) text
 #XSLTPARAM="--param use.xep.annotate.pdf=0"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLE-HA-nfs-quick
+++ b/DC-SLE-HA-nfs-quick
@@ -20,3 +20,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ## enable sourcing
 export DOCCONF=$BASH_SOURCE
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLE-HA-pmremote-quick
+++ b/DC-SLE-HA-pmremote-quick
@@ -23,3 +23,4 @@ export DOCCONF=$BASH_SOURCE
 
 ##do not show remarks directly in the (PDF) text
 #XSLTPARAM="--param use.xep.annotate.pdf=0"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"


### PR DESCRIPTION
### PR creator: Description

This change switches the validation schema from GeekoDoc to DocBook 5.2. This ensures that futures changes of GeekoDoc doesn't affect previous, now unsupported documents.


### PR creator: Are there any relevant issues/feature requests?

related to https://gitlab.suse.de/susedoc/docserv-config/-/merge_requests/510

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [x] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

no backport necessary
