### PR TITLE
Add more op monitors to the NFS guide

### DIFF
--- a/xml/article_nfs_storage.xml
+++ b/xml/article_nfs_storage.xml
@@ -554,7 +554,8 @@ include /etc/drbd.d;</screen>
       Create a primitive for the NFS client states on <literal>/dev/drbd0</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs-nfs-state Filesystem \
-  params device=/dev/drbd0 directory=/var/lib/nfs fstype=ext4</command></screen>
+  params device=/dev/drbd0 directory=/var/lib/nfs fstype=ext4 \
+  op monitor timeout=40s interval=20s</command></screen>
     </step>
     <step>
      <para>
@@ -562,7 +563,8 @@ include /etc/drbd.d;</screen>
       <literal>/dev/drbd1</literal>:
      </para>
 <screen>&prompt.crm.conf;<command>primitive fs-nfs-share Filesystem \
-  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4</command></screen>
+  params device=/dev/drbd1 directory=/srv/nfs/share fstype=ext4 \
+  op monitor timeout=40s interval=20s</command></screen>
      <para>
       <emphasis>Do not</emphasis> commit this configuration until
     after you add the colocation and order constraints.
@@ -723,7 +725,10 @@ include /etc/drbd.d;</screen>
      <para>
       Create a primitive for the virtual IP address:
      </para>
-<screen>&prompt.crm.conf;<command>primitive vip-nfs IPaddr2 params ip=&nfs-vip-exports;</command></screen>
+<screen>&prompt.crm.conf;<command>primitive vip-nfs IPaddr2 \
+  params ip=&nfs-vip-exports; \
+  op monitor timeout=20s interval=10s
+</command></screen>
     </step>
     <step>
      <para>
@@ -878,7 +883,8 @@ include /etc/drbd.d;</screen>
     Create a primitive for the file system to be exported on <literal>/dev/drbd2</literal>:
    </para>
 <screen>&prompt.crm.conf;<command>primitive fs-nfs-share2 Filesystem \
-  params device="/dev/drbd2" directory="/srv/nfs/share2" fstype=ext4</command></screen>
+  params device="/dev/drbd2" directory="/srv/nfs/share2" fstype=ext4 \
+  op monitor timeout=40s interval=20s</command></screen>
   </step>
   <step>
    <para>


### PR DESCRIPTION
### PR creator: Description

Based on PR#429
See also bsc#1231386


### PR creator: Are there any relevant issues/feature requests?

* bsc#1231386
* jsc#DOCTEAM-1682


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
