### PR TITLE
Add SP6 to upgrade paths

### DIFF
--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -714,6 +714,36 @@
         </itemizedlist>
        </entry>
       </row>
+      <row>
+       <entry>
+        <para>SLE&nbsp;HA&nbsp;15&nbsp;SP5 to
+         SLE&nbsp;HA&nbsp;15&nbsp;SP6</para>
+       </entry>
+       <entry>
+        <para>Cluster Rolling Upgrade</para>
+       </entry>
+       <entry>
+        <itemizedlist>
+         <listitem>
+          <para>
+           Base System: &upgrade_guide; for
+           &slsa;&nbsp;15&nbsp;SP6
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           SLE&nbsp;HA:
+           <xref linkend="pro-ha-migration-rolling-upgrade" xrefstyle="select:title nopage"/>
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           SLE&nbsp;HA&nbsp;Geo: <xref linkend="cha-ha-geo-upgrade"/>
+          </para>
+         </listitem>
+        </itemizedlist>
+       </entry>
+      </row>
      </tbody>
     </tgroup>
    </informaltable>
@@ -1071,6 +1101,12 @@
      <para>
       Upgrading from SLE&nbsp;HA&nbsp;15&nbsp;SP4 to
       SLE&nbsp;HA&nbsp;15&nbsp;SP5
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Upgrading from SLE&nbsp;HA&nbsp;15&nbsp;SP5 to
+      SLE&nbsp;HA&nbsp;15&nbsp;SP6
      </para>
     </listitem>
 <!--<listitem>


### PR DESCRIPTION
### PR creator: Description

In bsc#1224312 we're discussing removing this table and replacing it with a diagram like we have in the SLES upgrade guide. However, because it's still under discussion, I'm adding SP6 to the table for now, just in case. It may end up being redundant, but better there than not. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
  - [ ] 15 SP1
- SLE-HA 12
  - [ ] 12 SP5
  - [ ] 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
