### PR TITLE
Remove unnecessary duplicate callout xref

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -255,7 +255,7 @@
       address   &subnetI;.1:&drbd.port;;
       node-id   0;
    }
-   on &node2; { <xref linkend="co-ha-quick-nfs-drbd-on"/>
+   on &node2; {
       address   &subnetI;.2:&drbd.port;;
       node-id   1;
    }


### PR DESCRIPTION
### PR creator: Description

Although using an xref to repeat a callout works, the number is included when you copy the screen text. Therefore I'm removing the xref. It's not really necessary anyway. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1234130
* jsc#DOCTEAM-1655


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [x] 15 SP2
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
