### PR TITLE
Add pre-upgrade check

### DIFF
--- a/xml/MAIN.SLEHA.xml
+++ b/xml/MAIN.SLEHA.xml
@@ -33,7 +33,7 @@
   <meta name="series" its:translate="no">Product Documentation</meta>
  <revhistory>
    <revision>
-     <date>2026-07-02</date>
+     <date>2026-07-17</date>
      <revdescription>
        <para/>
      </revdescription>

--- a/xml/book_administration.xml
+++ b/xml/book_administration.xml
@@ -36,7 +36,7 @@
    </meta>
    <revhistory xml:id="rh-book-administration">
      <revision>
-       <date>2026-07-02</date>
+       <date>2026-07-17</date>
        <revdescription>
          <para/>
        </revdescription>
@@ -135,7 +135,7 @@
  <info xmlns:d="http://docbook.org/ns/docbook">
   <revhistory xml:id="rh-admin-part-maintenance">
    <revision>
-    <date>2026-06-30</date>
+    <date>2026-07-17</date>
     <revdescription>
      <para/>
     </revdescription>

--- a/xml/ha_migration.xml
+++ b/xml/ha_migration.xml
@@ -46,7 +46,7 @@
       </dm:docmanager>
     <revhistory xml:id="rh-cha-ha-migration">
    <revision>
-     <date>2025-04-14</date>
+     <date>2026-07-17</date>
      <revdescription>
        <para/>
      </revdescription>
@@ -534,6 +534,75 @@
      </para>
     </step>
    </procedure>
+  </sect2>
+
+  <sect2 xml:id="sec-ha-migration-upgrade-precheck">
+    <title>Pre-upgrade check for &productname; 16</title>
+      <para>
+        You can use the cluster health check tool to make sure the &ha; cluster can safely upgrade
+        from &slehaa; 15 to &slehaa; 16. The tool reports any issues that will prevent the upgrade,
+        as well as issues that can be fixed during or after the upgrade.
+      </para>
+        <para>
+    You can perform this procedure on any node in the cluster.
+  </para>
+  <procedure>
+    <step>
+      <para>
+        Log in to the node either as the &rootuser; user or as a user with <command>sudo</command>
+        privileges.
+      </para>
+    </step>
+    <step>
+      <para>
+        Run the cluster health check:
+      </para>
+<screen>&prompt.user;<command>sudo crm cluster health sles16</command></screen>
+      <para>
+        This command reports issues in two categories:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            The <literal>WARN</literal> category indicates cluster configuration that isn't
+            recommended, such as deprecated features. Issues in this category can be fixed during
+            or after the upgrade, so the migration check passes. For example:
+          </para>
+<screen>[WARN] Corosync transport "udpu" will be deprecated in favor of "knet" in corosync 3.</screen>
+        </listitem>
+        <listitem>
+          <para>
+            The <literal>FAIL</literal> category indicates cluster configuration that can't be
+            fixed during or after the upgrade, such as removed resource agents. Issues in this
+            category must be fixed before you can upgrade the cluster, so the migration check fails.
+            The command's output will tell you what to fix. For example:
+          </para>
+<screen>[FAIL] The following resource agents will be removed in SLES 16.
+       * ocf:heartbeat:IPaddr: please replace it with ocf:heartbeat:IPaddr2</screen>
+        </listitem>
+      </itemizedlist>
+    </step>
+    <step>
+      <para>
+        Fix any <literal>FAIL</literal> issues, then run the cluster health check again to make
+        sure you didn't miss anything.
+      </para>
+    </step>
+  </procedure>
+  <itemizedlist>
+    <title>For more information</title>
+    <listitem>
+      <para>
+        <command>crm cluster help health</command>
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <link xlink:href="https://documentation.suse.com/sle-ha/16.0/html/HA-upgrading/">
+        <citetitle>Upgrading from SLE HA 15 to SLE HA 16.0</citetitle></link>
+      </para>
+    </listitem>
+  </itemizedlist>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-ha-migration-update">


### PR DESCRIPTION
### PR creator: Description

Added the pre-upgrade check from the HA 16 upgrade guide. 

This has already been reviewed in the HA upgrade PR in doc-modular.


### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-12806


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE-HA 15
  - [x] 15 SP7 *(current `main`, no backport necessary)*
  - [ ] 15 SP6
  - [ ] 15 SP5
  - [ ] 15 SP4
  - [ ] 15 SP3
- SLE-HA 12
  - [ ] 12 SP5

### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [ ] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 

