### PR TITLE
Add ro option to GFS2 config

### DIFF
--- a/xml/ha_gfs2.xml
+++ b/xml/ha_gfs2.xml
@@ -333,11 +333,12 @@
    </step>
    <step>
     <para>
-     Configure Pacemaker to mount the GFS2 file system on every node in the
+     Configure Pacemaker to mount the GFS2 file system in read-only mode on every node in the
      cluster:
     </para>
 <screen>&prompt.crm.conf;<command>primitive gfs2-1 ocf:heartbeat:Filesystem \
-  params device="/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>" directory="/mnt/shared" fstype="gfs2" \
+  params device="/dev/disk/by-id/<replaceable>DEVICE_ID</replaceable>" directory="/mnt/shared" \
+    fstype=gfs2 options=ro \
   op monitor interval="20" timeout="40" \
   op start timeout="60" op stop timeout="60" \
   meta target-role="Stopped"</command></screen>


### PR DESCRIPTION
### PR creator: Description

Added the `ro` option to the GFS2 config, since this is what is supported in 15 SP6 and earlier.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1241527
* jsc#DOCTEAM-1826


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [ ] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
