### PR TITLE
Clarify SBD watchdog timeout

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -317,9 +317,15 @@
           <para>
            This also means that in <filename>/etc/multipath.conf</filename> the
            value of <literal>max_polling_interval</literal> must be less than the
-           <literal>watchdog</literal> timeout.
+           <literal>watchdog</literal> timeout set during initialization of the SBD device.
          </para>
        </note>
+       <para>
+        For diskless SBD, the watchdog timeout is set by the <literal>SBD_WATCHDOG_TIMEOUT</literal>
+        parameter in <filename>/etc/sysconfig/sbd</filename>. <literal>SBD_WATCHDOG_TIMEOUT</literal>
+        does not need to be set for disk-based SBD because the watchdog setting in the SBD disk's
+        metadata takes precedence over <filename>/etc/sysconfig/sbd</filename>.
+       </para>
       </listitem>
      </varlistentry>
      <varlistentry>
@@ -358,26 +364,40 @@
         This timeout is set in the CIB as a global cluster property. If not set
         explicitly, it defaults to <literal>0</literal>, which is appropriate for
         using SBD with one to three devices. For SBD in diskless mode, this timeout
-        must <emphasis>not</emphasis> be <literal>0</literal>. For details, see
-        <xref linkend="pro-ha-storage-protect-confdiskless"/>.</para>
+        must <emphasis>not</emphasis> be <literal>0</literal>.</para>
       </listitem>
      </varlistentry>
     </variablelist>
   <para>
-   If you change the watchdog timeout, you need to adjust the other two timeouts
-   as well. The following <quote>formula</quote> expresses the relationship
-   between these three values:
+   If you change the watchdog timeout, you must adjust the other timeouts
+   as well. The following formula expresses the relationship between these values
+   for disk-based SDB:
   </para>
-   <example xml:id="ex-ha-storage-protect-sbd-timings">
-    <title>Formula for timeout calculation</title>
+   <example xml:id="ex-ha-storage-protect-disk-based-sbd-timings">
+    <title>Formula for disk-based SBD timeout calculation</title>
     <screen>Timeout (msgwait) &gt;= (Timeout (watchdog) * 2)
 stonith-timeout &gt;= Timeout (msgwait) + 20%</screen>
+    <para>
+      For example, if you set the watchdog timeout to <literal>30</literal>,
+      set the <literal>msgwait</literal> timeout to at least <literal>60</literal> and
+      <literal>stonith-timeout</literal> to at least <literal>72</literal>.
+    </para>
    </example>
    <para>
-    For example, if you set the watchdog timeout to <literal>120</literal>,
-    set the <literal>msgwait</literal> timeout to at least <literal>240</literal> and the
-    <literal>stonith-timeout</literal> to at least <literal>288</literal>.
+    The following formula expresses the relationship between these values
+    for diskless SDB:
    </para>
+   <example xml:id="ex-ha-storage-protect-diskless-sbd-timings">
+    <title>Formula for diskless SBD timeout calculation</title>
+    <screen>stonith-watchdog-timeout &gt;= (SBD_WATCHDOG_TIMEOUT * 2)
+stonith-timeout &gt;= stonith-watchdog-timeout + 20%
+    </screen>
+    <para>
+      For example, if you set <literal>SBD_WATCHDOG_TIMEOUT</literal> to <literal>10</literal>,
+      set <literal>stonith-watchdog-timeout</literal> to at least <literal>20</literal> and
+      <literal>stonith-timeout</literal> to at least <literal>24</literal>.
+    </para>
+   </example>
     <para>
      If you use the bootstrap scripts provided by the &crmshell; to set up a
      cluster and to initialize the SBD device, the relationship between these
@@ -661,10 +681,10 @@ Header version     : 2.1
 UUID               : 619127f4-0e06-434c-84a0-ea82036e144c
 Number of slots    : 255
 Sector size        : 512
-Timeout (watchdog) : 5
+Timeout (watchdog) : 15
 Timeout (allocate) : 2
 Timeout (loop)     : 1
-Timeout (msgwait)  : 10
+Timeout (msgwait)  : 30
 ==Header on disk /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> is dumped</screen>
     <para> As you can see, the timeouts are also stored in the header, to ensure
     that all participating nodes agree on them. </para>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -315,7 +315,7 @@
           to the next path.
           </para>
           <para>
-           This also means that in <filename>/etc/multipath.conf</filename> the
+           This also means that in <filename>/etc/multipath.conf</filename>, the
            value of <literal>max_polling_interval</literal> must be less than the
            <literal>watchdog</literal> timeout set during initialization of the SBD device.
          </para>
@@ -686,7 +686,7 @@ Timeout (allocate) : 2
 Timeout (loop)     : 1
 Timeout (msgwait)  : 30
 ==Header on disk /dev/disk/by-id/<replaceable>DEVICE_ID</replaceable> is dumped</screen>
-    <para> As you can see, the timeouts are also stored in the header, to ensure
+    <para> As you can see, the timeouts are also stored in the header to ensure
     that all participating nodes agree on them. </para>
     </step>
    </procedure>

--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -308,7 +308,7 @@
         read within this time. Otherwise, the node might self-fence.
        </para>
        <note>
-        <title>Multipath or iSCSI setup</title>
+        <title>Multipath or iSCSI setup for disk-based SBD</title>
           <para>
           If your SBD devices reside on a multipath setup or iSCSI, the timeout
           should be set to the time required to detect a path failure and switch
@@ -323,7 +323,7 @@
        <para>
         For diskless SBD, the watchdog timeout is set by the <literal>SBD_WATCHDOG_TIMEOUT</literal>
         parameter in <filename>/etc/sysconfig/sbd</filename>. <literal>SBD_WATCHDOG_TIMEOUT</literal>
-        does not need to be set for disk-based SBD because the watchdog setting in the SBD disk's
+        does not need to be set for disk-based SBD because the watchdog setting in the SBD device's
         metadata takes precedence over <filename>/etc/sysconfig/sbd</filename>.
        </para>
       </listitem>


### PR DESCRIPTION
### PR creator: Description

Some small updates to clarify the watchdog timeout for disk-based and diskless SBD. I also added an example for diskless SBD because the formula is a bit different.

See comments below for rendered screen shots.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1239818
* jsc#DOCTEAM-1755


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
