### PR TITLE
Clarify rear mkbackup vs rear mkrescue

### DIFF
--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -353,10 +353,16 @@
      </term>
      <listitem>
       <para>
-       While the system to be protected is up and running use the
-       <command>rear mkbackup</command> command to create a file backup and
-       to generate a recovery system that contains a system-specific
-       &rear; recovery installer.
+       While the system to be protected is up and running, create a file backup and
+       generate a recovery system that contains a system-specific &rear; recovery installer.
+      </para>
+      <para>
+       For basic backups with <command>tar</command>, use the <command>rear mkbackup</command>
+       command to create both the backup and the recovery system.
+      </para>
+      <para>
+       For third-party backup tools, use the <command>rear mkrescue</command> command
+       to create the recovery system, and use the third-party backup tool to create the backup.
       </para>
      </listitem>
     </varlistentry>
@@ -544,43 +550,65 @@
  </sect1>
  <sect1 xml:id="sec-ha-rear-mkbackup">
   <title>Creating the recovery installation system</title>
-
   <para>
    After you have configured &rear; as described in
    <xref linkend="sec-ha-rear-config" xrefstyle="select:label"/>, create the
-   recovery installation system (including the &rear; recovery installer)
-   plus the file backup with the following command:
+   recovery installation system (including the &rear; recovery installer) plus the file backup.
   </para>
-
-  <screen>rear -d -D mkbackup</screen>
-
-  <para>
-   It executes the following steps:
-  </para>
-
-  <orderedlist spacing="normal">
-   <listitem>
+  <example xml:id="ex-ha-rear-mkbackup">
+    <title>Creating a recovery system with a basic <command>tar</command> backup</title>
     <para>
-     Analyzing the target system and gathering information, in particular
-     about the disk layout (partitioning, file systems, mount points) and
-     about the boot loader.
+      Run the <command>rear mkbackup</command> command:
     </para>
-   </listitem>
-   <listitem>
+<screen>&prompt.root;<command>rear -d -D mkbackup</command></screen>
     <para>
-     Creating a bootable recovery system with the information gathered in
-     the first step. The resulting &rear; recovery installer is
-     <emphasis>specific</emphasis> to the system that you want to protect
-     from disaster. It can only be used to re-create this specific system.
+     This command performs the following steps:
     </para>
-   </listitem>
-   <listitem>
-    <para>
-     Calling the configured backup tool to back up system and user files.
-    </para>
-   </listitem>
-  </orderedlist>
+    <itemizedlist>
+      <listitem>
+        <para>
+        Analyzing the target system and gathering information, in particular
+        about the disk layout (partitioning, file systems, mount points) and
+        about the boot loader.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+        Creating a bootable recovery system with the information gathered in
+        the first step. The resulting &rear; recovery installer is
+        <emphasis>specific</emphasis> to the system that you want to protect
+        from disaster. It can only be used to re-create this specific system.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+        Calling the internal backup tool to back up system files and user files.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </example>
+  <example xml:id="ex-ha-rear-mkrescue">
+    <title>Creating a recovery system with a third-party backup</title>
+    <orderedlist>
+      <listitem>
+        <para>
+          Run the <command>rear mkrescue</command> command:
+        </para>
+<screen>&prompt.root;<command>rear -d -D mkrescue</command></screen>
+        <para>
+          This command analyzes the target and creates a recovery system, but
+          does <emphasis>not</emphasis> create a backup of the files.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Create a file backup using your third-party backup tool.
+        </para>
+      </listitem>
+    </orderedlist>
+  </example>
  </sect1>
+
  <sect1 xml:id="sec-ha-rear-testing">
   <title>Testing the recovery process</title>
 


### PR DESCRIPTION
### PR creator: Description

`rear mkbackup` is only used with the internal backup tool, not with third-party backup tools. These are used separately, in combination with `rear mkrescue`. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1218910
* jsc#DOCTEAM-1243


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [x] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
