### PR TITLE
Clarify clvm step in 12 to 15 upgrade

### DIFF
--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -285,8 +285,11 @@
     <step>
      <para>If you use &clvm;, you need to migrate from clvmd to lvmlockd.
       See the man page of <command>lvmlockd</command>, section
-      <citetitle>changing a clvm VG to a lockd VG</citetitle> and <xref
-      linkend="sec-ha-clvm-migrate"/>.
+      <citetitle>Changing a clvm/clustered VG to a shared VG</citetitle>.
+     </para>
+     <para>
+      If you also use <systemitem class="daemon">cmirrord</systemitem>, we highly recommend
+      migrating to Cluster MD. See <xref linkend="sec-ha-clvm-migrate"/>.
      </para>
     </step>
     <step>


### PR DESCRIPTION
### PR creator: Description

Clarified a step in the 12 -> 15 upgrade procedure; clvmd -> lvmlockd and cmirrord -> cluster MD are different things.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1226518
* jsc#DOCTEAM-1467


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
