### PR TITLE
Fix node maintenance and standby steps

### DIFF
--- a/xml/MAIN.SLEHA.xml
+++ b/xml/MAIN.SLEHA.xml
@@ -33,7 +33,7 @@
   <meta name="series" its:translate="no">Product Documentation</meta>
  <revhistory>
    <revision>
-     <date>2024-10-08</date>
+     <date>2026-06-30</date>
      <revdescription>
        <para/>
      </revdescription>

--- a/xml/book_administration.xml
+++ b/xml/book_administration.xml
@@ -36,11 +36,9 @@
    </meta>
    <revhistory xml:id="rh-book-administration">
      <revision>
-       <date>2025-06-17</date>
+       <date>2026-06-30</date>
        <revdescription>
-         <para>
-           Updated for the initial release of &productname; &productnumber;.
-         </para>
+         <para/>
        </revdescription>
      </revision>
     </revhistory>
@@ -137,7 +135,7 @@
  <info xmlns:d="http://docbook.org/ns/docbook">
   <revhistory xml:id="rh-admin-part-maintenance">
    <revision>
-    <date>2026-04-23</date>
+    <date>2026-06-30</date>
     <revdescription>
      <para/>
     </revdescription>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -353,19 +353,31 @@
    </step>
    <step>
     <para>
-     In the left navigation bar, select <guimenu>Cluster Status</guimenu>.
+     In the left navigation bar, select <menuchoice><guimenu>Monitoring</guimenu>
+     <guimenu>Status</guimenu></menuchoice>.
     </para>
    </step>
    <step>
-    <para>
-     In one of the individual nodes' views, click the wrench icon next to the
-     node and select <guimenu>Maintenance</guimenu>.
-    </para>
+     <para>
+       Switch to the <guimenu>Nodes</guimenu> tab and find the node you want to put into
+       maintenance mode.
+     </para>
    </step>
    <step>
     <para>
-      After you have finished your maintenance task, click the wrench icon next to the node
-     and select <guimenu>Ready</guimenu>.
+     In the <guimenu>Maintenance</guimenu> column, click the toggle to turn on maintenance mode.
+    </para>
+   </step>
+   <step>
+     <para>
+       Click <guimenu>OK</guimenu> to confirm. The toggle changes from green to red.
+     </para>
+   </step>
+   <step>
+    <para>
+      After you have finished your maintenance task, click the toggle again to turn off
+      maintenance mode and click <guimenu>OK</guimenu> to confirm. The toggle changes
+      from red to green.
     </para>
    </step>
   </procedure>
@@ -392,24 +404,31 @@
    </step>
    <step>
     <para>
-     In the left navigation bar, select <guimenu>Cluster Status</guimenu>.
+     In the left navigation bar, select <menuchoice><guimenu>Monitoring</guimenu>
+     <guimenu>Status</guimenu></menuchoice>.
     </para>
    </step>
    <step>
-    <para>
-     In one of the individual nodes' views, click the wrench icon next to the
-     node and select <guimenu>Standby</guimenu>.
-    </para>
+     <para>
+       Switch to the <guimenu>Nodes</guimenu> tab and find the node you want to put into
+       standby mode.
+     </para>
    </step>
    <step>
     <para>
-     Finish the maintenance task for the node.
+     In the <guimenu>Standby</guimenu> column, click the toggle to turn on standby mode.
     </para>
    </step>
    <step>
+     <para>
+       Click <guimenu>OK</guimenu> to confirm. The toggle changes from green to red.
+     </para>
+   </step>
+   <step>
     <para>
-     To deactivate the standby mode, click the wrench icon next to the node
-     and select <guimenu>Ready</guimenu>.
+      After you have finished your maintenance task, click the toggle again to turn off
+      standby mode and click <guimenu>OK</guimenu> to confirm. The toggle changes
+      from red to green.
     </para>
    </step>
   </procedure>

--- a/xml/ha_maintenance.xml
+++ b/xml/ha_maintenance.xml
@@ -34,7 +34,7 @@
   </dm:docmanager>
  <revhistory xml:id="rh-cha-ha-maintenance">
    <revision>
-     <date>2026-04-23</date>
+     <date>2026-06-30</date>
      <revdescription>
        <para/>
      </revdescription>


### PR DESCRIPTION
### PR creator: Description

The steps for putting a node into maintenance mode and standby mode were outdated. I've fixed them. 


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-2267


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 SP7 *(current `main`, no backport necessary)*
  - [x] 15 SP6
  - [x] 15 SP5
  - [x] 15 SP4
  - [ ] 15 SP3
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 

