### PR TITLE
Improve ReaR backup config examples

### DIFF
--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -563,7 +563,7 @@ RETENTION_TIME="Month"</screen>
         <para>
           If your system boots with &uefisecboot;, you must also add the following line:
         </para>
-<screen>SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"</screen>
+<screen>SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/sles/shim.efi"</screen>
       </listitem>
     </orderedlist>
     <para>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -497,7 +497,8 @@
     <para>
      This <filename>/etc/rear/local.conf</filename> example is simplified from the example file
      <filename>SLE12-SP2-btrfs-example.conf</filename>. It includes the whole
-     <filename>/var</filename> directory instead of specific <filename>/var</filename>subdirectories. See the example file for details about the settings.
+     <filename>/var</filename> directory instead of specific <filename>/var</filename>
+     subdirectories. See the example file for details about the settings.
     </para>
 <screen>OUTPUT=ISO
 BACKUP=NETFS

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -465,14 +465,10 @@
     <para>
      Define the configuration for your NFS server in the
      <filename>/etc/exports</filename> file. Make sure the directory on the
-     NFS server has the right mount options. For example:
-    </para>
-<screen><replaceable>/srv/nfs</replaceable> *([...],rw,no_root_squash,[...])</screen>
-    <para>
-     Replace <filename>/srv/nfs</filename> with the path to your
-     backup data on the NFS server and adjust the mount options. You might
+     NFS server has the right mount options. For example, you might
      need <literal>no_root_squash</literal> as the
      <command>rear mkbackup</command> command runs as &rootuser;.
+     For more information, see <command>man exports</command>.
     </para>
    </listitem>
    <listitem>
@@ -497,8 +493,10 @@
     <para>
      This <filename>/etc/rear/local.conf</filename> example is simplified from the example file
      <filename>SLE12-SP2-btrfs-example.conf</filename>. It includes the whole
-     <filename>/var</filename> directory instead of specific <filename>/var</filename>
-     subdirectories. See the example file for details about the settings.
+     <filename>/var</filename> directory instead of specific <filename>/var</filename> subdirectories.
+    </para>
+    <para>
+     Adjust this example as required for your setup. See the example file for details about the settings.
     </para>
 <screen>OUTPUT=ISO
 BACKUP=NETFS
@@ -509,9 +507,13 @@ REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" snapper chattr lsattr )
 COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snapper/config-templates/default )
 BACKUP_PROG_INCLUDE=( /root /boot/grub2/i386-pc /tmp /opt /var /boot/grub2/x86_64-efi /srv /usr/local )
 POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota &amp;&amp; echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )</screen>
-   <para>
-    Adjust this example as required for your setup.
-   </para>
+    <tip>
+      <title>Directories for <literal>BACKUP_PROG_INCLUDE</literal></title>
+      <para>
+        You can find the directories for your specific system by running the following command:
+      </para>
+<screen>&prompt.root;<command>findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'</command></screen>
+    </tip>
   </example>
 
   <example xml:id="ex-ha-rear-config-EMC">
@@ -526,11 +528,11 @@ POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | gre
     adjust it according to your setup:
    </para>
 <screen>BACKUP=NSR
-    OUTPUT=ISO
-    BACKUP_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
-    OUTPUT_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
-    NSRSERVER=<replaceable>backupserver.&exampledomain;</replaceable>
-    RETENTION_TIME="Month"</screen>
+OUTPUT=ISO
+BACKUP_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
+OUTPUT_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
+NSRSERVER=<replaceable>backupserver.&exampledomain;</replaceable>
+RETENTION_TIME="Month"</screen>
    <para>
     For more information about supported third-party backup tools, see
     <command>man rear</command>, section <citetitle>BACKUP SOFTWARE INTEGRATION</citetitle>.

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -513,24 +513,6 @@ POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | gre
    </para>
   </example>
 
-  <example xml:id="ex-ex-ha-rear-config-UEFI">
-    <title>Booting your system with UEFI</title>
-    <para>
-      If your system boots with a UEFI boot loader, install the package
-      <package>ebiso</package> and add the following line to
-      <filename>/etc/rear/local.conf</filename>:
-     </para>
-    <screen>ISO_MKISOFS_BIN="/usr/bin/ebiso"</screen>
-    <para>
-     If your system boots with &uefisecboot;, you must also add the following line:
-    </para>
-<screen>SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"</screen>
-    <para>
-     For more information about &rear; configuration variables for UEFI, see the
-     <filename>/usr/share/rear/conf/default.conf</filename> file.
-    </para>
-  </example>
-
   <example xml:id="ex-ha-rear-config-EMC">
    <title>Using third-party backup tools like EMC NetWorker</title>
    <para>
