### PR TITLE
Geo Clustering Guide: integrate proofing corrections

### DIFF
--- a/xml/common_intro_convention_ha.xml
+++ b/xml/common_intro_convention_ha.xml
@@ -173,6 +173,6 @@ output</screen>
  </itemizedlist>
  <para>
   For an overview of naming conventions for cluster nodes and names,
-  resources, and constraints, see <xref linkend="app-naming"/>.
+  resources and constraints, see <xref linkend="app-naming"/>.
  </para>
 </sect1>

--- a/xml/geo_booth_i.xml
+++ b/xml/geo_booth_i.xml
@@ -327,7 +327,7 @@ ticket = "&ticket2;" <xref linkend="co-ha-geo-booth-config-ticket" xrefstyle="se
       run on the current cluster site. That means, it checks if the cluster is
       healthy enough to run the resource (all resource dependencies are
       fulfilled, the cluster partition has quorum, no dirty nodes, etc.). For
-      example, if a service in the dependency-chain has a fail count of
+      example, if a service in the dependency chain has a fail count of
       <literal>INFINITY</literal> on all available nodes, the service cannot be
       run on that site. In that case, it is of no use to claim the ticket.
      </para>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Geo Clustering Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP6
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
  - [ ] 15 SP2
- SLE-HA 12
  - [ ] 12 SP5