### PR TITLE
Add missing DRBD config

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -239,7 +239,7 @@
    }
 
    net {
-      protocol  C; <co xml:id="co-ha-quick-nfs-drbd-protocol"/>
+      protocol C; <co xml:id="co-ha-quick-nfs-drbd-protocol"/>
       fencing resource-and-stonith; <co xml:id="co-ha-quick-nfs-fencing-policy"/>
    }
 
@@ -282,14 +282,14 @@
        </callout>
        <callout arearefs="co-ha-quick-nfs-drbd-protocol">
         <para>The protocol to use for this connection. Protocol <literal>C</literal>
-         provides better data availability and does not consider a write to be
-         complete until it has reached all local and remote disks.
+         is the default option. It provides better data availability and does not consider
+         a write to be complete until it has reached all local and remote disks.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-fencing-policy">
         <para>
-         Specifies the fencing policy. To be supported, &sleha; clusters must have a
-         &stonith; device configured. Therefore, use <literal>resource-and-stonith</literal>.
+         Specifies the fencing policy <literal>resource-and-stonith</literal> at the DRBD level.
+         This policy immediately suspends active I/O operations until &stonith; completes.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-fencing-handlers">

--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -288,15 +288,17 @@
        </callout>
        <callout arearefs="co-ha-quick-nfs-fencing-policy">
         <para>
-         Specifies the fencing policy. For clusters with a &stonith; device
-         configured, use <literal>resource-and-stonith</literal>.
+         Specifies the fencing policy. To be supported, &sleha; clusters must have a
+         &stonith; device configured. Therefore, use <literal>resource-and-stonith</literal>.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-fencing-handlers">
         <para>
-         Enables resource-level fencing. If the DRBD replication link
-         becomes disconnected, &pace; tries to promote the DRBD resource
-         to another node. For more information, see <xref linkend="sec-ha-drbd-fencing"/>.
+         Enables resource-level fencing to prevent &pace; from starting a service
+         with outdated data. If the DRBD replication link
+         becomes disconnected, the <command>crm-fence-peer.9.sh</command> script
+         stops the DRBD resource from being promoted to another node until the replication link
+         becomes connected again and DRBD completes its synchronization process.
         </para>
        </callout>
        <callout arearefs="co-ha-quick-nfs-connectionmesh">

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -316,6 +316,14 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
   connection-mesh { <co xml:id="co-drbd-config-connection-mesh"/>
     hosts &node1; &node2;;
   }
+  net {
+    protocol  C; <co xml:id="co-drbd-config-protocol"/>
+    fencing resource-and-stonith; <co xml:id="co-drbd-config-fencing-policy"/>
+   }
+  handlers { <co xml:id="co-drbd-config-fencing-handlers"/>
+    fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
+    after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
+   }
 }</screen>
       <calloutlist>
        <callout arearefs="co-drbd-config-r0">
@@ -386,6 +394,25 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
        </callout>
        <callout arearefs="co-drbd-config-connection-mesh">
         &drbd-connection-mesh;
+       </callout>
+       <callout arearefs="co-drbd-config-protocol">
+        <para>The protocol to use for this connection. Protocol <literal>C</literal>
+         provides better data availability and does not consider a write to be
+         complete until it has reached all local and remote disks.
+        </para>
+       </callout>
+       <callout arearefs="co-drbd-config-fencing-policy">
+        <para>
+         Specifies the fencing policy. For clusters with a &stonith; device
+         configured, use <literal>resource-and-stonith</literal>.
+        </para>
+       </callout>
+       <callout arearefs="co-drbd-config-fencing-handlers">
+        <para>
+         Enables resource-level fencing. If the DRBD replication link
+         becomes disconnected, &pace; tries to promote the DRBD resource
+         to another node. For more information, see <xref linkend="sec-ha-drbd-fencing"/>.
+        </para>
        </callout>
       </calloutlist>
      </step>

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -403,15 +403,17 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
        </callout>
        <callout arearefs="co-drbd-config-fencing-policy">
         <para>
-         Specifies the fencing policy. For clusters with a &stonith; device
-         configured, use <literal>resource-and-stonith</literal>.
+         Specifies the fencing policy. To be supported, &sleha; clusters must have a
+         &stonith; device configured. Therefore, use <literal>resource-and-stonith</literal>.
         </para>
        </callout>
        <callout arearefs="co-drbd-config-fencing-handlers">
         <para>