@@ -565,6 +547,37 @@ POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | gre
     <para>
      Before you can restore the backup, you must manually re-create the device structure on
      the new system.
+    </para>
+  </example>
+
+  <example xml:id="ex-ex-ha-rear-config-UEFI">
+    <title>Booting your system with UEFI</title>
+    <para>
+      If your system boots with a UEFI boot loader, additional configuration is required:
+    </para>
+    <orderedlist>
+      <listitem>
+        <para>
+          Install the package <package>ebiso</package>:
+        </para>
+<screen>&prompt.root;<command>zypper install ebiso</command></screen>
+      </listitem>
+      <listitem>
+        <para>
+          Add the following line to <filename>/etc/rear/local.conf</filename>:
+        </para>
+<screen>ISO_MKISOFS_BIN="/usr/bin/ebiso"</screen>
+      </listitem>
+      <listitem>
+        <para>
+          If your system boots with &uefisecboot;, you must also add the following line:
+        </para>
+<screen>SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"</screen>
+      </listitem>
+    </orderedlist>
+    <para>
+     For more information about &rear; configuration variables for UEFI, see the
+     <filename>/usr/share/rear/conf/default.conf</filename> file.
     </para>
   </example>
  </sect1>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -487,6 +487,32 @@
   </orderedlist>
   </example>
 
+  <example xml:id="ex-ha-rear-config-sles-btrfs">
+    <title>Backing up Btrfs subvolumes with <command>tar</command></title>
+    <para>
+     Btrfs is set up with subvolumes, but <command>tar</command>
+     creates backups with the <option>--one-file-system</option> option, which excludes subvolumes.
+     Therefore, the subvolumes must be explicitly included in the &rear; configuration.
+    </para>
+    <para>
+     This <filename>/etc/rear/local.conf</filename> example is simplified from the example file
+     <filename>SLE12-SP2-btrfs-example.conf</filename>. It includes the whole
+     <filename>/var</filename> directory instead of specific <filename>/var</filename>subdirectories. See the example file for details about the settings.
+    </para>
+<screen>OUTPUT=ISO
+BACKUP=NETFS
+BACKUP_OPTIONS="nfsvers=4,nolock"
+BACKUP_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
+NETFS_KEEP_OLD_BACKUP_COPY=yes
+REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" snapper chattr lsattr )
+COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snapper/config-templates/default )
+BACKUP_PROG_INCLUDE=( /root /boot/grub2/i386-pc /tmp /opt /var /boot/grub2/x86_64-efi /srv /usr/local )
+POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota &amp;&amp; echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )</screen>
+   <para>
+    Adjust this example as required for your setup.
+   </para>
+  </example>
+
   <example xml:id="ex-ex-ha-rear-config-UEFI">
     <title>Booting your system with UEFI</title>
     <para>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -553,6 +553,20 @@ POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | gre
     <command>man rear</command>, section <citetitle>BACKUP SOFTWARE INTEGRATION</citetitle>.
    </para>
   </example>
+
+  <example xml:id="ex-ha-rear-config-multipath">
+    <title>Backing up multipath devices</title>
+    <para>
+     By default, &rear; ignores file systems on <filename>/dev/mapper</filename> devices because
+     it cannot re-create them when restoring the system. You can allow &rear; to include
+     these file systems by adding the following line to <filename>/etc/rear/local.conf</filename>:
+    </para>
+    <screen>AUTOEXCLUDE_MULTIPATH=n</screen>
+    <para>
+     Before you can restore the backup, you must manually re-create the device structure on
+     the new system.
+    </para>
+  </example>
  </sect1>
  <sect1 xml:id="sec-ha-rear-mkbackup">
   <title>Creating the recovery installation system</title>
@@ -634,6 +648,17 @@ POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | gre
     everything works as expected.
    </para>
   </warning>
