### PR TITLE
Fix mdadm csync2 steps

### DIFF
--- a/xml/ha_cluster_md.xml
+++ b/xml/ha_cluster_md.xml
@@ -144,8 +144,14 @@ ARRAY /dev/md0 UUID=1d70f103:49740ef1:af2afce5:fcf6a489</screen>
     <screen>group ha_group
 {
    # ... list of files pruned ...
-   include /etc/mdadm.conf
+   include /etc/mdadm.conf;
 }</screen>
+   </step>
+   <step>
+    <para>
+     Copy the configuration file to all nodes:
+    </para>
+<screen>&prompt.root;<command>csync2 -xv</command></screen>
    </step>
   </procedure>
  </sect1>


### PR DESCRIPTION
### PR creator: Description

Fixed the step/s for adding mdadm.conf to Csync2.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1243871
* jsc#DOCTEAM-1869


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 next *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
