### PR TITLE
Remove SAP from QDevice heuristics suggestion

### DIFF
--- a/xml/ha_qdevice-qnetd.xml
+++ b/xml/ha_qdevice-qnetd.xml
@@ -52,7 +52,7 @@
          <listitem>
             <para>
                You can write your own heuristics scripts to affect votes.
-               This is especially useful for complex setups, such as SAP applications.
+               This is especially useful for complex setups.
             </para>
          </listitem>
          <listitem>


### PR DESCRIPTION
### PR creator: Description

Removed SAP from the QDevice heuristics suggestion, as this hasn't been tested.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1228375
* jsc#DOCTEAM-1505


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