+  <important>
+    <title>Restoring a multipath backup</title>
+    <para>
+     If your backup includes file systems on a multipath device, you must manually re-create
+     the device structure on the new system before you can restore the backup.
+    </para>
+    <para>
+     Backing up multipath devices is disabled by default, but can be enabled by setting
+     <literal>AUTOEXCLUDE_MULTIPATH=n</literal> in <filename>/etc/rear/local.conf</filename>.
+    </para>
+  </important>
 
   <procedure xml:id="pro-ha-rear-testing">
    <title>Performing a disaster recovery on a test machine</title>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -168,10 +168,6 @@
 
   <sect2 xml:id="sec-ha-rear-concept-versions">
    <title>&rear; version updates</title>
-   <para>
-    &productname; &productnumber; ships with &rear; version 2.7, provided by the
-    package <package>rear27a</package>.
-   </para>
 
    <note>
     <title>Find important information in changelogs</title>
@@ -491,22 +487,14 @@
      Therefore, the subvolumes must be explicitly included in the &rear; configuration.
     </para>
     <para>
-     This <filename>/etc/rear/local.conf</filename> example is simplified from the example file
-     <filename>SLE12-SP2-btrfs-example.conf</filename>. It includes the whole
-     <filename>/var</filename> directory instead of specific <filename>/var</filename> subdirectories.
-    </para>
-    <para>
-     Adjust this example as required for your setup. See the example file for details about the settings.
+     Add this configuration snippet to <filename>/etc/rear/local.conf</filename> and
+    adjust it according to your setup. For more information and additional options, see the
+    example files at <filename>/usr/share/rear/conf/examples/SLE*-btrfs-example.conf</filename>.
     </para>
 <screen>OUTPUT=ISO
 BACKUP=NETFS
-BACKUP_OPTIONS="nfsvers=4,nolock"
 BACKUP_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
-NETFS_KEEP_OLD_BACKUP_COPY=yes
-REQUIRED_PROGS=( "${REQUIRED_PROGS[@]}" snapper chattr lsattr )
-COPY_AS_IS=( "${COPY_AS_IS[@]}" /usr/lib/snapper/installation-helper /etc/snapper/config-templates/default )
-BACKUP_PROG_INCLUDE=( /root /boot/grub2/i386-pc /tmp /opt /var /boot/grub2/x86_64-efi /srv /usr/local )
-POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | grep -q "^QGROUP.*[0-9]/[0-9]" ; then snapper --no-dbus -r $TARGET_FS_ROOT set-config QGROUP= ; snapper --no-dbus -r $TARGET_FS_ROOT setup-quota &amp;&amp; echo snapper setup-quota done || echo snapper setup-quota failed ; else echo snapper setup-quota not used ; fi' )</screen>
+BACKUP_PROG_INCLUDE=( /root /boot/grub2/i386-pc /tmp /opt /var /boot/grub2/x86_64-efi /srv /usr/local )</screen>
     <tip>
       <title>Directories for <literal>BACKUP_PROG_INCLUDE</literal></title>
       <para>
@@ -542,17 +530,9 @@ RETENTION_TIME="Month"</screen>
   <example xml:id="ex-ha-rear-config-multipath">
     <title>Backing up multipath devices</title>
     <para>
-     By default, &rear; ignores file systems on <filename>/dev/mapper</filename> devices because
-     it cannot re-create them when restoring the system. You can allow &rear; to include
-     these file systems by adding the following line to <filename>/etc/rear/local.conf</filename>:
+     By default, &rear; ignores file systems on multipath devices because it assumes they are on shared storage, not part of the local system. You can make &rear; include these file systems by adding the following line to <filename>/etc/rear/local.conf</filename>:
     </para>
     <screen>AUTOEXCLUDE_MULTIPATH=n</screen>
-    <important role="compact">
-      <para>
-      Before you can restore the backup, you must manually re-create the device structure on
-      the new system.
-      </para>
-    </important>
   </example>
 
   <example xml:id="ex-ex-ha-rear-config-UEFI">
@@ -666,17 +646,6 @@ RETENTION_TIME="Month"</screen>
     everything works as expected.
    </para>
   </warning>
-  <important>
-    <title>Restoring a multipath backup</title>
-    <para>
-     If your backup includes file systems on a multipath device, you must manually re-create
-     the device structure on the new system before you can restore the backup.
-    </para>
-    <para>
-     Backing up multipath devices is disabled by default, but can be enabled by setting
-     <literal>AUTOEXCLUDE_MULTIPATH=n</literal> in <filename>/etc/rear/local.conf</filename>.
-    </para>
-  </important>
 
   <procedure xml:id="pro-ha-rear-testing">
    <title>Performing a disaster recovery on a test machine</title>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -397,38 +397,18 @@
  </sect1>
  <sect1 xml:id="sec-ha-rear-config">
   <title>Setting up &rear; and your backup solution</title>
