### PR TITLE
Add man page for SBD_DELAY_START

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -717,9 +717,9 @@ Timeout (msgwait)  : 30
      cluster start-up. </para>
    </step>
    <step xml:id="st-ha-storage-protect-sbd-delay-start">
-    <para>Search for the following parameter: <parameter>SBD_DELAY_START</parameter>.</para>
+    <para>Search for the following parameter: <varname>SBD_DELAY_START</varname>.</para>
     <para>
-      Enables or disables a delay. Set <parameter>SBD_DELAY_START</parameter>
+      Enables or disables a delay. Set <varname>SBD_DELAY_START</varname>
       to <literal>yes</literal> if <literal>msgwait</literal> is
       long, but your cluster nodes boot quickly.
       Setting this parameter to <literal>yes</literal> delays the start of
@@ -728,11 +728,13 @@ Timeout (msgwait)  : 30
     <para>
       The default delay length is the same as the <literal>msgwait</literal> timeout value.
       Alternatively, you can specify an integer, in seconds, instead of <literal>yes</literal>.
+      For help calculating an appropriate value, see <command>man sbd</command>, section
+      <literal>Configuration via environment</literal>.
     </para>
     <para>
-      If you enable <parameter>SBD_DELAY_START</parameter>, you must also check the SBD service file
+      If you enable <varname>SBD_DELAY_START</varname>, you must also check the SBD service file
       to ensure that the value of <literal>TimeoutStartSec</literal> is greater than the value of
-      <parameter>SBD_DELAY_START</parameter>. For more information, see
+      <varname>SBD_DELAY_START</varname>. For more information, see
       <link xlink:href="https://www.suse.com/support/kb/doc/?id=000019356"/>.
     </para>
    </step>
@@ -1007,7 +1009,8 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
         If you need to delay the start of SBD on boot, change <varname>SBD_DELAY_START</varname>
         to <literal>yes</literal>. The default delay length is double the value of
         <varname>SBD_WATCHDOG_TIMEOUT</varname>. Alternatively, you can specify an integer,
-        in seconds, instead of <literal>yes</literal>.
+        in seconds, instead of <literal>yes</literal>. For help calculating an appropriate value,
+        see <command>man sbd</command>, section <literal>Configuration via environment</literal>.
       </para>
       <important>
        <title><literal>SBD_WATCHDOG_TIMEOUT</literal> for diskless SBD and &qdevice;</title>


### PR DESCRIPTION
### PR creator: Description

Added a reference to the SBD man page to help calculate an appropriate value for SBD_DELAY_START.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1242942
* jsc#DOCTEAM-1845


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
