### PR TITLE
Add note that lvmlockd with sanlock is not supported

### DIFF
--- a/xml/ha_cluster_lvm.xml
+++ b/xml/ha_cluster_lvm.xml
@@ -61,9 +61,13 @@
       to protect the LVM metadata on shared storage. From &sle; 15 onward, the
       cluster extension uses lvmlockd, which replaces
       clvmd. For more information about lvmlockd, see the man page of the
-      <command>lvmlockd</command> command (<command>man 8
-      lvmlockd</command>).
+      <command>lvmlockd</command> command (<command>man 8 lvmlockd</command>).
      </para>
+     <important role="compact">
+      <para>
+        lvmlockd with sanlock is not officially supported.
+      </para>
+    </important>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
### PR creator: Description

Added a note stating that lvmlockd with sanlock is not supported.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1233762
* jsc#DOCTEAM-1634


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
