### PR TITLE
Add colocation and ordering for clvm

### DIFF
--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -276,31 +276,35 @@
       <itemizedlist>
         <listitem>
           <para>
-            For a single VG using shared activation mode, you can add the VG
-            to the cloned <literal>g-storage</literal> group, which already has
-            internal colocation and order constraints:
+           <emphasis role="bold">Exclusive activation mode:</emphasis>
           </para>
-<screen>&prompt.root;<command>crm configure modgroup g-storage add vg1</command></screen>
-        </listitem>
-        <listitem>
           <para>
-            For a single VG using exclusive activation mode, add constraints directly:
+            Because this VG is only active on a single node, do <emphasis>not</emphasis>
+            add it to the cloned <literal>g-storage</literal> group. Instead, add
+            constraints directly to the resource:
           </para>
 <screen>&prompt.root;<command>crm configure colocation col-vg-with-dlm inf: vg1 cl-storage</command>
 &prompt.root;<command>crm configure order o-dlm-before-vg Mandatory: cl-storage vg1</command></screen>
-        </listitem>
-        <listitem>
           <para>
-            For multiple VGs using exclusive activation mode, you can add constraints
-            that apply to batches of resources:
+            For multiple VGs, you can add constraints to multiple resources at once:
           </para>
 <screen>&prompt.root;<command>crm configure colocation col-vg-with-dlm inf: ( vg1 vg2 ) cl-storage</command>
 &prompt.root;<command>crm configure order o-dlm-before-vg Mandatory: cl-storage ( vg1 vg2 )</command></screen>
         </listitem>
         <listitem>
           <para>
-            For multiple VGs using shared activation mode, you must clone the resources and
-            add constraints to the clones:
+            <emphasis role="bold">Shared activation mode:</emphasis>
+          </para>
+          <para>
+            Because this VG is active on multiple nodes, you can add it to the cloned
+            <literal>g-storage</literal> group, which already has internal colocation
+            and order constraints:
+          </para>
+<screen>&prompt.root;<command>crm configure modgroup g-storage add vg1</command></screen>
+          <para>
+            Do <emphasis>not</emphasis> add multiple VGs to the group, because this
+            creates a dependency between the VGs. For multiple VGs, clone the resources and add
+            constraints to the clones:
           </para>
 <screen>&prompt.root;<command>crm configure clone cl-vg1 vg1 meta interleave=true</command>
 &prompt.root;<command>crm configure clone cl-vg2 vg2 meta interleave=true</command>

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -258,17 +258,46 @@
       </listitem>
       <listitem>
        <para>
-        Use shared activation mode for &ocfs; and add it to the cloned
-        <literal>g-storage</literal> group:
+        Use shared activation mode for &ocfs;:
        </para>
 <screen>&prompt.root;<command>crm configure primitive vg1 LVM-activate \
    params vgname=vg1 vg_access_mode=lvmlockd activation_mode=shared \
    op start timeout=90s interval=0 \
    op stop timeout=90s interval=0 \
-   op monitor interval=30s timeout=90s</command>
-&prompt.root;<command>crm configure modgroup g-storage add vg1</command></screen>
+   op monitor interval=30s timeout=90s</command></screen>
       </listitem>
      </itemizedlist>
+    </step>
+    <step>
+      <para>
+        Make sure the VG can only be activated on nodes where the DLM and
+        <systemitem>lvmlockd</systemitem> resources are already running:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            For a single VG using shared activation mode, you can add the VG
+            to the cloned <literal>g-storage</literal> group, which already has
+            internal colocation and order constraints:
+          </para>
+<screen>&prompt.root;<command>crm configure modgroup g-storage add vg1</command></screen>
+        </listitem>
+        <listitem>
+          <para>
+            For a single VG using exclusive activation mode, add constraints directly:
+          </para>
+<screen>&prompt.root;<command>crm configure colocation col-vg-with-dlm inf: vg1 cl-storage</command>
+&prompt.root;<command>crm configure order o-dlm-before-vg Mandatory: cl-storage vg1</command></screen>
+        </listitem>
+        <listitem>
+          <para>
+            For multiple VGs using either activation mode, you can add constraints
+            that apply to batches of resources:
+          </para>
+<screen>&prompt.root;<command>crm configure colocation col-vg-with-dlm inf: ( vg1 vg2 ) cl-storage</command>
+&prompt.root;<command>crm configure order o-dlm-before-vg Mandatory: cl-storage ( vg1 vg2 )</command></screen>
+        </listitem>
+      </itemizedlist>
     </step>
     <step>
      <para>

--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -291,11 +291,21 @@
         </listitem>
         <listitem>
           <para>
-            For multiple VGs using either activation mode, you can add constraints
+            For multiple VGs using exclusive activation mode, you can add constraints
             that apply to batches of resources:
           </para>
 <screen>&prompt.root;<command>crm configure colocation col-vg-with-dlm inf: ( vg1 vg2 ) cl-storage</command>
 &prompt.root;<command>crm configure order o-dlm-before-vg Mandatory: cl-storage ( vg1 vg2 )</command></screen>
+        </listitem>
+        <listitem>
+          <para>
+            For multiple VGs using shared activation mode, you must clone the resources and
+            add constraints to the clones:
+          </para>
+<screen>&prompt.root;<command>crm configure clone cl-vg1 vg1 meta interleave=true</command>
+&prompt.root;<command>crm configure clone cl-vg2 vg2 meta interleave=true</command>
+&prompt.root;<command>crm configure colocation col-vg-with-dlm inf: ( cl-vg1 cl-vg2 ) cl-storage</command>
+&prompt.root;<command>crm configure order o-dlm-before-vg Mandatory: cl-storage ( cl-vg1 cl-vg2 )</command></screen>
         </listitem>
       </itemizedlist>
     </step>


### PR DESCRIPTION
### PR creator: Description

Added a step to make sure VGs are only activated after DLM is already running. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1222440
* jsc#DOCTEAM-1357


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
