### PR TITLE
Add step for multiple cluster MD devices

### DIFF
--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -171,22 +171,25 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
     <itemizedlist>
       <listitem>
         <para>
-          You can add a single <systemitem>Raid1</systemitem> primitive to the cloned
-          <literal>g-storage</literal> group, which already has internal colocation
-          and order constraints:
+          You can add a single <systemitem>Raid1</systemitem> primitive to the
+          <literal>g-storage</literal> group described in <xref linkend="pro-dlm-resources"/>:
         </para>
 <screen>&prompt.crm.conf;<command>modgroup g-storage add raider</command></screen>
+        <para>
+          This group already has internal colocation and order constraints.
+        </para>
       </listitem>
       <listitem>
         <para>
           Do <emphasis>not</emphasis> add multiple <systemitem>Raid1</systemitem> primitives to
           the group, because this creates a dependency between the Cluster MD devices.
-          For multiple devices, clone the primitives and add constraints to the clones:
+          For multiple devices, clone the primitives and colocate them with the independent
+          DLM resource described in <xref linkend="pro-dlm-multiple-resources"/>:
         </para>
 <screen>&prompt.crm.conf;<command>crm configure clone cl-raider1 raider1 meta interleave=true</command>
 &prompt.crm.conf;<command>crm configure clone cl-raider2 raider2 meta interleave=true</command>
-&prompt.crm.conf;<command>crm configure colocation col-cmd-with-dlm inf: ( cl-raider1 cl-raider2 ) cl-storage</command>
-&prompt.crm.conf;<command>crm configure order o-dlm-before-cmd Mandatory: cl-storage ( cl-raider1 cl-raider2 )</command></screen>
+&prompt.crm.conf;<command>crm configure colocation col-cmd-with-dlm inf: ( cl-raider1 cl-raider2 ) cl-dlm</command>
+&prompt.crm.conf;<command>crm configure order o-dlm-before-cmd Mandatory: cl-dlm ( cl-raider1 cl-raider2 )</command></screen>
       </listitem>
     </itemizedlist>
    </step>

--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -155,7 +155,7 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
   <para>Configure a CRM resource as follows:</para>
   <procedure>
    <step>
-    <para>Create a <systemitem>Raid1</systemitem> primitive:</para>
+    <para>Create a <systemitem>Raid1</systemitem> primitive for the Cluster MD device:</para>
     <screen>&prompt.crm.conf;<command>primitive raider Raid1 \
   params raidconf="/etc/mdadm.conf" raiddev=/dev/md0 \
   force_clones=true \
@@ -164,17 +164,32 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
   op stop timeout=20s interval=0</command></screen>
    </step>
    <step>
-    <para>Add the <systemitem>raider</systemitem> resource to the base group for storage that you have created for
-     DLM:</para>
-    <screen>&prompt.crm.conf;<command>modgroup g-storage add raider</command></screen>
-    <para>The <command>add</command> sub-command appends the new group
-     member by default. </para>
-   <para>
-    If not already done, clone the <literal>g-storage</literal> group so that it runs on all nodes:
-   </para>
-   <screen>&prompt.crm.conf;<command>clone cl-storage g-storage \
-    meta interleave=true target-role=Started</command></screen>
-    </step>
+    <para>
+      Make sure the <systemitem>Raid1</systemitem> primitive can only run on nodes where the
+      DLM resource is already running:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          You can add a single <systemitem>Raid1</systemitem> primitive to the cloned
+          <literal>g-storage</literal> group, which already has internal colocation
+          and order constraints:
+        </para>
+<screen>&prompt.crm.conf;<command>modgroup g-storage add raider</command></screen>
+      </listitem>
+      <listitem>
+        <para>
+          Do <emphasis>not</emphasis> add multiple <systemitem>Raid1</systemitem> primitives to
+          the group, because this creates a dependency between the Cluster MD devices.
+          For multiple devices, clone the primitives and add constraints to the clones:
+        </para>
+<screen>&prompt.crm.conf;<command>crm configure clone cl-raider1 raider1 meta interleave=true</command>
+&prompt.crm.conf;<command>crm configure clone cl-raider2 raider2 meta interleave=true</command>
+&prompt.crm.conf;<command>crm configure colocation col-cmd-with-dlm inf: ( cl-raider1 cl-raider2 ) cl-storage</command>
+&prompt.crm.conf;<command>crm configure order o-dlm-before-cmd Mandatory: cl-storage ( cl-raider1 cl-raider2 )</command></screen>
+      </listitem>
+    </itemizedlist>
+   </step>
    <step>
     <para>Review your changes with
      <command>show</command>.</para>


### PR DESCRIPTION
### PR creator: Description

Added a step for cloning and adding constraints for multiple cluster MD devices.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1235513
* jsc#DOCTEAM-1660


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
  - [ ] 15 SP2
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