-
   <para>
-   To set up &rear;, you need to edit at least the &rear;
-   configuration file <filename>/etc/rear/local.conf</filename> and, if
-   needed, the Bash scripts that are part of the &rear; framework.
+   Before you can configure &rear;, you must install the latest &rear; package:
   </para>
-
+<screen>&prompt.root;<command>zypper install rear</command></screen>
   <para>
-   In particular, you need to define the following tasks that &rear;
-   should do:
+   To configure &rear;, add your settings to the &rear; configuration file
+   <filename>/etc/rear/local.conf</filename> and, if needed, edit the Bash
+   scripts that are part of the &rear; framework. In particular, you need to
+   define the following tasks that &rear; should do:
   </para>
 
   <itemizedlist>
-   <listitem>
-    <formalpara>
-     <title>When your system is booted with UEFI</title>
-     <para>
-      If your system boots with a UEFI boot loader, install the package
-      <package>ebiso</package> and add the following line to
-      <filename>/etc/rear/local.conf</filename>:
-     </para>
-    </formalpara>
-    <screen>ISO_MKISOFS_BIN="/usr/bin/ebiso"</screen>
-    <para>
-     If your system boots with &uefisecboot;, you must also add the following line:
-    </para>
-<screen>SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"</screen>
-    <para>
-     For more information about &rear; configuration variables for UEFI, see the
-     <filename>/usr/share/rear/conf/default.conf</filename> file.
-    </para>
-   </listitem>
    <listitem>
     <formalpara>
      <title>How to back up files and how to create and store the disaster recovery system</title>
@@ -440,10 +420,10 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>What to re-create exactly (partitioning, file systems, mount points, etc.)</title>
+     <title>What to re-create (partitioning, file systems, mount points, etc.)</title>
      <para>
-      This can be defined in <filename>/etc/rear/local.conf</filename> (for
-      example, what to exclude). To re-create non-standard systems, you may
+      This can be defined in <filename>/etc/rear/local.conf</filename>.
+      To re-create non-standard systems, you may
       need to enhance the Bash scripts.
      </para>
     </formalpara>
@@ -461,54 +441,31 @@
   </itemizedlist>
 
   <para>
-   To configure &rear;, add your options to the
-   <filename>/etc/rear/local.conf</filename> configuration file. (The former
-   configuration file <filename>/etc/rear/sites.conf</filename> has been
-   removed from the package. However, if you have such a file from your last
-   setup, &rear; will still use it.)
-  </para>
-
-  <para>
-   All &rear; configuration variables and their default values are set in
+   All &rear; configuration variables and their default values are explained in
    <filename>/usr/share/rear/conf/default.conf</filename>.
-   Example files (<filename>*example.conf</filename>) for user configurations
-   (for example, what is set in <filename>/etc/rear/local.conf</filename>)
-   are available in the <filename>examples</filename> subdirectory.
-   Find more information in the &rear; man page.
   </para>
   <para>
-   You should start with a matching example configuration file as template
-   and adapt it as needed to create your particular configuration file.
-   Copy options from several example configuration files and paste them
-   into your specific <filename>/etc/rear/local.conf</filename> file that
-   matches your particular system.
-   Do not use original example configuration files, because they provide an
-   overview of variables that can be used for specific setups.
+   Below are some examples of useful configuration options. You can also find example files
+   for different scenarios in the <filename>/usr/share/rear/conf/examples/</filename> subdirectory.
+   Use these to help you create your <filename>/etc/rear/local.conf</filename> file.
   </para>
 
   <example xml:id="ex-ha-rear-nfs-server-backup">
    <title>Using an NFS server to store the file backup</title>
-   <para>
-    &rear; can be used in different scenarios. The following example uses
-    an NFS server as storage for the file backup.
-   </para>
-  </example>
-
-  <procedure>
-   <step>
+  <orderedlist>
+   <listitem>
     <para>
      Set up an NFS server with &yast; as described in the
      <link
       xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/cha-nfs.html">
       &admin; for &sls; &productnumber;</link>.
     </para>
