### PR TITLE
Remove outdated CCM from glossary

### DIFF
--- a/xml/ha_glossary.xml
+++ b/xml/ha_glossary.xml
@@ -106,16 +106,6 @@
    </para>
   </glossdef>
  </glossentry>
- <glossentry><glossterm>CCM (consensus cluster membership)</glossterm>
-  <glossdef>
-   <para>
-    The CCM determines which nodes make up the cluster and shares this
-    information across the cluster. Any new addition and any loss of nodes
-    or quorum is delivered by the CCM. A CCM module runs on each node of the
-    cluster.
-   </para>
-  </glossdef>
- </glossentry>
  <glossentry><glossterm>CIB (cluster information base)</glossterm>
   <glossdef>
    <para>


### PR DESCRIPTION
### PR creator: Description

This outdated term wasn't used anywhere else in the HA docs, so I've removed it.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1236371
* jsc#DOCTEAM-1681


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
