### PR TITLE
Update iscsi steps

### DIFF
--- a/xml/ha_iscsi_for_sbd.xml
+++ b/xml/ha_iscsi_for_sbd.xml
@@ -81,7 +81,7 @@
   </step>
   <step>
    <para>
-    In the <guimenu>Discovery</guimenu> tab, activate <guimenu>Discovery Authentication</guimenu>.
+    In the <guimenu>Global</guimenu> tab, activate <guimenu>Discovery Authentication</guimenu>.
     </para>
    </step>
   <step>
@@ -99,7 +99,7 @@
   </step>
   <step>
    <para>
-    In the <guimenu>Target</guimenu> tab, select <guimenu>Add</guimenu>.
+    In the <guimenu>Targets</guimenu> tab, select <guimenu>Add</guimenu>.
    </para>
   </step>
   <step>
@@ -109,7 +109,8 @@
   </step>
   <step>
    <para>
-    Add the <guimenu>IP Address</guimenu> of the server.
+    The <guimenu>IP Address</guimenu> of this server should be filled automatically. If not,
+    add the IP address now.
    </para>
   </step>
   <step>
@@ -157,9 +158,9 @@
   <title>Configuring an &iscsi; initiator</title>
   <step>
    <para>
-    Install the package <package>yast2-iscsi-client</package>:
+    Install the required packages:
    </para>
-<screen>&prompt.root;<command>zypper install yast2-iscsi-client</command></screen>
+<screen>&prompt.root;<command>zypper install open-iscsi yast2-iscsi-client</command></screen>
   </step>
   <step>
    <para>


### PR DESCRIPTION
### PR creator: Description

Noticed some changed steps in the iSCSI procedure while setting up a new test cluster. Not sure when they changed as the SLES Storage guide has the changes all the way back to 12 SP5, but I originally did this procedure based on a 15 SP4 test VM. I guess it doesn't matter :shrug: 


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-1459


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
