### PR TITLE
Remove note on negative stonith-watchdog-timeout value

### DIFF
--- a/xml/ha_storage_protection.xml
+++ b/xml/ha_storage_protection.xml
@@ -1076,11 +1076,6 @@ SBD_WATCHDOG_TIMEOUT=5</screen>
        self-fenced. Use the following formula to calculate this timeout:
       </para>
       <screen>stonith-watchdog-timeout &gt;= (SBD_WATCHDOG_TIMEOUT * 2)</screen>
-      <para>
-        If you set <parameter>stonith-watchdog-timeout</parameter>
-        to a negative value, Pacemaker automatically calculates this timeout
-        and sets it to twice the value of <parameter>SBD_WATCHDOG_TIMEOUT</parameter>.
-      </para>
      </callout>
      <callout arearefs="co-ha-sbd-diskless-stonith-timeout">
        <para>


### PR DESCRIPTION
### PR creator: Description

Based on discussion in bsc#1246622 I've removed the mention of setting `stonith-watchdog-timeout` to a negative value.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1246622
* jsc#DOCTEAM-1908


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 SP7 *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [x] 15 SP3
- SLE-HA 12
  - [x] 12 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
