### PR TITLE
Stopping the cluster services while in maintenance mode

### DIFF
--- a/xml/book_administration.xml
+++ b/xml/book_administration.xml
@@ -137,7 +137,7 @@
  <info xmlns:d="http://docbook.org/ns/docbook">
   <revhistory xml:id="rh-admin-part-maintenance">
    <revision>
-    <date>2025-06-17</date>
+    <date>2026-04-23</date>
     <revdescription>
      <para/>
     </revdescription>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -630,7 +630,7 @@ Node <replaceable>&node2;</replaceable>: standby
  </sect1>
 
 <sect1 xml:id="sec-ha-maint-shutdown-node-maint-mode">
- <title>Rebooting a cluster node while in maintenance mode</title>
+ <title>Stopping the cluster services while in maintenance mode</title>
     <note>
       <title>Implications</title>
       <para>
@@ -654,36 +654,38 @@ Node <replaceable>&node2;</replaceable>: standby
      </note>
 
    <procedure xml:id="pro-ha-maint-reboot-node">
-    <title>Rebooting a cluster node while the cluster or node is in maintenance mode</title>
+    <title>Stopping the cluster services while the cluster or node is in maintenance mode</title>
     <step>
     <para>
-     On the node you want to reboot or shut down, log in as &rootuser; or
-     equivalent.
+      Log in as the &rootuser; user or as a user with <command>sudo</command> privileges.
     </para>
    </step>
    <step>
     <para>
      If you have a DLM resource (or other resources depending on DLM), make
-     sure to explicitly stop those resources before stopping the cluster services:
+     sure to explicitly stop those resources before putting the cluster or the
+     node into maintenance mode. Stopping &pace; also stops the &corosync; service,
+     which DLM depends on. If &corosync; stops, the DLM resource assumes a split-brain
+     scenario and triggers a fencing operation.
     </para>
-<screen>&prompt.crm.res;<command>stop <replaceable>RESOURCE_ID</replaceable></command></screen>
+<screen>&prompt.root;<command>crm --wait resource stop <replaceable>RESOURCE_ID</replaceable></command></screen>
     <para>
-     The reason is that stopping &pace; also stops the &corosync; service on
-     whose membership and messaging services DLM depends. If &corosync; stops,
-     the DLM resource assumes a split-brain scenario and triggers a fencing
-     operation.
+      The <option>--wait</option> option makes sure the resource has really stopped
+      before the command returns.
     </para>
+   </step>
+   <step>
+     <para>
+      Put the cluster or the node into maintenance mode with one of the following commands:
+     </para>
+<screen>&prompt.root;<command>crm maintenance on</command></screen>
+<screen>&prompt.root;<command>crm node maintenance <replaceable>NODENAME</replaceable></command></screen>
    </step>
    <step>
     <para>
      Stop the cluster services on that node:
     </para>
 <screen>&prompt.root;<command>crm cluster stop</command></screen>
-   </step>
-   <step>
-    <para>
-     Shut down or reboot the node.
-    </para>
    </step>
   </procedure>
  </sect1>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -33,7 +33,7 @@
   </dm:docmanager>
  <revhistory xml:id="rh-cha-ha-maintenance">
    <revision>
-     <date>2025-04-25</date>
+     <date>2026-04-23</date>
      <revdescription>
        <para/>
      </revdescription>


### PR DESCRIPTION
### PR creator: Description

Improved the procedure for stopping the cluster services while in maintenance mode.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1259888
* jsc#DOCTEAM-2204


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 SP7 *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [ ] 15 SP3
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 

