### PR TITLE
Add op monitor to nfsserver resource

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -617,7 +617,8 @@ include /etc/drbd.d;</screen>
       Create a primitive to manage the NFS server daemon:
      </para>
 <screen>&prompt.crm.conf;<command>primitive nfsserver nfsserver \
-  params nfs_server_scope=SUSE</command></screen>
+  params nfs_server_scope=SUSE \
+  op monitor interval=10s timeout=20s</command></screen>
      <para>
       The <literal>nfs_server_scope</literal> must be the same on all nodes in the
       cluster that run the NFS server, but this is not set by default. All clusters


### PR DESCRIPTION
### PR creator: Description

Added an `op monitor` to the `nfsserver` resource. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1236450
* jsc#DOCTEAM-1682


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