-   </step>
-   <step>
+   </listitem>
+   <listitem>
     <para>
      Define the configuration for your NFS server in the
      <filename>/etc/exports</filename> file. Make sure the directory on the
-     NFS server (where you want the backup data to be available), has the
-     right mount options. For example:
+     NFS server has the right mount options. For example:
     </para>
 <screen><replaceable>/srv/nfs</replaceable> *([...],rw,no_root_squash,[...])</screen>
     <para>
@@ -517,8 +474,8 @@
      need <literal>no_root_squash</literal> as the
      <command>rear mkbackup</command> command runs as &rootuser;.
     </para>
-   </step>
-   <step>
+   </listitem>
+   <listitem>
     <para>
      Adjust the various <varname>BACKUP</varname> parameters in the
      configuration file <filename>/etc/rear/local.conf</filename> to make
@@ -526,8 +483,27 @@
      examples in your installed system under
      <filename>/usr/share/rear/conf/examples/SLE*-example.conf</filename>.
     </para>
-   </step>
-  </procedure>
+   </listitem>
+  </orderedlist>
+  </example>
+
+  <example xml:id="ex-ex-ha-rear-config-UEFI">
+    <title>Booting your system with UEFI</title>
+    <para>
+      If your system boots with a UEFI boot loader, install the package
+      <package>ebiso</package> and add the following line to
+      <filename>/etc/rear/local.conf</filename>:
+     </para>
+    <screen>ISO_MKISOFS_BIN="/usr/bin/ebiso"</screen>
+    <para>
+     If your system boots with &uefisecboot;, you must also add the following line:
+    </para>
+<screen>SECURE_BOOT_BOOTLOADER="/boot/efi/EFI/BOOT/shim.efi"</screen>
+    <para>
+     For more information about &rear; configuration variables for UEFI, see the
+     <filename>/usr/share/rear/conf/default.conf</filename> file.
+    </para>
+  </example>
 
   <example xml:id="ex-ha-rear-config-EMC">
    <title>Using third-party backup tools like EMC NetWorker</title>
@@ -546,6 +522,10 @@
     OUTPUT_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
     NSRSERVER=<replaceable>backupserver.&exampledomain;</replaceable>
     RETENTION_TIME="Month"</screen>
+   <para>
+    For more information about supported third-party backup tools, see
+    <command>man rear</command>, section <citetitle>BACKUP SOFTWARE INTEGRATION</citetitle>.
+   </para>
   </example>
  </sect1>
  <sect1 xml:id="sec-ha-rear-mkbackup">

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -173,7 +173,7 @@
     To see which versions of &rear; are available with &productname; &productnumber;,
     run the following command:
    </para>
-<screen>&prompt.root;<command>zypper search -v rear</command></screen>
+<screen>&prompt.root;<command>zypper search --type package --verbose rear</command></screen>
 
    <note>
     <title>Find important information in changelogs</title>
@@ -400,9 +400,14 @@
  <sect1 xml:id="sec-ha-rear-config">
   <title>Setting up &rear; and your backup solution</title>
   <para>
-   Before you can configure &rear;, you must install the latest &rear; package:
+   To install the latest version of &rear;, run the following command:
   </para>
 <screen>&prompt.root;<command>zypper install rear</command></screen>
+  <para>
+    If you need to install an earlier version of &rear;, you can specify the package version.
+    For example:
+  </para>
+<screen>&prompt.root;<command>zypper install rear23a</command></screen>
   <para>
    To configure &rear;, add your settings to the &rear; configuration file
    <filename>/etc/rear/local.conf</filename> and, if needed, edit the Bash
@@ -488,23 +493,24 @@
   <example xml:id="ex-ha-rear-config-sles-btrfs">
     <title>Backing up Btrfs subvolumes with <command>tar</command></title>
     <para>
-     Btrfs is set up with subvolumes, but <command>tar</command>
-     creates backups with the <option>--one-file-system</option> option, which excludes subvolumes.
-     Therefore, the subvolumes must be explicitly included in the &rear; configuration.
+     Btrfs is set up with subvolumes, but <command>tar</command> creates backups with the
+     <option>--one-file-system</option> option, which excludes subvolumes. Therefore, the
+     mount points for the subvolumes must be explicitly included in the &rear; configuration.
     </para>
     <para>
      Add this configuration snippet to <filename>/etc/rear/local.conf</filename> and
