### PR TITLE
Geo Clustering Quick Start: Integrate proofing corrections

### DIFF
--- a/xml/article_geo_clustering.xml
+++ b/xml/article_geo_clustering.xml
@@ -246,7 +246,7 @@
    patterns. These patterns are only available after the &productname; is installed.
   </para>
   <para>
-   You can register to the &scc; and install &productname; while installing &sles;,
+   You can register with the &scc; and install &productname; while installing &sles;,
    or after installation. For more information, see
    <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-register-sle.html">
    &deploy;</link> for &sles;.


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Geo Clustering Quick Start from proofing drop 2.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4
