### PR TITLE
Deprecate OCFS2 and fully support GFS2

### DIFF
--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -18,11 +18,6 @@
     GFS2 in a cluster requires hardware to allow access to the shared
     storage, and a lock manager to control access to the storage.
    </para>
-        <para>
-    &suse; recommends OCFS2 over GFS2 for your cluster environments if
-    performance is one of your major requirements. Our tests have revealed
-    that OCFS2 performs better as compared to GFS2 in such settings.
-   </para>
       </abstract>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:maintainer/>
@@ -35,13 +30,6 @@
         <dm:repository/>
       </dm:docmanager>
     </info>
-
-    <important>
-     <title>GFS2 support</title>
-     <para>
-      &suse; only supports GFS2 in read-only mode. Write operations are not supported.
-     </para>
-    </important>
 
     <sect1 xml:id="sec-ha-gfs2-utils">
   <title>GFS2 packages and management utilities</title>

--- a/xml/ha_ocfs2.xml
+++ b/xml/ha_ocfs2.xml
@@ -24,6 +24,15 @@
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
     </info>
+
+ <important>
+   <title>&ocfs; support</title>
+   <para>
+     &ocfs; is deprecated in &productname; &productnumber;. It will not be
+     supported in future releases.
+   </para>
+ </important>
+
  <sect1 xml:id="sec-ha-ocfs2-features">
   <title>Features and benefits</title>
 


### PR DESCRIPTION
### PR creator: Description

Part 1 of the OCFS2 -> GFS2 task for 15 SP7. This PR removes content encouraging the use of OCFS2 over GFS2, and adds a warning that OCFS2 is deprecated.


### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-11046


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [ ] 15 SP6
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
