### PR TITLE
Improve persistent device name warning

### DIFF
--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -77,11 +77,7 @@
    </listitem>
   </itemizedlist>
 
-  <para>
-   For better stability, use persistent device names
-   such as <literal>/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></literal>
-   instead of <literal>/dev/sd<replaceable>X</replaceable></literal> names.
-  </para>
+  &warning-persistent-shared-storage-name;
 
   <procedure>
    <step>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -648,3 +648,14 @@
      <systemitem class="resource">softdog</systemitem> can be used as kernel
      watchdog module.</para>
    </important>'>
+
+<!ENTITY warning-persistent-shared-storage-name '<warning xmlns="http://docbook.org/ns/docbook">
+  <title>Always use persistent device names</title>
+  <para>
+    Always use cluster-wide persistent device names, such as
+    <literal>/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable></literal>.
+    Unstable device names like <literal>/dev/sd<replaceable>X</replaceable></literal> or
+    <literal>/dev/dm-<replaceable>X</replaceable></literal> might become mismatched on different
+    nodes, causing major problems across the cluster.
+  </para>
+</warning>'>


### PR DESCRIPTION
### PR creator: Description

Improved the Cluster MD warning about persistent device names. Added it to the phrases entity file so we can easily reuse it wherever it's needed.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1226367
* jsc#DOCTEAM-1466


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
