### PR TITLE
Back up Chrony instead of legacy NTP configuration

### DIFF
--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -458,7 +458,7 @@
 /etc/sysconfig/sbd
 /etc/modules-load.d/watchdog.conf
 /etc/hosts
-/etc/ntp.conf</screen>
+/etc/chrony.conf</screen>
      <!--</example>-->
      <para>Depending on your resources, you may also need the following files:</para>
      <!--<example xml:id="ex.ha.migration.extlist4backup">


### PR DESCRIPTION
### PR creator: Description

Update backup recommendations to reflect latest software stack.


### PR creator: Are there any relevant issues/feature requests?

no

### PR creator: Which product versions do the changes apply to?

I think Chrony is the default NTP implementation on all 15 SP's but I'm not fully sure.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