-    adjust it according to your setup. For more information and additional options, see the
-    example files at <filename>/usr/share/rear/conf/examples/SLE*-btrfs-example.conf</filename>.
+     adjust it according to your setup. For more information and additional options, see the
+     example files at <filename>/usr/share/rear/conf/examples/SLE*-btrfs-example.conf</filename>.
     </para>
 <screen>OUTPUT=ISO
 BACKUP=NETFS
 BACKUP_URL=nfs://<replaceable>host.&exampledomain;/path/to/rear/backup</replaceable>
 BACKUP_PROG_INCLUDE=( /root /boot/grub2/i386-pc /tmp /opt /var /boot/grub2/x86_64-efi /srv /usr/local )</screen>
     <tip>
-      <title>Directories for <literal>BACKUP_PROG_INCLUDE</literal></title>
+      <title>Mount points for <literal>BACKUP_PROG_INCLUDE</literal></title>
       <para>
-        You can find the directories for your specific system by running the following command:
+        You can find the mount points for the subvolumes on your specific system by running
+        the following command:
       </para>
 <screen>&prompt.root;<command>findmnt -n -r -o TARGET -t btrfs | grep -v '^/$' | egrep -v 'snapshots|crash'</command></screen>
     </tip>
@@ -537,7 +543,7 @@ RETENTION_TIME="Month"</screen>
     <title>Backing up multipath devices</title>
     <para>
      By default, &rear; ignores file systems on multipath devices because it assumes they are
-     on shared storage, not part of the local system. You can make &rear; include these
+     on remote storage, not part of the local system. You can make &rear; include these
      file systems by adding the following line to <filename>/etc/rear/local.conf</filename>:
     </para>
     <screen>AUTOEXCLUDE_MULTIPATH=n</screen>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -169,6 +169,12 @@
   <sect2 xml:id="sec-ha-rear-concept-versions">
    <title>&rear; version updates</title>
 
+   <para>
+    To see which versions of &rear; are available with &productname; &productnumber;,
+    run the following command:
+   </para>
+<screen>&prompt.root;<command>zypper search -v rear</command></screen>
+
    <note>
     <title>Find important information in changelogs</title>
     <para>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -544,10 +544,12 @@ POST_RECOVERY_SCRIPT=( 'if snapper --no-dbus -r $TARGET_FS_ROOT get-config | gre
      these file systems by adding the following line to <filename>/etc/rear/local.conf</filename>:
     </para>
     <screen>AUTOEXCLUDE_MULTIPATH=n</screen>
-    <para>
-     Before you can restore the backup, you must manually re-create the device structure on
-     the new system.
-    </para>
+    <important role="compact">
+      <para>
+      Before you can restore the backup, you must manually re-create the device structure on
+      the new system.
+      </para>
+    </important>
   </example>
 
   <example xml:id="ex-ex-ha-rear-config-UEFI">

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -536,7 +536,9 @@ RETENTION_TIME="Month"</screen>
   <example xml:id="ex-ha-rear-config-multipath">
     <title>Backing up multipath devices</title>
     <para>
-     By default, &rear; ignores file systems on multipath devices because it assumes they are on shared storage, not part of the local system. You can make &rear; include these file systems by adding the following line to <filename>/etc/rear/local.conf</filename>:
+     By default, &rear; ignores file systems on multipath devices because it assumes they are
+     on shared storage, not part of the local system. You can make &rear; include these
+     file systems by adding the following line to <filename>/etc/rear/local.conf</filename>:
     </para>
     <screen>AUTOEXCLUDE_MULTIPATH=n</screen>
   </example>

--- a/xml/ha_rear.xml
+++ b/xml/ha_rear.xml
@@ -169,8 +169,8 @@
   <sect2 xml:id="sec-ha-rear-concept-versions">
    <title>&rear; version updates</title>
    <para>
-    &productname; &productnumber; ships with &rear; version 2.3, provided by the
-    package <package>rear23a</package>.
+    &productname; &productnumber; ships with &rear; version 2.7, provided by the
+    package <package>rear27a</package>.
    </para>
 
    <note>


### PR DESCRIPTION
### PR creator: Description

Added more examples for creating the ReaR backup config, and improved the section overall. 

PDF: 
[cha-ha-rear_en.pdf](https://github.com/user-attachments/files/16756848/cha-ha-rear_en.pdf) **(Updated Aug 27)**

### PR creator: Are there any relevant issues/feature requests?

* bsc#1204927
* jsc#DOCTEAM-787


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
