### PR TITLE
Fix DRBD disconnect steps

### DIFF
--- a/xml/ha_drbd.xml
+++ b/xml/ha_drbd.xml
@@ -1131,15 +1131,14 @@ resource r0-U {
     To resolve this situation, enter the following commands on the node which has
     data to be discarded:
    </para>
-<screen>&prompt.root;<command>drbdadm secondary r0</command></screen>
+<screen>&prompt.root;<command>drbdadm disconnect r0</command>
+&prompt.root;<command>drbdadm secondary r0</command>
+&prompt.root;<command>drbdadm connect --discard-my-data r0</command></screen>
    <para>
-    If the state is in <literal>WFconnection</literal>, disconnect first:
+    On the node which has the latest data, enter the following commands:
    </para>
-   <screen>&prompt.root;<command>drbdadm disconnect r0</command></screen>
-   <para>
-    On the node which has the latest data enter the following:
-   </para>
-<screen>&prompt.root;<command>drbdadm connect  --discard-my-data r0</command></screen>
+<screen>&prompt.root;<command>drbdadm disconnect r0</command>
+&prompt.root;<command>drbdadm connect r0</command></screen>
    <para>
     That resolves the issue by overwriting one node's data with the peer's
     data, therefore getting a consistent view on both nodes.


### PR DESCRIPTION
### PR creator: Description

The steps for resolving a split-brain for DRBD were incorrect. This PR corrects them.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1229715
* jsc#DOCTEAM-1550


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
