### PR TITLE
Fix structure of SBD device procedure and example

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -616,35 +616,46 @@ stonith-timeout &gt;= Timeout (msgwait) + 20%</screen>
      <para>Decide which block device or block devices to use for SBD.</para>
     </step>
     <step>
-     <para>Initialize the SBD device with the following command: </para>
+     <para>Initialize the SBD device: </para>
+     <itemizedlist>
+       <listitem>
+         <para>
+           To use one device with the default timeout values, run the following command:
+         </para>
 <screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> create</command></screen>
-        <para> To use more than one device for SBD, specify the <option>-d</option> option multiple times, for
-      example: </para>
+       </listitem>
+       <listitem>
+         <para>
+           To use more than one device for SBD, specify the <option>-d</option> option multiple
+           times, for example:
+         </para>
 <screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID1</replaceable> -d /dev/disk/by-id/<replaceable>DEVICE_ID2</replaceable> -d /dev/disk/by-id/<replaceable>DEVICE_ID3</replaceable> create</command></screen>
+       </listitem>
+       <listitem>
+       <para>To adjust the timeouts to use for SBD (for example, if your SBD device resides on a
+        multipath group), use the <option>-1</option> and <option>-4</option> options. If you
+        initialize more than one device, you must set the same timeout values for all devices. For
+        details, see <xref linkend="sec-ha-storage-protect-watchdog-timings"/>.
+        All timeouts are given in seconds:</para>
+<screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> -1 30</command><co xml:id="co-ha-sbd-watchdog"/> <command>-4 60</command><co xml:id="co-ha-sbd-msgwait"/> <command>create</command></screen>
+       <calloutlist>
+         <callout arearefs="co-ha-sbd-watchdog">
+         <para> The <option>-1</option> option is used to specify the
+          <literal>watchdog</literal> timeout. In the example above, it is set
+          to <literal>30</literal> seconds. The minimum allowed value for the
+          emulated watchdog is <literal>15</literal> seconds. </para>
+        </callout>
+        <callout arearefs="co-ha-sbd-msgwait">
+        <para> The <option>-4</option> option is used to specify the
+          <literal>msgwait</literal> timeout. In the example above, it is set to
+          <literal>60</literal> seconds. </para>
+        </callout>
+      </calloutlist>
+      </listitem>
+     </itemizedlist>
     </step>
     <step>
-     <para>If your SBD device resides on a multipath group, use the <option>-1</option>
-      and <option>-4</option> options to adjust the timeouts to use for SBD. If you initialized
-      more than one device, you must set the same timeout values for all devices. For
-      details, see <xref linkend="sec-ha-storage-protect-watchdog-timings"/>.
-      All timeouts are given in seconds:</para>
-<screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> -1 90</command><co xml:id="co-ha-sbd-watchdog"/> <command>-4 180</command><co xml:id="co-ha-sbd-msgwait"/> <command>create</command></screen>
-     <calloutlist>
-      <callout arearefs="co-ha-sbd-watchdog">
-       <para> The <option>-1</option> option is used to specify the
-         <literal>watchdog</literal> timeout. In the example above, it is set
-        to <literal>90</literal> seconds. The minimum allowed value for the
-        emulated watchdog is <literal>15</literal> seconds. </para>
-      </callout>
-      <callout arearefs="co-ha-sbd-msgwait">
-       <para> The <option>-4</option> option is used to specify the
-         <literal>msgwait</literal> timeout. In the example above, it is set to
-         <literal>180</literal> seconds. </para>
-      </callout>
-     </calloutlist>
-    </step>
-    <step>
-     <para>Check what has been written to the device: </para>
+     <para>Check what is written on the device: </para>
      <screen>&prompt.root;<command>sbd -d /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> dump</command>
 Header version     : 2.1
 UUID               : 619127f4-0e06-434c-84a0-ea82036e144c
@@ -1118,7 +1129,7 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
       <step>
        <para>Simulate an SBD failure by terminating the SBD inquisitor process.
        In our example, the process ID of the SBD inquisitor is
-         <literal>1859</literal>):</para>
+         <literal>1859</literal>:</para>
        <screen>&prompt.root;<command>kill -9 1859</command></screen>
        <para>
         The node proactively self-fences. The other nodes notice the loss of


### PR DESCRIPTION
### PR creator: Description

The timeout step being separate made it seem like an additional thing to do after initialising the device, but `create` overwrites the disk so you wouldn't run it twice. This should, in fact, be another option for step 2. 

I've also changed the example to one of the suggestions from https://www.suse.com/support/kb/doc/?id=000017952


### PR creator: Are there any relevant issues/feature requests?

* bsc#1238348
* jsc#DOCTEAM-1718


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