-         Enables resource-level fencing. If the DRBD replication link
-         becomes disconnected, &pace; tries to promote the DRBD resource
-         to another node. For more information, see <xref linkend="sec-ha-drbd-fencing"/>.
+         Enables resource-level fencing to prevent &pace; from starting a service
+         with outdated data. If the DRBD replication link becomes disconnected, the
+         <command>crm-fence-peer.9.sh</command> script stops the DRBD resource from
+         being promoted to another node until the replication link becomes connected
+         again and DRBD completes its synchronization process.
         </para>
        </callout>
       </calloutlist>
@@ -771,65 +773,6 @@ resource r0-U {
   }
 }</screen>
   </example>
- </sect1>
-
- <sect1 xml:id="sec-ha-drbd-fencing">
-  <title>Using resource-level fencing with &stonith;</title>
-  <para>
-   When a DRBD replication link becomes interrupted, &pace; tries to promote
-   the DRBD resource to another node. To prevent &pace; from starting a service
-   with outdated data, enable resource-level fencing in the DRBD configuration
-   file.
-  </para>
-   <para>
-    The fencing policy can have different values (see man page <command>drbdsetup</command> and the
-     <option>--fencing</option> option).
-    As a &productname; cluster is normally used with a &stonith; device, the value
-    <constant>resource-and-stonith</constant> is used in
-    <xref linkend="ex-ha-drbd-fencing"/>.
-  </para>
-
-  <example xml:id="ex-ha-drbd-fencing">
-   <title>Configuration of DRBD with resource-level fencing using the Cluster
-    Information Base (CIB)</title>
-   <screen>resource <replaceable>RESOURCE</replaceable> {
-  net {
-    fencing resource-and-stonith;
-    # ...
-  }
-  handlers {
-    fence-peer "/usr/lib/drbd/crm-fence-peer.9.sh";
-    after-resync-target "/usr/lib/drbd/crm-unfence-peer.9.sh";
-    # ...
-  }
-  ...
-}</screen>
-  </example>
-  <para>If the DRBD replication link becomes disconnected, DRBD does the
-  following:</para>
-  <orderedlist>
-   <listitem>
-    <para>DRBD calls the <command>crm-fence-peer.9.sh</command> script.</para>
-   </listitem>
-   <listitem>
-    <para>The script contacts the cluster manager.
-    </para>
-   </listitem>
-   <listitem>
-    <para>The script determines the &pace; resource associated with this
-     DRBD resource.</para>
-   </listitem>
-   <listitem>
-    <para>The script ensures that the DRBD resource no longer gets
-    promoted to any other node. It stays on the currently active one.</para>
-   </listitem>
-   <listitem>
-    <para>If the replication link becomes connected again and DRBD
-    completes its synchronization process, then the constraint is removed.
-    The cluster manager is now free to promote the resource.
-    </para>
-   </listitem>
-  </orderedlist>
  </sect1>
 
  <sect1 xml:id="sec-ha-drbd-test">

--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -317,7 +317,7 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
     hosts &node1; &node2;;
   }
   net {
-    protocol  C; <co xml:id="co-drbd-config-protocol"/>
+    protocol C; <co xml:id="co-drbd-config-protocol"/>
     fencing resource-and-stonith; <co xml:id="co-drbd-config-fencing-policy"/>
    }
   handlers { <co xml:id="co-drbd-config-fencing-handlers"/>
@@ -397,14 +397,14 @@ NAME       SIZELIMIT OFFSET AUTOCLEAR RO BACK-FILE
        </callout>
        <callout arearefs="co-drbd-config-protocol">
         <para>The protocol to use for this connection. Protocol <literal>C</literal>
-         provides better data availability and does not consider a write to be
-         complete until it has reached all local and remote disks.
+         is the default option. It provides better data availability and does not consider
+         a write to be complete until it has reached all local and remote disks.
         </para>
        </callout>
        <callout arearefs="co-drbd-config-fencing-policy">
         <para>
-         Specifies the fencing policy. To be supported, &sleha; clusters must have a
-         &stonith; device configured. Therefore, use <literal>resource-and-stonith</literal>.
+         Specifies the fencing policy <literal>resource-and-stonith</literal> at the DRBD level.
+         This policy immediately suspends active I/O operations until &stonith; completes.
         </para>
        </callout>
        <callout arearefs="co-drbd-config-fencing-handlers">


### PR DESCRIPTION
### PR creator: Description

Added fencing config for DRBD. Descriptions are copied from article_nfs_storage.xml.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1220064
* jsc#DOCTEAM-1267


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
